### PR TITLE
docs: fix Star History chart with sealed token

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,11 +202,11 @@ A single image cannot reveal hidden sides or guarantee exact geometry. The skill
 
 If img2threejs is useful to you, a star helps others find it.
 
-<a href="https://star-history.com/#hoainho/img2threejs&Date">
+<a href="https://www.star-history.com/#hoainho/img2threejs&Timeline">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=hoainho/img2threejs&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=hoainho/img2threejs&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=hoainho/img2threejs&type=Date" width="600" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=hoainho/img2threejs&type=timeline&theme=dark&legend=top-left&sealed_token=HhzHOwb32twyQntl75HMLNf5E7hkH9aNTaSpn20ZThsyQC2Rt7fA_Wthz0osSgItW_WUiwA3MUa5-7GXquQCVL1uHLePUOUN9uVoiArBCm-l21DXJ51yVQ" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=hoainho/img2threejs&type=timeline&legend=top-left&sealed_token=HhzHOwb32twyQntl75HMLNf5E7hkH9aNTaSpn20ZThsyQC2Rt7fA_Wthz0osSgItW_WUiwA3MUa5-7GXquQCVL1uHLePUOUN9uVoiArBCm-l21DXJ51yVQ" />
+    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hoainho/img2threejs&type=timeline&legend=top-left&sealed_token=HhzHOwb32twyQntl75HMLNf5E7hkH9aNTaSpn20ZThsyQC2Rt7fA_Wthz0osSgItW_WUiwA3MUa5-7GXquQCVL1uHLePUOUN9uVoiArBCm-l21DXJ51yVQ" width="600" />
   </picture>
 </a>
 


### PR DESCRIPTION
The existing Star History embed used the tokenless star-history endpoint, which currently returns HTTP 500 (GitHub rate limiting) — so the chart rendered blank.

Switched to a repo-scoped **sealed token** URL (star-history's supported mechanism for embedding in public READMEs). Verified the new URL returns a valid chart (200, ~3.2K stars). Theme-aware dark/light `<picture>` preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)