### PR TITLE
docs: document the v1.4.1 review gates and make the suite guard them

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -157,10 +157,18 @@ Full flags: `grimoire/scripts.md`. Never let a script *score* visuals — that i
    `forge/stage3_build/generate_threejs_factory.py object-sculpt-spec.json --out src/createObjectModel.ts`
    (generator is pass-gated: a future `--pass-id` fails until prior passes are reviewed `continue`).
 7. Render the current pass in a browser/preview, capture a screenshot at a review viewpoint.
+   For `blockout`, capture a second **map-stripped** render from the same viewpoint with every
+   material map disabled (`map`, `normalMap`, `roughnessMap`, `metalnessMap`, `aoMap`), so structure
+   is judged on geometry alone and a convincing texture cannot stand in for real form. Keep that
+   shot: `diagnose_render.py` and `append_review.py` both refuse to credit `blockout` without it.
 8. Package one side-by-side sheet, then inspect it with agent vision:
    `forge/stage4_review/make_comparison_sheet.py --reference <img> --render <shot> --out cmp.png --json`.
 9. Record the review (overall + per-layer + per-feature scores + decision):
     `forge/stage4_review/append_review.py object-sculpt-spec.json --pass-id <pass> --fidelity <0-1> --action <continue|refine-spec|refine-code|request-input|stop> --summary "..." --render-screenshot <shot> --comparison-image cmp.png --ai-vision-score <0-1> --layer-scores-json '{...}' --feature-reviews-json <f.json> --in-place`.
+   For `blockout`, add `--map-stripped-render <shot>` (the maps-disabled render from step 7);
+   `action=continue` is refused without it.
+   Passes are credited in order: submitting any pass other than the currently unlocked one is
+   refused. Use `--force-out-of-order` only for a deliberate re-review of an already-visited pass.
    For the CS2 knife path, also attach the versioned report with
    `--cs2-review-json cs2-review.json --review-scene-json forge/tests/fixtures/knife_review_scene.json`.
    A failed family, painted-region, projection-coverage, critical-detail, or orbit gate blocks
@@ -263,7 +271,11 @@ evidence caused it, what still differs, and choose exactly one next action:
 - **Bounded correction loop (token-burn safety)**: `forge/stage4_review/correction_loop.py`
   guarantees termination (success/repeated-defect/oscillation/plateau/hard-ceiling), escalating to
   `request-input` — never a silent infinite burn.
-- **Tier 1 (legacy, still valid)**: "Tier 2 (AI-vision) never runs against a render that has not passed Tier 1." Run `forge/stage4_review/diagnose_render.py` (silhouette IoU/proportion/symmetry/per-part color) and record it (`--spec ... --in-place`) before requesting a comparison sheet; `orchestrate_passes.py check` refuses otherwise.
+- **Tier 1 (legacy, still valid)**: "Tier 2 (AI-vision) never runs against a render that has not
+  passed Tier 1." Run `forge/stage4_review/diagnose_render.py` (silhouette IoU/proportion/symmetry/
+  per-part color) and record it (`--spec ... --in-place`) before requesting a comparison sheet;
+  `orchestrate_passes.py check` refuses otherwise. On `blockout` it also fails without
+  `--map-stripped-render <shot>`, leaving the result `passed: false` so the pass stays locked.
 - **Pre-spec / strict-quality**: blocks code gen until the spec is deep enough for its contract.
 - **Screenshot feedback**: `continue` is allowed only with a render + comparison sheet + global
   AI-vision score ≥ threshold (default 0.7) AND every critical feature ≥ its own threshold.

--- a/forge/tests/test_cs2_review.py
+++ b/forge/tests/test_cs2_review.py
@@ -102,18 +102,25 @@ class Cs2ReviewGateTest(unittest.TestCase):
             spec_path.write_text(json.dumps({"sourceImage": "ref.png"}), encoding="utf-8")
             report_path.write_text(json.dumps(report), encoding="utf-8")
             failed_path.write_text(json.dumps(failed), encoding="utf-8")
+            # This test exercises the CS2 report gate, not pass ordering: credit is
+            # deliberately recorded out of the unlocked order, so --force-out-of-order
+            # is required for both calls.
             append_review_main([
                 str(spec_path), "--pass-id", "optimization-pass", "--fidelity", "0.9",
                 "--action", "continue", "--summary", "ok", "--cs2-review-json", str(report_path),
                 "--review-scene-json", str(ROOT / "tests" / "fixtures" / "knife_review_scene.json"),
-                "--in-place",
+                "--force-out-of-order", "--in-place",
             ])
             persisted = json.loads(spec_path.read_text(encoding="utf-8"))
             self.assertEqual(persisted["reviewHistory"][0]["cs2Review"]["verdict"], "pass")
-            with self.assertRaises(ValueError):
+            # Assert on the message so this stays a CS2-gate test: without
+            # --force-out-of-order the ordered-credit gate would raise first and
+            # silently mask the behaviour under test.
+            with self.assertRaisesRegex(ValueError, "CS2 review gate is blocking continuation"):
                 append_review_main([
                     str(spec_path), "--pass-id", "optimization-pass", "--fidelity", "0.9",
                     "--action", "continue", "--summary", "blocked", "--cs2-review-json", str(failed_path),
+                    "--force-out-of-order",
                 ])
 
 

--- a/forge/tests/test_pipeline.py
+++ b/forge/tests/test_pipeline.py
@@ -55,8 +55,12 @@ class PipelineTest(unittest.TestCase):
         self.spec = self.dir / "object-sculpt-spec.json"
         self.ref = self.dir / "ref.png"
         self.render = self.dir / "render.png"
+        # blockout is credited only against a maps-disabled render, so structure is
+        # judged on geometry alone (see diagnose_render.py / append_review.py gates).
+        self.map_stripped = self.dir / "render-map-stripped.png"
         write_png(self.ref)
         write_png(self.render)
+        write_png(self.map_stripped)
 
     def test_probe_image(self):
         r = run("stage1_intake/probe_image.py", self.ref)
@@ -238,8 +242,11 @@ class PipelineTest(unittest.TestCase):
         self.assertIn("Tier 1 diagnostics have not passed", blocked.stdout + blocked.stderr)
 
         # Recording a PASSING tier1 result (identical ref/render) unblocks it.
+        # blockout additionally requires maps-disabled evidence, or the recorded
+        # tier1Result stays passed=false and the pass never unlocks.
         run("stage4_review/diagnose_render.py", "--reference", self.ref, "--render", self.ref,
-            "--pass-id", "blockout", "--spec", self.spec, "--in-place")
+            "--pass-id", "blockout", "--spec", self.spec, "--in-place",
+            "--map-stripped-render", self.map_stripped)
         unblocked = run("stage3_build/orchestrate_passes.py", "check", self.spec, "--pass-id", "blockout")
         self.assertEqual(unblocked.returncode, 0, unblocked.stderr)
 
@@ -573,12 +580,48 @@ class PipelineTest(unittest.TestCase):
                 "--fidelity", "0.8", "--action", "continue",
                 "--summary", "Blockout silhouette acceptable.",
                 "--render-screenshot", self.render, "--comparison-image", cmp,
+                "--map-stripped-render", self.map_stripped,
                 "--ai-vision-score", "0.8", "--layer-scores-json", layers,
                 "--feature-reviews-json", freviews,
                 "--camera-view", "front", "--in-place")
         self.assertEqual(r.returncode, 0, r.stderr)
         spec = json.loads(self.spec.read_text())
         self.assertTrue(len(spec.get("reviewHistory", [])) >= 1)
+
+    def test_blockout_continue_refused_without_map_stripped_render(self):
+        # v1.4.1 gate: a convincing texture must not stand in for real structure,
+        # so blockout cannot be credited on a render with material maps enabled.
+        run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
+        r = run("stage4_review/append_review.py", self.spec, "--pass-id", "blockout",
+                "--fidelity", "0.8", "--action", "continue", "--summary", "no stripped evidence",
+                "--render-screenshot", self.render, "--in-place")
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("--map-stripped-render", r.stdout + r.stderr)
+
+    def test_append_review_refuses_out_of_order_pass(self):
+        # v1.4.1 gate: passes are credited in unlocked order unless a re-review is
+        # explicitly requested with --force-out-of-order.
+        run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
+        blocked = run("stage4_review/append_review.py", self.spec, "--pass-id", "material-pass",
+                      "--fidelity", "0.8", "--action", "continue", "--summary", "skipping ahead",
+                      "--render-screenshot", self.render, "--in-place")
+        self.assertNotEqual(blocked.returncode, 0)
+        self.assertIn("--force-out-of-order", blocked.stdout + blocked.stderr)
+
+    def test_diagnose_render_fails_blockout_without_map_stripped_render(self):
+        # The same evidence rule is enforced one stage earlier, so the recorded
+        # tier1Result is passed=false and orchestrate_passes.py keeps the pass locked.
+        run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
+        run("stage4_review/diagnose_render.py", "--reference", self.ref, "--render", self.ref,
+            "--pass-id", "blockout", "--spec", self.spec, "--in-place")
+        spec = json.loads(self.spec.read_text())
+        results = spec.get("tier1Results", [])
+        self.assertTrue(results, "diagnose_render should record a tier1Result")
+        self.assertFalse(results[-1]["passed"])
+        self.assertIn("blockout requires --map-stripped-render evidence", results[-1]["failures"])
+        still_locked = run("stage3_build/orchestrate_passes.py", "check", self.spec,
+                           "--pass-id", "blockout")
+        self.assertNotEqual(still_locked.returncode, 0)
 
     def test_pbr_extraction_runs(self):
         # low-detail synthetic image: either passes or refuses (non-zero) — both are valid,

--- a/grimoire/scripts.md
+++ b/grimoire/scripts.md
@@ -57,6 +57,10 @@ Evidence flags: `--matched --mismatches --spec-fixes --code-fixes --evidence --r
 --feature-reviews-json f.json --ai-vision-notes "..." --visual-threshold 0-1 --camera-view NAME
 --require-screenshot-files`. Layer keys: `silhouetteProportion, componentStructure, formDetail,
 materialSurface, lightingCamera`. Records one self-correction entry into `reviewHistory`.
+Two hard gates block `--action continue`: `blockout` requires `--map-stripped-render SHOT`
+(an unlit, maps-disabled render, also required by `stage4_review/diagnose_render.py`), and passes
+are credited in unlocked order — any other `--pass-id` is refused unless `--force-out-of-order`
+is passed for a deliberate re-review.
 
 ## stage1_intake/extract_pbr_evidence.py
 `stage1_intake/extract_pbr_evidence.py <crop> --out-dir DIR --material-id ID [--target-threshold 0.7] [--size N]


### PR DESCRIPTION
Fixes #33.

## Summary

v1.4.1 added hard gates to the review path but updated neither `SKILL.md` nor the tests. The user-facing effect is that an agent following `SKILL.md` step 9 verbatim fails on `blockout` — the **first** review pass of every run — so it cannot credit a single pass.

This PR syncs the docs and makes the test suite guard the gates instead of tripping over them. **No production code is changed.**

## The issue missed a third gate

@byosamah's report identifies two gates in `append_review.py`. There is a third, in `diagnose_render.py:273`:

```python
if args.pass_id == "blockout":
    if not args.map_stripped_render:
        result.setdefault("failures", []).append("blockout requires --map-stripped-render evidence")
        result["passed"] = False
```

This is why `test_orchestrator_refuses_current_pass_without_passing_tier1` was failing — that test never calls `append_review.py` at all. It calls `diagnose_render.py`, which records a `tier1Result` with `passed: false`, so `orchestrate_passes.py check` keeps the pass locked. Applying only the fix suggested in the issue would have left that test red.

## Docs

- **Step 7** now instructs capturing the maps-disabled `blockout` render, naming the exact maps that `strip_material_maps()` clears (`map`, `normalMap`, `roughnessMap`, `metalnessMap`, `aoMap`).
- **Step 9** documents `--map-stripped-render` and the ordered-credit rule, including `--force-out-of-order`.
- **The Tier 1 bullet** explains why `blockout` records `passed: false` without the evidence. I rewrapped it to the ~100-col convention its neighbouring bullets already use — it was the file's longest line at 336 chars and my addition would have pushed it to 539. The file's longest line is now 329, slightly shorter than before this PR.
- **`grimoire/scripts.md`** — `SKILL.md` cites this as "Full flags", and its `append_review.py` evidence-flag list was missing both new flags. Fixing `SKILL.md` while leaving the reference it points at stale would have reproduced the same bug.

I deliberately did **not** document `--map-stripped-scene` as the mechanism for producing the render. It is referenced nowhere else in the repo, nothing in the documented flow produces a scene JSON (the pipeline output is a TypeScript factory), and it rewrites its input file in place. Documenting it looked like a footgun, so step 7 states the requirement instead of prescribing an unproven workflow.

## Tests

The three failures are fixed at their real root cause rather than worked around:

- `test_pipeline` — supply `--map-stripped-render` to both `append_review.py` and `diagnose_render.py`.
- `test_cs2_review` — this test exercises the CS2 report gate, not pass ordering, so it credits out of order deliberately via `--force-out-of-order`. It now asserts on the error message with `assertRaisesRegex`; without that, the ordered-credit gate would raise first and silently mask the behaviour the test claims to check.

Plus **three new regression tests**, since nothing guarded the new gates:

| Test | Guards |
|---|---|
| `test_blockout_continue_refused_without_map_stripped_render` | `append_review.py` blockout evidence gate |
| `test_append_review_refuses_out_of_order_pass` | ordered-credit gate |
| `test_diagnose_render_fails_blockout_without_map_stripped_render` | `diagnose_render.py` blockout gate + the resulting orchestrator lock |

## Verification

```
python3 -m unittest discover -s forge/tests   ->  245 tests, 3 failing   (before)
                                              ->  248 tests, all passing (after)
python3 forge/tests/test_pipeline.py          ->  59 tests, all passing
```

Each new test was mutation-verified: disabling any one gate in the source fails exactly its own test, and only that test.

Checked against `CONTRIBUTING.md` — no emojis, stdlib only, both documented test commands pass, no production code touched. Verified on Python 3.12; the CI in #37 targets 3.10 and nothing here is version-sensitive.

## Note on ownership

@kokorolx is assigned to #33 and said this was planned for the next release. This was already written when I noticed — very happy to close it if you'd rather land your own, and the third-gate finding above stands either way.
