### PR TITLE
docs: add Chinese and Japanese README translations

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,225 @@
+<p align="center">
+  <a href="./README.md">English</a> · <a href="./README.zh-CN.md">简体中文</a> · <strong>日本語</strong>
+</p>
+
+<div align="center">
+
+<img src="assets/logo.svg" width="112" height="112" alt="img2threejs ロゴ" />
+
+# img2threejs
+
+**参照画像内のオブジェクトを、コードのみで構成されたプロシージャルな Three.js モデルとして再構築します。**
+
+品質ゲートを備え、アニメーションに対応し、意図的にトークン効率を最適化しています。フォトグラメトリ、メッシュ抽出、ダウンロードしたアートパックではなく、コードによる再構築です。
+
+[![ライセンス：MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![バージョン](https://img.shields.io/badge/version-1.2.0-green.svg)](SKILL.md)
+[![PR 歓迎](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![ランタイム](https://img.shields.io/badge/runtime-Three.js-000000.svg)](https://threejs.org)
+[![ツール](https://img.shields.io/badge/tooling-Python%203.10%2B%20stdlib-3776ab.svg)](scripts)
+
+<a href="https://trendshift.io/repositories/83608?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-83608" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/83608/daily?language=Python" alt="Trendshift の hoainho%2Fimg2threejs" width="250" height="55"/></a>
+
+![img2threejs デモ——戦利品の宝箱の参照画像をプロシージャルな Three.js モデルとして再構築](assets/demo.gif)
+
+</div>
+
+*1 枚の参照画像をコードで再構築し、正しい比率、色、ベベル、金色の縁取り、発光するエンブレムを備えた状態でブラウザー内で動作させます。*
+
+### [→ ライブデモギャラリーを開く](https://hoainho.github.io/img2threejs-showcase/)
+
+ギャラリー内のすべてのモデルは、ブラウザーで実行される生成コードです。メッシュファイルもダウンロードも使用しません。
+
+---
+
+## ライブデモ
+
+プリミティブ、プロシージャルシェーダー、生成ジオメトリだけで構築された再構築モデルです。以下のクリップはブラウザー内で動作するライブモデルです。各モデルを開くと周囲を回転して確認し、生成されたソースを読めます。
+
+| デモ | プレビュー | 対象 | 表示 | ソース |
+| --- | --- | --- | --- | --- |
+| Sony WF-1000XM3 イヤホンとケース | <img src="assets/sony-wf1000xm3.gif" width="260" alt="Sony WF-1000XM3 ライブデモ" /> | ハードサーフェスオブジェクト | [ライブ](https://hoainho.github.io/img2threejs-showcase/#/demo/sony-wf1000xm3) | [コード](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/sony-wf1000xm3/createSonyWf1000xm3Model.ts) |
+| ISSACA 12 ゲージショットガン | <img src="assets/issaca-shotgun.gif" width="260" alt="ISSACA 12 ゲージショットガンのライブデモ" /> | ハードサーフェスオブジェクト | [ライブ](https://hoainho.github.io/img2threejs-showcase/#/demo/issaca-shotgun) | [コード](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/issaca-shotgun/createIssacaShotgunModel.ts) |
+| Gerber パラコードナイフ | <img src="assets/gerber-knife.gif" width="260" alt="Gerber パラコードナイフのライブデモ" /> | ハードサーフェスオブジェクト | [ライブ](https://hoainho.github.io/img2threejs-showcase/#/demo/gerber-knife) | [コード](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/gerber-knife/createGerberKnifeModel.ts) |
+| ドラえもんの家（アイソメトリックジオラマ） | <img src="assets/doraemon-house.gif" width="260" alt="ドラえもんの家のライブデモ" /> | ハードサーフェスオブジェクト | [ライブ](https://hoainho.github.io/img2threejs-showcase/#/demo/doraemon-house) | [コード](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/doraemon-house/createDoraemonHouseModel.ts) |
+| War-Hauler「SECTOR 07」 | <img src="assets/warhauler.gif" width="260" alt="War-Hauler SECTOR 07 のライブデモ" /> | ハードサーフェスオブジェクト | [ライブ](https://hoainho.github.io/img2threejs-showcase/#/demo/warhauler) | [コード](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/warhauler/createWarHaulerModel.ts) |
+| 王冠付き戦利品の宝箱 | <img src="assets/crown-chest.gif" width="260" alt="王冠付き戦利品の宝箱のライブデモ" /> | ハードサーフェスオブジェクト | [ライブ](https://hoainho.github.io/img2threejs-showcase/#/demo/crown-chest) | [コード](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/crown-chest/createCrownChestModel.ts) |
+
+ギャラリーのソースは [hoainho/img2threejs-showcase](https://github.com/hoainho/img2threejs-showcase) にあります。このプロジェクトが役立った場合は、このリポジトリに Star を付けることで他の人が見つけやすくなります。
+
+---
+
+## 機能
+
+オブジェクトの参照画像を 1 枚渡すと、プリミティブ、プロシージャルシェーダー、生成ジオメトリからそのオブジェクトを再現する TypeScript 製の `THREE.Group` ファクトリを生成します。ランタイム階層（ピボット、ソケット、コライダー）を備えているため、結果は静的な塊ではなく、そのままアニメーションに利用できます。
+
+Claude Code、Codex、OpenCode 上で動作し、特定のエージェントには依存しません。ドキュメントで「エージェントビジョン」または「エージェントブラウザーツール」と記載されている箇所では、ネイティブ画像読み取り、ブラウザー MCP、プロジェクトプレビュー、ユーザー提供のスクリーンショットなど、ホストが提供する機能を使用します。
+
+### 対象と細部の精度
+
+- **オブジェクトとキャラクター。** 各対象は `object`、`character`、`hybrid` のいずれかに分類されます。オブジェクトはハードサーフェスパイプラインを使用し、キャラクターは `grimoire/character/reconstruction.md` に記載された解剖学を考慮する経路（頭身、顔のランドマーク、ポーズ）を使用します。
+- **細部優先の分析。** コード生成前に、アイデンティティを決める細部（光沢、ベベルや丸み、ネジやリベット、彫刻または塗装された線、輪郭、汚れ、摩耗）の `detailInventory` を列挙します。すべての細部は実在するコンポーネントまたはマテリアル項目に対応する必要があり、厳格品質ゲートはインベントリが完成するまで生成を停止します。分類法は `grimoire/intake/detail_inventory.md` にあります。
+- **特定の人物やキャラクターを最大限に再現。** オプトインの投影優先経路は、パラメトリックテンプレートを画像ランドマークに合わせ、写真の照明を除去し、レンダリングカメラを一致させ、参照画像をメッシュへ投影します。1 枚の画像で 100% の類似性を保証することはできないため、パイプラインは領域ごとの信頼度を報告し、重要な場合は追加の視点を求めます。詳細は `grimoire/character/likeness_maximization.md` を参照してください。
+
+---
+
+## 仕組み
+
+このスキルは段階的なスカルプトパイプラインを実行します。スクリプトが各段階をゲートし、パスを承認できるのはエージェントのビジョンだけです。
+
+```mermaid
+flowchart TD
+    A[Reference image] --> B[Probe and suitability gate]
+    B --> C[Pre-Spec Assessment: class, complexity, quality contract]
+    C --> D[Author ObjectSculptSpec: components, materials, sockets]
+    D --> E{Validate and strict-quality}
+    E -- too shallow --> D
+    E -- ok --> F[Locked build passes]
+    F --> G[Generate Three.js factory: current pass only]
+    G --> H[Render in browser and screenshot]
+    H --> I[Package one side-by-side sheet]
+    I --> J{Agent vision review}
+    J -- score below threshold --> K[Self-correct: refine-spec or refine-code]
+    K --> F
+    J -- pass --> L{More passes?}
+    L -- yes --> F
+    L -- no --> M[Animation-ready Three.js model]
+```
+
+### ビルドパス
+
+モデルは決められた順序でスカルプトされ、前のパスがレビューされ承認された後にのみ次のパスが解放されます。
+
+`blockout → structural-pass → form-refinement → material-pass → surface-pass → lighting-pass → interaction-pass → optimization-pass`
+
+各パスには独自の合格基準があります。実際のレンダリング、比較シート、しきい値以上のエージェントビジョンスコアがあり、アイデンティティを決める各特徴もそれぞれのしきい値以上である場合にのみ、パスは `continue` としてマークされます。
+
+### ゲート
+
+- **適合性**——画像が 3D の対象として実現可能かどうか。
+- **事前仕様と厳格品質**——仕様がオブジェクトの複雑さに対して十分な深さになるまでコード生成を停止します（複合オブジェクトに単一ルート仕様は使用できません）。
+- **スクリーンショットのフィードバック**——`continue` にはレンダリング、比較シート、合格したビジョンスコアが必要です。
+- **アクション対応**——モデルは `root.userData.sculptRuntime` を通じてランタイム階層（ピボット、ソケット、コライダー、破壊グループ）を公開します。
+- **接続の正確性**——子パーツ（ハンドル、手足、チューブ）は親への接続方法を宣言するため、空中に浮くことがありません。
+- **マテリアルと照明のリアリズム**——独立した PBR チャンネルと実際のライトを使用し、アルベドをラフネスとして流用しません。
+
+### 自己修正
+
+各パスの後、エージェントは `continue`、`refine-spec`、`refine-code`、`request-input`、`stop` の中から正確に 1 つを選択します。`refine-spec` は誤っている、または浅い仕様を修正して再検証し、`refine-code` は正しい仕様と一致しないジオメトリ、マテリアル、照明を修正します。
+
+---
+
+## クイックスタート
+
+1. **インストール**——このフォルダーをスキルディレクトリに配置します。
+
+   ```bash
+   git clone https://github.com/hoainho/img2threejs.git ~/.claude/skills/img2threejs
+   ```
+
+2. **呼び出し**——Claude Code でオブジェクト画像を添付または指定し、次を実行します。
+
+   ```
+   /img2threejs Rebuild this object as a Three.js model, keep the proportions, angles, and colours.
+   ```
+
+3. **パイプラインに従う**——スキルは画像を検証し、評価と仕様を作成し、ファクトリをパスごとに生成します。レンダリングが一致するまで、各段階で横並びの比較を表示します。
+
+スクリプトはスキルのルートから実行し、必要なのは Python 3.10+ だけです。追加インストールは不要です。
+
+```bash
+python3 forge/stage1_intake/probe_image.py <image>
+python3 forge/stage2_spec/new_pre_spec_assessment.py "Name" --image <image> --out assessment.json
+python3 forge/stage2_spec/new_sculpt_spec.py "Name" --image <image> --assessment assessment.json --out spec.json
+python3 forge/stage2_spec/validate_sculpt_spec.py spec.json --strict-quality
+python3 forge/stage3_build/generate_threejs_factory.py spec.json --out src/createObjectModel.ts
+```
+
+---
+
+## トークン効率が高い理由
+
+多くの画像から 3D を生成するエージェントループは、パスごとにモデル全体を読み直す、ピクセルを採点する、JSON を手作業で検証する、完了済みの手順を再実行するなど、機械的な作業をモデルに行わせてトークンを消費します。img2threejs はこれらをすべて決定論的なスクリプトへ移し、実際に判断が必要な場面だけでモデルトークンを使用します。
+
+- **スクリプトが強制し、モデルが判断。** Python スクリプトが検証、ゲート、仕様作成、PBR 抽出、比較シートのパッケージ化、パイプライン状態を処理しますが、視覚的な採点はしません。モデルのトークンは、横並びの 1 枚のシートを見て合否を判断することだけに使われます。
+- **依存関係ゼロ、インストールの手間ゼロ。** すべてのスクリプトは純粋な Python 3.10+ 標準ライブラリです。pip、PIL、numpy、Playwright は不要です。PNG の読み書きには `struct` と `zlib` を使用します。インストール不要なので、コンテキスト内でデバッグするものもありません。
+- **パスでゲートされた生成。** コードジェネレーターは、現在解放されているビルドパスだけを出力します。モデルが反復ごとにモデル全体を再生成または再読込する必要はなく、各手順は小さく限定されています。
+- **コード生成前に早期失敗。** 厳格品質ゲートは、Three.js のコードを 1 行も生成する前に浅い仕様を停止するため、最初から仕様不足のモデルをレンダリングしてトークンを消費することがありません。
+- **レビューごとに 1 枚の画像。** 各パスは、散在する複数のスクリーンショットではなく、参照画像とレンダリングを並べた 1 枚の比較シートだけで判断されます。
+- **バイナリではなくテキスト出力。** 結果は差分を確認できる TypeScript と JSON 仕様です。数 MB のメッシュファイルではなく、小さくレビュー可能で、バージョン管理できます。
+
+最終的には、画像から忠実な 3D モデルを取得しつつ、高価なモデルコンテキストを記録作業ではなく視覚的な判断とコードに割り当てられます。段階別およびサイクル別の完全なトークン内訳は [docs/TOKEN_COST.md](docs/TOKEN_COST.md) を参照してください。
+
+---
+
+## スクリプト
+
+| スクリプト | 役割 |
+| --- | --- |
+| `stage1_intake/probe_image.py` | 画像メタデータと明らかな技術的問題（視覚チェックではありません）。 |
+| `stage2_spec/new_pre_spec_assessment.py` | オブジェクトを分類し、複雑さを採点して品質契約を出力します。 |
+| `stage2_spec/new_sculpt_spec.py` | 評価から ObjectSculptSpec を作成します。 |
+| `stage2_spec/validate_sculpt_spec.py` | 仕様を検証し、`--strict-quality` がコード生成前に浅い仕様を停止します。 |
+| `stage1_intake/extract_pbr_evidence.py` | クロップごとに参照画像由来の PBR 証拠を生成します（推論であり、逆レンダリングではありません）。 |
+| `stage3_build/orchestrate_passes.py` | ロックされたパスの状態：ステータス、チェック、同期。 |
+| `stage3_build/generate_threejs_factory.py` | 現在解放されているパス用の Three.js `Group` ファクトリを出力します。 |
+| `stage4_review/make_comparison_sheet.py` | レビュー用に参照画像とレンダリングを並べた 1 枚のシートをパッケージ化します。 |
+| `stage4_review/append_review.py` | パスごとのレビュー（スコア、判断、証拠）を記録します。 |
+| `_shared/feature_acceptance_policy.py` | 特徴ごとのスコアしきい値を適用する内部ヘルパーです。 |
+| `stage1_intake/build_detail_inventory.py` | 参照画像をゾーンに分割し、詳細インベントリの雛形を作成します。 |
+| `stage1_intake/extract_landmarks.py` | ランドマークグリッドを重ね、キャラクター用の解剖ブロックの雛形を作成します。 |
+| `stage1_intake/solve_camera_pose.py` | レンダリングのカメラを一致させるため、参照カメラブロックを出力します。 |
+| `stage1_intake/delight_albedo.py` | テクスチャ投影前に写真から中立的なアルベドを近似します。 |
+| `stage3_build/bake_projected_texture.py` | 写真テクスチャ投影用の投影または UV ベイク記述子を出力します。 |
+
+`grimoire/` フォルダーには、各ゲートが適用する詳細な基準（検証、事前仕様評価、プロシージャルパターン、マテリアルと照明のリアリズム、接続の正確性、アクション対応モデル、自己修正）が含まれます。
+
+---
+
+## 得られるもの
+
+- `ObjectSculptSpec` JSON：コンポーネントツリー全体、マテリアル、反復システム、ソケット、各パスで記録されたレビュー履歴。
+- TypeScript の `createObjectNameModel(spec, options)` ファクトリは `THREE.Group` を返し、`root.userData.sculptRuntime` がノード、ソケット、コライダー、破壊グループを公開します。
+- 各パスの忠実度を記録するレンダリングと比較シート。
+
+---
+
+## ロードマップ
+
+- **v1.0**——オブジェクトパイプライン：段階的なスカルプト、レンダリングと参照画像のレビューループ、アクション対応階層。*リリース済み。*
+- **v1.1**——細部優先の分析：必須の詳細インベントリ、厳格品質ゲート。*リリース済み。*
+- **v1.2**——人型キャラクタージェネレーター：解剖トラック、比率ロック、特徴配置パス。*リリース済み。*
+- **v1.3**——類似性の最大化：投影優先のキャラクターレンダリング、領域ごとの信頼度。*計画中。*
+- **v1.4**——アニメーション対応リグ：SkinnedMesh、モーフターゲット、glTF エクスポート。*計画中。*
+
+詳細と今後のマイルストーンは [ROADMAP.md](ROADMAP.md)、技術仕様は [docs/UPGRADE_PLAN.md](docs/UPGRADE_PLAN.md) を参照してください。
+
+---
+
+## 制限について
+
+1 枚の画像から隠れた側面を把握したり、正確なジオメトリを保証したりすることはできません。このスキルは出力が近似、スタイル化、ローポリである場合に明示し、確信があるように装うのではなく、見えている面を反転して見えない面を推測します。ハードサーフェスオブジェクトには強い一方、キャラクターはフォトリアルな類似ではなく、スタイル化された再構築になります。「この画像から要求された忠実度には到達できない」という結果も有効であり、想定されています。
+
+---
+
+## Star の履歴
+
+img2threejs が役立った場合は、Star を付けることで他の人が見つけやすくなります。
+
+<a href="https://star-history.com/#hoainho/img2threejs&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hoainho/img2threejs&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hoainho/img2threejs&type=Date" />
+    <img alt="Star 履歴チャート" src="https://api.star-history.com/svg?repos=hoainho/img2threejs&type=Date" width="600" />
+  </picture>
+</a>
+
+---
+
+## コントリビューション
+
+コントリビューションを歓迎します。特に、プロシージャルマテリアルのレシピ、新しいゲート、ホスト対応、デモを募集しています。プロジェクトの今後については [CONTRIBUTING.md](CONTRIBUTING.md) と[ロードマップ](ROADMAP.md)を参照してください。
+
+## ライセンス
+
+MIT。詳しくは [LICENSE](LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <strong>English</strong> · <a href="./README.zh-CN.md">简体中文</a> · <a href="./README.ja.md">日本語</a>
+</p>
+
 <div align="center">
 
 <img src="assets/logo.svg" width="112" height="112" alt="img2threejs logo" />

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,225 @@
+<p align="center">
+  <a href="./README.md">English</a> · <strong>简体中文</strong> · <a href="./README.ja.md">日本語</a>
+</p>
+
+<div align="center">
+
+<img src="assets/logo.svg" width="112" height="112" alt="img2threejs 标志" />
+
+# img2threejs
+
+**将参考图中的物体重建为完全由代码生成的程序化 Three.js 模型。**
+
+通过质量门控、支持动画，并且刻意优化令牌效率——这是代码重建，而不是摄影测量、网格提取或下载美术资源包。
+
+[![许可证：MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![版本](https://img.shields.io/badge/version-1.2.0-green.svg)](SKILL.md)
+[![欢迎 PR](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![运行时](https://img.shields.io/badge/runtime-Three.js-000000.svg)](https://threejs.org)
+[![工具](https://img.shields.io/badge/tooling-Python%203.10%2B%20stdlib-3776ab.svg)](scripts)
+
+<a href="https://trendshift.io/repositories/83608?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-83608" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/83608/daily?language=Python" alt="Trendshift 上的 hoainho%2Fimg2threejs" width="250" height="55"/></a>
+
+![img2threejs 演示——将一张战利品宝箱参考图重建为程序化 Three.js 模型](assets/demo.gif)
+
+</div>
+
+*使用代码重建一张参考图——比例、颜色、倒角、金色饰边和发光徽章均正确——并在浏览器中实时运行。*
+
+### [→ 打开在线演示库](https://hoainho.github.io/img2threejs-showcase/)
+
+演示库中的每个模型都是在浏览器中运行的生成代码，不使用网格文件，也无需下载。
+
+---
+
+## 在线演示
+
+这些重建完全由基础几何体、程序化着色器和生成几何体构成。以下片段是在浏览器中运行的实时模型——打开任意模型即可环绕查看并阅读生成的源代码。
+
+| 演示 | 预览 | 对象 | 查看 | 源码 |
+| --- | --- | --- | --- | --- |
+| Sony WF-1000XM3 耳机和充电盒 | <img src="assets/sony-wf1000xm3.gif" width="260" alt="Sony WF-1000XM3 在线演示" /> | 硬表面物体 | [在线](https://hoainho.github.io/img2threejs-showcase/#/demo/sony-wf1000xm3) | [代码](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/sony-wf1000xm3/createSonyWf1000xm3Model.ts) |
+| ISSACA 12 号霰弹枪 | <img src="assets/issaca-shotgun.gif" width="260" alt="ISSACA 12 号霰弹枪在线演示" /> | 硬表面物体 | [在线](https://hoainho.github.io/img2threejs-showcase/#/demo/issaca-shotgun) | [代码](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/issaca-shotgun/createIssacaShotgunModel.ts) |
+| Gerber 伞绳刀 | <img src="assets/gerber-knife.gif" width="260" alt="Gerber 伞绳刀在线演示" /> | 硬表面物体 | [在线](https://hoainho.github.io/img2threejs-showcase/#/demo/gerber-knife) | [代码](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/gerber-knife/createGerberKnifeModel.ts) |
+| 哆啦 A 梦小屋（等距微缩景观） | <img src="assets/doraemon-house.gif" width="260" alt="哆啦 A 梦小屋在线演示" /> | 硬表面物体 | [在线](https://hoainho.github.io/img2threejs-showcase/#/demo/doraemon-house) | [代码](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/doraemon-house/createDoraemonHouseModel.ts) |
+| 战争运输车“SECTOR 07” | <img src="assets/warhauler.gif" width="260" alt="战争运输车 SECTOR 07 在线演示" /> | 硬表面物体 | [在线](https://hoainho.github.io/img2threejs-showcase/#/demo/warhauler) | [代码](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/warhauler/createWarHaulerModel.ts) |
+| 王冠战利品宝箱 | <img src="assets/crown-chest.gif" width="260" alt="王冠战利品宝箱在线演示" /> | 硬表面物体 | [在线](https://hoainho.github.io/img2threejs-showcase/#/demo/crown-chest) | [代码](https://github.com/hoainho/img2threejs-showcase/blob/main/src/demos/crown-chest/createCrownChestModel.ts) |
+
+演示库源码位于 [hoainho/img2threejs-showcase](https://github.com/hoainho/img2threejs-showcase)。如果本项目对你有帮助，给仓库点一个 Star 可以让更多人发现它。
+
+---
+
+## 功能
+
+你提供一张物体参考图，它会生成一个用 TypeScript 编写的 `THREE.Group` 工厂，通过基础几何体、程序化着色器和生成几何体重现该物体，并包含运行时层级结构（枢轴、插槽、碰撞体），因此结果可以直接制作动画，而不是一团静态模型。
+
+它可以在 Claude Code、Codex 或 OpenCode 中运行，并且与具体智能体无关。文档中提到“智能体视觉”或“智能体浏览器工具”时，它会使用宿主提供的能力——原生图像读取、浏览器 MCP、项目预览或用户提供的截图。
+
+### 对象与细节精度
+
+- **物体与角色。** 每个对象会被分类为 `object`、`character` 或 `hybrid`。物体使用硬表面流程；角色则进入 `grimoire/character/reconstruction.md` 中记录的解剖感知流程（头部单位比例、面部标志点和姿势）。
+- **细节优先分析。** 在生成代码之前，流程会列出由身份定义型微小细节组成的 `detailInventory`（光泽、倒角或圆角、螺钉或铆钉、雕刻或绘制线条、轮廓、污渍和磨损）。每个细节必须映射到真实组件或材质条目，严格质量门控会阻止生成，直到清单完整。分类法位于 `grimoire/intake/detail_inventory.md`。
+- **最大程度还原特定人物或角色。** 可选的投影优先流程会将参数化模板拟合到图像标志点，对照片去光照、匹配渲染相机，并将参考图投影到网格上。单张图像无法保证 100% 相似，因此流程会报告各区域置信度，并在必要时请求更多视角。详情见 `grimoire/character/likeness_maximization.md`。
+
+---
+
+## 工作原理
+
+此技能运行一个分阶段的雕刻流程。脚本对每个阶段进行门控；只有智能体的视觉能力可以批准一次构建通过。
+
+```mermaid
+flowchart TD
+    A[Reference image] --> B[Probe and suitability gate]
+    B --> C[Pre-Spec Assessment: class, complexity, quality contract]
+    C --> D[Author ObjectSculptSpec: components, materials, sockets]
+    D --> E{Validate and strict-quality}
+    E -- too shallow --> D
+    E -- ok --> F[Locked build passes]
+    F --> G[Generate Three.js factory: current pass only]
+    G --> H[Render in browser and screenshot]
+    H --> I[Package one side-by-side sheet]
+    I --> J{Agent vision review}
+    J -- score below threshold --> K[Self-correct: refine-spec or refine-code]
+    K --> F
+    J -- pass --> L{More passes?}
+    L -- yes --> F
+    L -- no --> M[Animation-ready Three.js model]
+```
+
+### 构建阶段
+
+模型按固定顺序进行雕刻；只有前一阶段经过检查并获准后，下一阶段才会解锁：
+
+`blockout → structural-pass → form-refinement → material-pass → surface-pass → lighting-pass → interaction-pass → optimization-pass`
+
+每个阶段都有自己的验收标准。只有具备真实渲染图、对比图、达到或超过阈值的智能体视觉评分，并且每个身份定义型特征都达到其自身阈值时，该阶段才会标记为 `continue`。
+
+### 门控
+
+- **适用性**——图像是否适合作为 3D 目标。
+- **预规格与严格质量**——在规格深度足以匹配物体复杂度前阻止代码生成（复合物体不能使用单根规格）。
+- **截图反馈**——`continue` 需要渲染图、对比图以及通过的视觉评分。
+- **可执行性**——模型通过 `root.userData.sculptRuntime` 暴露运行时层级结构（枢轴、插槽、碰撞体、破坏组）。
+- **连接正确性**——子部件（把手、四肢、管道）会声明其与父级的连接方式，确保不会悬浮在半空中。
+- **材质与光照真实感**——使用独立的 PBR 通道和真实灯光，绝不把反照率直接复用为粗糙度。
+
+### 自我修正
+
+每个阶段结束后，智能体必须准确选择一个操作：`continue`、`refine-spec`、`refine-code`、`request-input` 或 `stop`。`refine-spec` 修复错误或过浅的规格并重新验证；`refine-code` 修复不符合正确规格的几何体、材质或光照。
+
+---
+
+## 快速开始
+
+1. **安装**——将此文件夹放入你的技能目录：
+
+   ```bash
+   git clone https://github.com/hoainho/img2threejs.git ~/.claude/skills/img2threejs
+   ```
+
+2. **调用**——在 Claude Code 中附加或指向一张物体图像并运行：
+
+   ```
+   /img2threejs Rebuild this object as a Three.js model, keep the proportions, angles, and colours.
+   ```
+
+3. **按照流程操作**——此技能会验证图像、编写评估和规格、逐阶段生成工厂，并在每一步显示并排对比，直到渲染结果匹配。
+
+脚本从技能根目录运行，只需要 Python 3.10+，无需安装任何其他内容。
+
+```bash
+python3 forge/stage1_intake/probe_image.py <image>
+python3 forge/stage2_spec/new_pre_spec_assessment.py "Name" --image <image> --out assessment.json
+python3 forge/stage2_spec/new_sculpt_spec.py "Name" --image <image> --assessment assessment.json --out spec.json
+python3 forge/stage2_spec/validate_sculpt_spec.py spec.json --strict-quality
+python3 forge/stage3_build/generate_threejs_factory.py spec.json --out src/createObjectModel.ts
+```
+
+---
+
+## 为什么它节省令牌
+
+大多数图像转 3D 智能体循环会让模型执行机械性工作而浪费令牌，例如每个阶段重新读取整个模型、对像素评分、手动验证 JSON、重新运行已经完成的步骤。img2threejs 将所有这些工作交给确定性脚本，只在真正需要判断的地方使用模型令牌。
+
+- **脚本执行规则，模型负责判断。** Python 脚本处理验证、门控、规格编写、PBR 提取、对比图打包和流程状态，但绝不对视觉效果评分。模型令牌只用于一件事：查看一张并排对比图并判断通过或失败。
+- **零依赖，零安装干扰。** 每个脚本都只使用纯 Python 3.10+ 标准库。不使用 pip、PIL、numpy 或 Playwright。PNG 读写通过 `struct` 和 `zlib` 完成。无需安装就意味着无需在上下文中调试安装问题。
+- **阶段门控生成。** 代码生成器只输出当前解锁的构建阶段。模型不必在每次迭代中重新生成或读取整个模型——每一步都小而聚焦。
+- **在代码生成前快速失败。** 严格质量门控会在生成任何一行 Three.js 代码前拦截过浅的规格，从而避免将令牌浪费在渲染一开始就规格不足的模型上。
+- **每次检查只用一张图。** 每个阶段都只依据一张打包好的对比图（参考图与渲染图并排）进行判断，而不是分散的多张截图。
+- **文本输出，而非二进制文件。** 结果是可比较差异的 TypeScript 和 JSON 规格——体积小、易于检查、可纳入版本控制，而不是数 MB 的网格文件。
+
+最终效果是：你仍能从图像得到忠实的 3D 模型，但昂贵的模型上下文会留给视觉判断和代码，而不是记录工作。完整的各阶段与各循环令牌明细见 [docs/TOKEN_COST.md](docs/TOKEN_COST.md)。
+
+---
+
+## 脚本
+
+| 脚本 | 作用 |
+| --- | --- |
+| `stage1_intake/probe_image.py` | 图像元数据和明显的技术问题（不进行视觉检查）。 |
+| `stage2_spec/new_pre_spec_assessment.py` | 对物体分类、评估复杂度并生成质量契约。 |
+| `stage2_spec/new_sculpt_spec.py` | 根据评估编写 ObjectSculptSpec。 |
+| `stage2_spec/validate_sculpt_spec.py` | 验证规格；`--strict-quality` 在代码生成前拦截过浅的规格。 |
+| `stage1_intake/extract_pbr_evidence.py` | 为每个裁剪区域生成源自参考图的 PBR 证据（推断，而非逆向渲染）。 |
+| `stage3_build/orchestrate_passes.py` | 锁定阶段状态：状态、检查、同步。 |
+| `stage3_build/generate_threejs_factory.py` | 为当前解锁阶段输出 Three.js `Group` 工厂。 |
+| `stage4_review/make_comparison_sheet.py` | 打包一张参考图与渲染图的对比图以供检查。 |
+| `stage4_review/append_review.py` | 记录每个阶段的检查：评分、决定和证据。 |
+| `_shared/feature_acceptance_policy.py` | 强制执行各特征评分阈值的内部辅助工具。 |
+| `stage1_intake/build_detail_inventory.py` | 将参考图划分为区域并搭建细节清单框架。 |
+| `stage1_intake/extract_landmarks.py` | 叠加标志点网格，并为角色搭建解剖结构块。 |
+| `stage1_intake/solve_camera_pose.py` | 输出参考相机块，以便渲染可以匹配相机。 |
+| `stage1_intake/delight_albedo.py` | 在纹理投影前，从照片近似生成中性反照率。 |
+| `stage3_build/bake_projected_texture.py` | 为照片纹理投影输出投影或 UV 烘焙描述符。 |
+
+`grimoire/` 文件夹包含每个门控应用的详细评分准则（验证、预规格评估、程序化模式、材质和光照真实感、连接正确性、可执行模型、自我修正）。
+
+---
+
+## 输出内容
+
+- 一份 `ObjectSculptSpec` JSON：完整的组件树、材质、重复系统、插槽，以及每个阶段记录的检查历史。
+- 一个 TypeScript `createObjectNameModel(spec, options)` 工厂，返回 `THREE.Group`，并通过 `root.userData.sculptRuntime` 暴露节点、插槽、碰撞体和破坏组。
+- 一张渲染图以及记录各阶段保真度的对比图。
+
+---
+
+## 路线图
+
+- **v1.0**——物体流程：分阶段雕刻、渲染图与参考图检查循环、可执行层级结构。*已发布。*
+- **v1.1**——细节优先分析：必需的细节清单、严格质量门控。*已发布。*
+- **v1.2**——人形角色生成器：解剖流程、比例锁定和特征定位阶段。*已发布。*
+- **v1.3**——相似度最大化：投影优先的角色渲染、各区域置信度。*计划中。*
+- **v1.4**——动画就绪骨骼：SkinnedMesh、变形目标、glTF 导出。*计划中。*
+
+完整详情和后续里程碑见 [ROADMAP.md](ROADMAP.md)。技术规格见 [docs/UPGRADE_PLAN.md](docs/UPGRADE_PLAN.md)。
+
+---
+
+## 坦诚说明限制
+
+单张图像无法呈现隐藏的侧面，也无法保证几何体完全准确。此技能会明确说明输出何时为近似、风格化或低多边形，并通过镜像可见面来推断不可见面，而不是假装确定。它擅长处理硬表面物体；角色属于风格化重建，而不是照片级相似。“无法从此图像达到所要求的保真度”是有效且预期的结果。
+
+---
+
+## Star 历史
+
+如果 img2threejs 对你有帮助，点一个 Star 可以让更多人发现它。
+
+<a href="https://star-history.com/#hoainho/img2threejs&Date">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hoainho/img2threejs&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hoainho/img2threejs&type=Date" />
+    <img alt="Star 历史图表" src="https://api.star-history.com/svg?repos=hoainho/img2threejs&type=Date" width="600" />
+  </picture>
+</a>
+
+---
+
+## 参与贡献
+
+欢迎贡献，尤其是程序化材质配方、新门控、宿主覆盖和演示。请参阅 [CONTRIBUTING.md](CONTRIBUTING.md) 和[路线图](ROADMAP.md)，了解项目的发展方向。
+
+## 许可证
+
+MIT。请参阅 [LICENSE](LICENSE)。


### PR DESCRIPTION
Adds complete Simplified Chinese and Japanese README translations and links all three language versions for Chinese and Japanese readers.

Validation: preserved heading, list, and table structure, code blocks, inline code, links, and HTML targets; all relative paths resolve and both translations contain no emoji. Documentation-only; no runtime tests run.