### PR TITLE
Fix generator bypass of sculpt review gates

### DIFF
--- a/scripts/generate_threejs_factory.py
+++ b/scripts/generate_threejs_factory.py
@@ -10,7 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from sculpt_pass_orchestrator import pass_specific_gaps
+from sculpt_pass_orchestrator import pass_specific_gaps, review_completes_pass
 
 
 VALID_PRIMITIVES = {
@@ -38,7 +38,6 @@ DEFAULT_PASS_ORDER = [
     "interaction-pass",
     "optimization-pass",
 ]
-VISUAL_PASS_IDS = set(DEFAULT_PASS_ORDER) - {"optimization-pass"}
 PASS_LEVELS = {
     "blockout": {"macro"},
     "structural-pass": {"macro", "meso"},
@@ -66,26 +65,16 @@ def pass_order(spec: dict[str, Any]) -> list[str]:
     return ids or DEFAULT_PASS_ORDER.copy()
 
 
-def review_visual_evidence(entry: dict[str, Any]) -> dict[str, Any]:
-    visual = entry.get("visualEvidence")
-    return visual if isinstance(visual, dict) else {}
-
-
-def review_completes_pass(entry: dict[str, Any], pass_id: str) -> bool:
-    if entry.get("passId") != pass_id or entry.get("action") != "continue":
-        return False
-    if pass_id in VISUAL_PASS_IDS and not review_visual_evidence(entry).get("renderScreenshot"):
-        return False
-    return True
-
-
 def completed_passes(spec: dict[str, Any], ids: list[str]) -> list[str]:
     history = spec.get("reviewHistory", [])
     if not isinstance(history, list):
         return []
     completed: list[str] = []
     for pass_id in ids:
-        if any(isinstance(entry, dict) and review_completes_pass(entry, pass_id) for entry in history):
+        if any(
+            isinstance(entry, dict) and review_completes_pass(spec, entry, pass_id)
+            for entry in history
+        ):
             completed.append(pass_id)
         else:
             break
@@ -112,7 +101,7 @@ def assert_pass_unlocked(spec: dict[str, Any], requested_pass: str) -> None:
     previous = ids[previous_index] if previous_index >= 0 else ""
     raise ValueError(
         f"build pass {requested_pass!r} is locked; complete {previous!r} first with "
-        "append_sculpt_review.py action=continue and browser screenshot evidence"
+        "append_sculpt_review.py action=continue and all required visual comparison evidence"
     )
 
 

--- a/scripts/tests/test_pipeline.py
+++ b/scripts/tests/test_pipeline.py
@@ -112,6 +112,28 @@ class PipelineTest(unittest.TestCase):
                      "--pass-id", "lighting-pass")
         self.assertNotEqual(locked.returncode, 0)
 
+    def test_generate_factory_rejects_incomplete_manual_review_evidence(self):
+        run("new_sculpt_spec.py", "Oak", "--out", self.spec)
+        spec = json.loads(self.spec.read_text())
+        spec["reviewHistory"] = [{
+            "passId": "blockout",
+            "action": "continue",
+            "visualEvidence": {"renderScreenshot": str(self.render)},
+        }]
+        self.spec.write_text(json.dumps(spec))
+
+        orchestrator = run("sculpt_pass_orchestrator.py", "check", self.spec,
+                           "--pass-id", "structural-pass")
+        self.assertNotEqual(orchestrator.returncode, 0)
+
+        out = self.dir / "createObjectModel.ts"
+        generated = run("generate_threejs_factory.py", self.spec, "--out", out,
+                        "--pass-id", "structural-pass")
+        self.assertNotEqual(generated.returncode, 0)
+        message = generated.stdout + generated.stderr
+        self.assertIn("locked", message)
+        self.assertIn("visual comparison evidence", message)
+
     def test_comparison_sheet_packages_without_scoring(self):
         cmp = self.dir / "cmp.png"
         r = run("make_visual_comparison_sheet.py", "--reference", self.ref,
@@ -155,6 +177,11 @@ class PipelineTest(unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
         spec = json.loads(self.spec.read_text())
         self.assertTrue(len(spec.get("reviewHistory", [])) >= 1)
+
+        out = self.dir / "createObjectModel.ts"
+        generated = run("generate_threejs_factory.py", self.spec, "--out", out,
+                        "--pass-id", "structural-pass")
+        self.assertEqual(generated.returncode, 0, generated.stderr)
 
     def test_pbr_extraction_runs(self):
         # low-detail synthetic image: either passes or refuses (non-zero) — both are valid,


### PR DESCRIPTION
## Summary

- make `generate_threejs_factory.py` use the orchestrator's authoritative review-completion gate
- prevent manually edited screenshot-only review history from unlocking later sculpt passes
- keep valid, fully reviewed passes unlockable and update the lock guidance to mention the required visual comparison evidence

## Problem

The generator had a weaker local copy of `review_completes_pass`. A manually edited review entry with `action=continue` and only `visualEvidence.renderScreenshot` could unlock the next pass, even though `sculpt_pass_orchestrator.py` correctly rejected the same entry because it lacked a comparison image, an accepted AI vision score, and passing critical feature reviews.

## Verification

- Added a regression test and confirmed it failed before the fix because the generator returned exit code 0.
- Confirmed the regression test passes after delegating to the orchestrator gate.
- Confirmed a valid review created through `append_sculpt_review.py` still unlocks `structural-pass` generation.
- `python3 -m unittest discover -s scripts/tests -v` — 20 tests passed.
- `ruff check scripts/generate_threejs_factory.py scripts/tests/test_pipeline.py` — passed.
- `python3 -m compileall -q scripts` — passed.
- `git diff --check` — passed.
