### PR TITLE
fix: degenerate silhouette evidence no longer scores as a perfect match

### DIFF
--- a/forge/stage4_review/diagnose_render.py
+++ b/forge/stage4_review/diagnose_render.py
@@ -63,17 +63,30 @@ COLOR_DELTA_E_THRESHOLD = 20.0  # generous vs. the JND (~2-3) to tolerate render
 MASK_GRID_SIZE = 224
 
 
-def load_mask(png_path: Path, size: int = MASK_GRID_SIZE) -> list[bool]:
-    """Returns a flat row-major boolean grid of length size*size (foreground=True)."""
+def mask_is_inverted(warnings: list[str]) -> bool:
+    """build_foreground_mask falls back to "all opaque pixels" when keyed coverage is
+    under 3.5%, which turns a tiny silhouette into a full frame. Any silhouette
+    comparison against an inverted mask is meaningless — two disjoint small objects
+    both invert to the full frame and score IoU 1.0 — so callers must gate on this
+    instead of scoring it. Mirrors the same check in diagnose_render_multi_angle.py."""
+    return any("tiny" in str(warning).lower() for warning in warnings)
+
+
+def load_mask(png_path: Path, size: int = MASK_GRID_SIZE) -> tuple[list[bool], list[str]]:
+    """Returns (flat row-major boolean grid of length size*size, mask warnings).
+
+    The warnings are returned rather than dropped because the <3.5%-coverage fallback
+    inverts the mask; a caller that discards them cannot tell a real silhouette from a
+    full-frame inversion. Gate with mask_is_inverted()."""
     width, height, pixels, _warnings = load_image(png_path)
-    mask, _diag, _warn = build_foreground_mask(width, height, pixels)
+    mask, _diag, mask_warnings = build_foreground_mask(width, height, pixels)
     resized: list[bool] = []
     for y in range(size):
         sy = min(height - 1, int(y * height / size))
         for x in range(size):
             sx = min(width - 1, int(x * width / size))
             resized.append(mask[sy * width + sx])
-    return resized
+    return resized, mask_warnings
 
 
 def silhouette_iou(reference_mask: list[bool], render_mask: list[bool]) -> float:
@@ -84,7 +97,9 @@ def silhouette_iou(reference_mask: list[bool], render_mask: list[bool]) -> float
             union += 1
             if ref and render:
                 intersection += 1
-    return intersection / union if union else 1.0
+    # An empty union means neither image has any foreground — two failed captures, not a
+    # perfect match. Scoring that 1.0 passes the IoU hard gate on no evidence at all.
+    return intersection / union if union else 0.0
 
 
 def bbox_of(mask: list[bool], size: int = MASK_GRID_SIZE) -> tuple[int, int, int, int]:
@@ -178,8 +193,12 @@ def run_tier1(
     spec_path: Path | None = None,
     pass_id: str | None = None,
 ) -> dict[str, Any]:
-    reference_mask = load_mask(reference_path)
-    render_mask = load_mask(render_path)
+    reference_mask, reference_mask_warnings = load_mask(reference_path)
+    render_mask, render_mask_warnings = load_mask(render_path)
+    mask_warnings = (
+        [f"reference: {w}" for w in reference_mask_warnings]
+        + [f"render: {w}" for w in render_mask_warnings]
+    )
 
     iou = silhouette_iou(reference_mask, render_mask)
     reference_bbox = bbox_of(reference_mask)
@@ -194,6 +213,14 @@ def run_tier1(
         "bilateralSymmetryError": round(symmetry, 4),
     }
     failures: list[str] = []
+    # Gate this BEFORE reading IoU: an inverted mask makes every silhouette-derived
+    # number meaningless, and the inverted case reads as a perfect match, not a bad one.
+    if mask_is_inverted(reference_mask_warnings) or mask_is_inverted(render_mask_warnings):
+        failures.append(
+            "silhouette evidence is unusable: the foreground mask fell back to whole-frame "
+            "coverage (subject under 3.5% of the frame), so IoU and proportion are not "
+            "measuring the subject; re-capture with the subject filling more of the frame"
+        )
     if iou < SILHOUETTE_IOU_THRESHOLD:
         failures.append(f"silhouette IoU {iou:.3f} is below threshold {SILHOUETTE_IOU_THRESHOLD}")
     if proportions["aspect_ratio_delta"] > ASPECT_RATIO_DELTA_THRESHOLD:
@@ -230,6 +257,7 @@ def run_tier1(
         "passed": not failures,
         "checks": checks,
         "failures": failures,
+        "maskWarnings": mask_warnings,
         "renderHash": render_hash(render_path),
         "passId": pass_id,
     }

--- a/forge/stage4_review/divine_eye.py
+++ b/forge/stage4_review/divine_eye.py
@@ -41,6 +41,7 @@ from diagnose_render import (  # noqa: E402
     bbox_of,
     bilateral_symmetry_error,
     load_mask,
+    mask_is_inverted,
     proportion_delta,
     silhouette_iou,
 )
@@ -234,7 +235,9 @@ def edge_overlap(a: list[float], b: list[float], size: int) -> float:
             union += 1
             if ea[i] and eb[i]:
                 inter += 1
-    return inter / union if union else 1.0
+    # No edges anywhere in either image is an absence of evidence, not agreement;
+    # scoring it 1.0 feeds a free 1.0-weighted term into the fidelity ensemble.
+    return inter / union if union else 0.0
 
 
 def _blown_fraction(luma: list[float], hi: float = 0.95) -> float:
@@ -274,8 +277,8 @@ def tonal_parity(ref: list[float], ren: list[float], bins: int = 16) -> float:
 
 def evaluate(reference_png: Path, render_png: Path) -> dict[str, Any]:
     """Run all deterministic signals and combine into a verdict + routing action."""
-    ref_mask = load_mask(reference_png)
-    ren_mask = load_mask(render_png)
+    ref_mask, ref_mask_warnings = load_mask(reference_png)
+    ren_mask, ren_mask_warnings = load_mask(render_png)
     ref_luma = load_luma(reference_png, LUMA_SIZE)
     ren_luma = load_luma(render_png, LUMA_SIZE)
     ref_edge = load_luma(reference_png, EDGE_SIZE)
@@ -327,6 +330,15 @@ def evaluate(reference_png: Path, render_png: Path) -> dict[str, Any]:
 
     # HARD gates: a fail is an immediate reject with a specific numeric reason.
     hard_failures: list[str] = []
+    # The <3.5%-coverage fallback inverts a tiny mask to the full frame, so IoU, scale and
+    # aspect are no longer measuring the subject. Two disjoint objects both invert and score
+    # IoU 1.0, which reads as a perfect match rather than a failed capture — gate it first.
+    mask_inverted = mask_is_inverted(ref_mask_warnings) or mask_is_inverted(ren_mask_warnings)
+    if mask_inverted:
+        hard_failures.append(
+            "foreground mask fell back to whole-frame coverage; silhouette, scale and aspect "
+            "signals are not measuring the subject"
+        )
     if iou < IOU_HARD_MIN:
         hard_failures.append(f"silhouette IoU {iou:.3f} < {IOU_HARD_MIN}")
     if scale_delta > SCALE_HARD_MAX:
@@ -369,6 +381,11 @@ def evaluate(reference_png: Path, render_png: Path) -> dict[str, Any]:
     # hard failure is IoU AND objectness says "same object" (high, brightness/bg-invariant),
     # downgrade the confident reject to a probe rather than hard-failing a faithful build.
     # Never rescues a scale-delta failure or a genuinely different object (low objectness).
+    # Note: an inverted-mask failure cannot be rescued here, because the all()-match below
+    # requires every hard failure to be an IoU failure and the inversion message is not one.
+    # If that message is ever reworded to contain "silhouette IoU", this rescue would start
+    # firing on degenerate masks — test_disjoint_tiny_objects_are_not_a_perfect_match is the
+    # backstop for that.
     reconstruction_suspected = False
     if hard_failures and objectness is not None and objectness >= RECON_OBJ_MIN:
         if all("silhouette IoU" in f for f in hard_failures):
@@ -392,6 +409,10 @@ def evaluate(reference_png: Path, render_png: Path) -> dict[str, Any]:
         "fidelity": round(fidelity, 4),
         "fidelityTarget": FIDELITY_TARGET,
         "hardGateFailures": hard_failures,
+        "maskWarnings": (
+            [f"reference: {w}" for w in ref_mask_warnings]
+            + [f"render: {w}" for w in ren_mask_warnings]
+        ),
         "disagreementSpread": round(spread, 4),
         "signals": {
             "silhouetteIoU": round(iou, 4),

--- a/forge/tests/test_divine_eye.py
+++ b/forge/tests/test_divine_eye.py
@@ -21,6 +21,7 @@ from divine_eye import (  # noqa: E402
     global_ssim,
     tonal_parity,
 )
+from diagnose_render import mask_is_inverted, silhouette_iou  # noqa: E402
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
@@ -136,6 +137,62 @@ class DivineEyeIntegrationTest(unittest.TestCase):
         r = evaluate(aref, aref)
         self.assertEqual(r["fidelity"], 1.0)
         self.assertEqual(r["verdict"], "pass")
+
+
+class DegenerateEvidenceTest(unittest.TestCase):
+    """Absence of evidence must never score as agreement.
+
+    build_foreground_mask falls back to whole-frame coverage when the keyed subject is
+    under 3.5% of the frame. Two unrelated small subjects therefore both invert to a full
+    frame and compare as an exact match; an empty union scored 1.0 compounded it.
+    """
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+
+    def test_silhouette_iou_empty_union_is_zero(self):
+        # two failed captures are not a perfect match
+        self.assertEqual(silhouette_iou([False] * 16, [False] * 16), 0.0)
+
+    def test_silhouette_iou_still_correct_when_populated(self):
+        self.assertEqual(silhouette_iou([True, True, False, False], [True, True, False, False]), 1.0)
+        self.assertEqual(silhouette_iou([True, False, False, False], [False, True, False, False]), 0.0)
+
+    def test_edge_overlap_no_edges_is_zero(self):
+        # a flat image pair has no edges anywhere; that is missing evidence, not agreement,
+        # and it used to feed a free 1.0 into the weighted fidelity ensemble.
+        flat = [0.5] * 64
+        self.assertEqual(edge_overlap(flat, flat, 8), 0.0)
+
+    def test_mask_is_inverted_detects_the_tiny_coverage_fallback(self):
+        self.assertTrue(mask_is_inverted(["foreground mask is tiny; material extraction is unreliable"]))
+        self.assertFalse(mask_is_inverted([]))
+        self.assertFalse(mask_is_inverted(["image is not clearly isolated from background"]))
+
+    def test_disjoint_tiny_objects_are_not_a_perfect_match(self):
+        # THE regression: 30x30 subjects at opposite corners of a 200x200 frame share zero
+        # pixels. Each is 2.25% coverage, so both masks invert to the full frame and the
+        # silhouette compares as identical. This must be a hard failure, not a pass.
+        ref = self.dir / "corner_a.png"
+        ren = self.dir / "corner_b.png"
+        write_rgb_png(ref, 200, 200, block(10, 10, 40, 40, fg=(220, 30, 30)))
+        write_rgb_png(ren, 200, 200, block(160, 160, 190, 190, fg=(30, 30, 220)))
+        r = evaluate(ref, ren)
+        self.assertTrue(r["hardGateFailures"], "disjoint subjects must trip a hard gate")
+        self.assertNotEqual(r["verdict"], "pass")
+        self.assertTrue(r["maskWarnings"], "the mask inversion must be reported, not discarded")
+
+    def test_same_shape_at_different_positions_still_fails(self):
+        # Identical 28x28 subjects at opposite corners: shape, colour and size all match, so
+        # every non-silhouette signal agrees. Only the inversion gate separates this from a
+        # genuine match, which is why it must be a hard failure rather than a soft penalty.
+        ref = self.dir / "tiny_a.png"
+        ren = self.dir / "tiny_b.png"
+        write_rgb_png(ref, 200, 200, block(20, 20, 48, 48, fg=(200, 40, 40)))
+        write_rgb_png(ren, 200, 200, block(150, 150, 178, 178, fg=(200, 40, 40)))
+        r = evaluate(ref, ren)
+        self.assertTrue(r["hardGateFailures"])
+        self.assertEqual(r["action"], "refine-code")
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_pipeline.py
+++ b/forge/tests/test_pipeline.py
@@ -580,6 +580,42 @@ class PipelineTest(unittest.TestCase):
         spec = json.loads(self.spec.read_text())
         self.assertTrue(len(spec.get("reviewHistory", [])) >= 1)
 
+    def test_tier1_rejects_whole_frame_mask_fallback(self):
+        # build_foreground_mask inverts to whole-frame coverage below 3.5%, so two subjects
+        # sharing zero pixels compare as an exact silhouette match. Tier 1 discarded that
+        # warning and reported silhouetteIoU 1.0 / passed=true on a completely wrong render.
+        def solid(path, w, h, rect, fg):
+            raw = bytearray()
+            for y in range(h):
+                raw.append(0)
+                for x in range(w):
+                    inside = rect[0] <= x < rect[2] and rect[1] <= y < rect[3]
+                    raw += bytes(fg if inside else (255, 255, 255))
+
+            def chunk(tag, data):
+                c = struct.pack(">I", len(data)) + tag + data
+                return c + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+            Path(path).write_bytes(
+                b"\x89PNG\r\n\x1a\n"
+                + chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+                + chunk(b"IDAT", zlib.compress(bytes(raw), 9))
+                + chunk(b"IEND", b"")
+            )
+
+        ref = self.dir / "tiny_ref.png"
+        ren = self.dir / "tiny_render.png"
+        solid(ref, 200, 200, (10, 10, 40, 40), (220, 30, 30))
+        solid(ren, 200, 200, (160, 160, 190, 190), (30, 30, 220))
+        r = run("stage4_review/diagnose_render.py", "--reference", ref, "--render", ren, "--json")
+        result = json.loads(r.stdout)
+        self.assertFalse(result["passed"], "disjoint subjects must not pass Tier 1")
+        self.assertTrue(result["maskWarnings"], "mask warnings must reach the result")
+        self.assertTrue(
+            any("silhouette evidence is unusable" in f for f in result["failures"]),
+            f"expected an explicit unusable-evidence failure, got {result['failures']}",
+        )
+
     def test_pbr_extraction_runs(self):
         # low-detail synthetic image: either passes or refuses (non-zero) — both are valid,
         # but it must not crash and must respect the confidence gate.


### PR DESCRIPTION
Fixes bugs 2 and 8 of #18.

## Two unrelated objects currently pass as an exact silhouette match

200×200 frames, 30×30 subjects at opposite corners, **zero shared pixels**, run against untouched `main`:

```
true silhouette overlap : ZERO
reported silhouetteIoU  : 1.0
passed                  : True
failures                : []
warning surfaced        : none
```

`build_foreground_mask` falls back to "all opaque pixels" when keyed coverage drops below 3.5%, inverting a small subject into a full frame. It *does* warn about this — and both mask consumers discarded the warning:

```python
# diagnose_render.load_mask
mask, _diag, _warn = build_foreground_mask(width, height, pixels)
```

`divine_eye.evaluate` inherited the same blindness through `load_mask`. Notably `diagnose_render_multi_angle.py:52` already handles this correctly, so the repo contained both the right and the wrong pattern.

Separately, `silhouette_iou` and `edge_overlap` both returned `1.0` on an empty union. Two blank frames therefore also scored a perfect match, and `edge_overlap` contributed a free 1.0-weighted term to the fidelity ensemble.

The common thread: **absence of evidence was being scored as agreement.**

## Changes

**`diagnose_render.py`**
- `load_mask` returns `(mask, warnings)` rather than dropping them. This is a signature change; both in-repo callers are updated.
- New `mask_is_inverted()` helper, matching the convention already used in `diagnose_render_multi_angle.py`.
- `run_tier1` gates on it *before* reading IoU, fails with an explicit unusable-evidence reason, and surfaces `maskWarnings` in its result.
- Empty union → `0.0`.

**`divine_eye.py`**
- `evaluate` raises the same condition as a hard gate and reports `maskWarnings`.
- `edge_overlap` empty union → `0.0`.

## On the objectness rescue path

I initially added a `not mask_inverted` guard to the reconstruction-mode rescue. Mutation testing showed removing it changed nothing, so I dug in: the rescue requires `all("silhouette IoU" in f for f in hard_failures)`, and the inversion failure message is not an IoU failure, so the rescue is already unreachable in this state (objectness is `0.0` there regardless).

It was dead code and the test I had written to justify it proved nothing, so I removed both and left a comment recording the invariant and naming the test that backstops it if the message is ever reworded. Flagging it here because it is the kind of thing that looks like a deliberate safety guard in review when it is actually unreachable.

## Tests

7 regression tests across `test_divine_eye.py` and `test_pipeline.py`, covering the unit level (`silhouette_iou`, `edge_overlap`, `mask_is_inverted`), the `evaluate` level (disjoint subjects; identical subjects at different positions, where every non-silhouette signal agrees and only this gate separates it from a real match), and the Tier-1 CLI level.

Every guard was mutation-verified — reverting any one of the five individually fails exactly its own test:

```
silhouette_iou empty -> 1.0            CAUGHT
edge_overlap empty -> 1.0              CAUGHT
tier1 inversion gate removed           CAUGHT
divine_eye inversion gate removed      CAUGHT
same-shape case vs inversion gate      CAUGHT
```

## Verification

```
245 -> 252 tests, zero new failures
```

The 3 failures on this branch are pre-existing on `main` and are exactly the ones from #33. **This PR should land after the #33 fix**, after which the combined suite is **255 tests, all passing** (verified locally). The two touch adjacent lines in `test_pipeline.py`, so whichever merges second needs a one-line conflict resolution — happy to rebase on request.

## Credit

Bugs 2 and 8 come from @cktang88's audit in #18, which is unusually thorough. I re-verified both independently against current `main` with my own repro scripts before writing anything, and can confirm:

- **Bug 1 (scale-gate key mismatch) is already fixed** on `main` — the audit was filed against `7b1c62c`.
- **Bugs 3, 4 and 5 are still live.** Bug 4 in particular reproduces exactly as described: a lathe primitive with no profile data passes plain validation, and the generator exits 0 emitting the hardcoded default hourglass with no marker — four lines below a docstring promising *"Never silently substitute a box... with no signal that anything was wrong."*

@cktang88 offered to send PRs for these. I've only taken 2 and 8 and am glad to leave the rest, or to help with them if that's useful.
