### PR TITLE
fix: restore assets/logo.svg (README logo 404)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ runtime/**/dist/
 runtime/**/.vite/
 
 .cache/spec-search/
-assets/
+# Demo GIFs/renders in assets/ stay local, but the README's logo must ship with the repo.
+# Note the trailing `*`: git cannot re-include a file whose parent directory is excluded,
+# so `assets/` + `!assets/logo.svg` would silently not work.
+assets/*
+!assets/logo.svg
 openspec/
 runtime/

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,68 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="img2threejs organization avatar">
+  <title>img2threejs</title>
+  <defs>
+    <linearGradient id="a-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#1b1244"/>
+      <stop offset="0.55" stop-color="#120e2e"/>
+      <stop offset="1" stop-color="#0a0918"/>
+    </linearGradient>
+    <radialGradient id="a-glow-cyan" cx="0.78" cy="0.16" r="0.62">
+      <stop offset="0" stop-color="#38e8ff" stop-opacity="0.30"/>
+      <stop offset="1" stop-color="#38e8ff" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="a-glow-violet" cx="0.16" cy="0.86" r="0.66">
+      <stop offset="0" stop-color="#8b5cff" stop-opacity="0.28"/>
+      <stop offset="1" stop-color="#8b5cff" stop-opacity="0"/>
+    </radialGradient>
+
+    <linearGradient id="a-top" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cff"/>
+      <stop offset="1" stop-color="#38e8ff"/>
+    </linearGradient>
+    <linearGradient id="a-left" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2bd4c8"/>
+      <stop offset="1" stop-color="#118a9c"/>
+    </linearGradient>
+    <linearGradient id="a-right" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#6a3cf0"/>
+      <stop offset="1" stop-color="#2a1a7a"/>
+    </linearGradient>
+    <linearGradient id="a-pix" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#ffd76a"/>
+      <stop offset="1" stop-color="#ff8bd0"/>
+    </linearGradient>
+
+    <filter id="a-shadow" x="-40%" y="-40%" width="180%" height="180%">
+      <feGaussianBlur stdDeviation="18"/>
+    </filter>
+  </defs>
+
+  <!-- full-bleed badge: GitHub applies its own corner rounding -->
+  <rect width="512" height="512" fill="url(#a-bg)"/>
+  <rect width="512" height="512" fill="url(#a-glow-cyan)"/>
+  <rect width="512" height="512" fill="url(#a-glow-violet)"/>
+
+  <g transform="translate(256,256) scale(0.92) translate(-256,-256)">
+    <g transform="translate(16,-4)">
+      <!-- contact shadow -->
+      <ellipse cx="256" cy="412" rx="132" ry="26" fill="#05040d" opacity="0.55" filter="url(#a-shadow)"/>
+
+      <!-- source pixels dissolving into the cube (image -> 3D) -->
+      <rect x="48" y="320" width="48" height="48" rx="11" fill="url(#a-pix)" opacity="0.38"/>
+      <rect x="48" y="384" width="48" height="48" rx="11" fill="url(#a-pix)" opacity="0.62"/>
+      <rect x="112" y="384" width="48" height="48" rx="11" fill="url(#a-pix)" opacity="0.88"/>
+
+      <!-- isometric cube -->
+      <polygon points="256,110 398,181 256,252 114,181" fill="url(#a-top)"/>
+      <polygon points="114,181 256,252 256,402 114,331" fill="url(#a-left)"/>
+      <polygon points="398,181 256,252 256,402 398,331" fill="url(#a-right)"/>
+
+      <!-- edge definition -->
+      <path d="M114,181 L256,110 L398,181" fill="none" stroke="#ffffff" stroke-opacity="0.34" stroke-width="5" stroke-linejoin="round" stroke-linecap="round"/>
+      <path d="M256,252 L256,402" fill="none" stroke="#0b0a1f" stroke-opacity="0.22" stroke-width="5" stroke-linecap="round"/>
+
+      <!-- specular glint on the top face -->
+      <path d="M248,127 L256,147 L276,155 L256,163 L248,183 L240,163 L220,155 L240,147 Z" fill="#f4faff" opacity="0.94"/>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## What

`README.md` line 3 renders `<img src="assets/logo.svg" ...>`, but that file no longer exists on `main` — so the logo 404s:
https://github.com/img2threejs/img2threejs/blob/main/assets/logo.svg

## Why it went missing

`chore: update readme (#31)` deleted the whole `assets/` directory **and** added `assets/` to `.gitignore`. Dropping the demo GIFs was intentional; `logo.svg` went with them by accident.

## Changes

- Restore `assets/logo.svg` from the org brand source (`img2threejs-org/brand/logo-avatar.svg`, 512×512 square — matches the README's `width=112 height=112`).
- Narrow the ignore rule from `assets/` to `assets/*` + `!assets/logo.svg`.

The trailing `*` matters: git cannot re-include a file whose **parent directory** is excluded, so `assets/` + `!assets/logo.svg` would silently fail and the logo would need `git add -f` forever — i.e. it would quietly disappear again on the next cleanup.

## Verified

- `git check-ignore` resolves `assets/logo.svg` to the negation rule; `assets/*.gif` still resolves to `assets/*` (demo GIFs stay untracked, as intended).
- SVG reviewed line by line before publishing: gradients + polygons only, no scripts, no external refs, no credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)