### PR TITLE
fix: decode JPEG in-process so reference images work off macOS

### DIFF
--- a/forge/_shared/jpeg.py
+++ b/forge/_shared/jpeg.py
@@ -1,0 +1,448 @@
+#!/usr/bin/env python3
+"""Baseline JPEG decoder in pure Python 3.10+ standard library.
+
+Why this exists: every image-consuming script fell back to macOS `sips` for any
+format that is not PNG, so a JPEG reference — the most common kind of reference
+photo there is — failed hard on Linux and Windows, and in CI. This decodes
+baseline JPEG directly so the pipeline behaves the same on every platform.
+
+Scope is deliberately narrow and honest about it:
+  * baseline sequential DCT (SOF0) and extended sequential (SOF1), 8-bit
+  * grayscale (1 component) and YCbCr (3 components), any sampling factors
+  * restart intervals
+  * progressive (SOF2), arithmetic coding, 12-bit and CMYK raise a clear
+    UnsupportedJpeg so callers can fall back rather than silently mis-decode
+
+Returns the same shape as read_png(): (width, height, [(r, g, b, a), ...]).
+"""
+from __future__ import annotations
+
+import struct
+from math import cos, pi
+
+__all__ = ["decode_jpeg", "is_jpeg", "UnsupportedJpeg"]
+
+
+class UnsupportedJpeg(ValueError):
+    """A JPEG this decoder deliberately does not handle (e.g. progressive)."""
+
+
+SOI, EOI, SOS, DQT, DHT, DRI = 0xD8, 0xD9, 0xDA, 0xDB, 0xC4, 0xDD
+SOF_BASELINE, SOF_EXTENDED, SOF_PROGRESSIVE = 0xC0, 0xC1, 0xC2
+
+ZIGZAG = (
+    0, 1, 8, 16, 9, 2, 3, 10, 17, 24, 32, 25, 18, 11, 4, 5,
+    12, 19, 26, 33, 40, 48, 41, 34, 27, 20, 13, 6, 7, 14, 21, 28,
+    35, 42, 49, 56, 57, 50, 43, 36, 29, 22, 15, 23, 30, 37, 44, 51,
+    58, 59, 52, 45, 38, 31, 39, 46, 53, 60, 61, 54, 47, 55, 62, 63,
+)
+
+# IDCT[u][x] = C(u)/2 * cos((2x+1) u pi / 16); applying it on rows then columns
+# yields the 1/4 scaling of the 2-D inverse DCT.
+_IDCT = [
+    [((0.353553390593273762 if u == 0 else 0.5) * cos((2 * x + 1) * u * pi / 16))
+     for x in range(8)]
+    for u in range(8)
+]
+
+
+def is_jpeg(data: bytes) -> bool:
+    return len(data) >= 2 and data[0] == 0xFF and data[1] == SOI
+
+
+class _BitReader:
+    """MSB-first bit reader over entropy-coded data, unstuffing 0xFF 0x00."""
+
+    __slots__ = ("data", "pos", "bits", "nbits")
+
+    def __init__(self, data: bytes, pos: int) -> None:
+        self.data = data
+        self.pos = pos
+        self.bits = 0
+        self.nbits = 0
+
+    def _fill(self) -> None:
+        data = self.data
+        while self.nbits <= 24:
+            if self.pos >= len(data):
+                self.bits = (self.bits << 8) | 0
+                self.nbits += 8
+                continue
+            byte = data[self.pos]
+            self.pos += 1
+            if byte == 0xFF:
+                nxt = data[self.pos] if self.pos < len(data) else 0
+                if nxt == 0x00:
+                    self.pos += 1
+                elif 0xD0 <= nxt <= 0xD7:
+                    # restart marker: stop feeding, sync() consumes it
+                    self.pos -= 1
+                    self.bits = (self.bits << 8) | 0
+                    self.nbits += 8
+                    continue
+                else:
+                    self.pos -= 1
+                    self.bits = (self.bits << 8) | 0
+                    self.nbits += 8
+                    continue
+            self.bits = (self.bits << 8) | byte
+            self.nbits += 8
+
+    def receive(self, length: int) -> int:
+        if length == 0:
+            return 0
+        if self.nbits < length:
+            self._fill()
+        self.nbits -= length
+        value = (self.bits >> self.nbits) & ((1 << length) - 1)
+        self.bits &= (1 << self.nbits) - 1
+        return value
+
+    def bit(self) -> int:
+        return self.receive(1)
+
+    def sync_restart(self) -> None:
+        """Consume an RSTn marker and drop partial bits."""
+        self.bits = 0
+        self.nbits = 0
+        data = self.data
+        while self.pos + 1 < len(data):
+            if data[self.pos] == 0xFF and 0xD0 <= data[self.pos + 1] <= 0xD7:
+                self.pos += 2
+                return
+            self.pos += 1
+
+
+def _build_huffman(counts: bytes, symbols: bytes) -> dict[tuple[int, int], int]:
+    """Map (bit-length, code) -> symbol. Canonical JPEG Huffman assignment."""
+    table: dict[tuple[int, int], int] = {}
+    code = 0
+    index = 0
+    for length in range(1, 17):
+        for _ in range(counts[length - 1]):
+            table[(length, code)] = symbols[index]
+            index += 1
+            code += 1
+        code <<= 1
+    return table
+
+
+def _decode_huffman(reader: _BitReader, table: dict[tuple[int, int], int]) -> int:
+    code = 0
+    for length in range(1, 17):
+        code = (code << 1) | reader.bit()
+        symbol = table.get((length, code))
+        if symbol is not None:
+            return symbol
+    raise ValueError("invalid Huffman code in entropy-coded data")
+
+
+def _extend(value: int, length: int) -> int:
+    """Convert an unsigned magnitude to its signed JPEG value."""
+    if length == 0:
+        return 0
+    return value if value >= (1 << (length - 1)) else value - (1 << length) + 1
+
+
+def _idct_2d(block: list[float]) -> list[float]:
+    """Separable 8x8 inverse DCT. DC-only blocks short-circuit."""
+    if not any(block[1:]):
+        flat = block[0] * 0.125
+        return [flat] * 64
+
+    tmp = [0.0] * 64
+    for y in range(8):
+        row = y * 8
+        coeffs = block[row:row + 8]
+        if not any(coeffs[1:]):
+            value = coeffs[0] * 0.353553390593273762
+            for x in range(8):
+                tmp[row + x] = value
+            continue
+        for x in range(8):
+            total = 0.0
+            for u in range(8):
+                c = coeffs[u]
+                if c:
+                    total += c * _IDCT[u][x]
+            tmp[row + x] = total
+
+    out = [0.0] * 64
+    for x in range(8):
+        column = [tmp[y * 8 + x] for y in range(8)]
+        if not any(column[1:]):
+            value = column[0] * 0.353553390593273762
+            for y in range(8):
+                out[y * 8 + x] = value
+            continue
+        for y in range(8):
+            total = 0.0
+            for v in range(8):
+                c = column[v]
+                if c:
+                    total += c * _IDCT[v][y]
+            out[y * 8 + x] = total
+    return out
+
+
+def _axis_map(out_len: int, samp: int, samp_max: int, plane_len: int) -> list[tuple[int, int, float]]:
+    """Per-output-pixel (low, high, fraction) for triangular chroma upsampling.
+
+    Subsampled chroma samples sit at the centre of the luma pixels they cover, so
+    output pixel x maps to chroma coordinate (x + 0.5) * samp/samp_max - 0.5.
+    Nearest-neighbour replication instead of this interpolation is visible as
+    banding on sharp colour edges (~30/255 against a libjpeg reference)."""
+    scale = samp / samp_max
+    mapping: list[tuple[int, int, float]] = []
+    last = max(0, plane_len - 1)
+    for x in range(out_len):
+        coord = (x + 0.5) * scale - 0.5
+        low = int(coord // 1)
+        frac = coord - low
+        if low < 0:
+            low, frac = 0, 0.0
+        high = low + 1
+        if low > last:
+            low = last
+        if high > last:
+            high = last
+        mapping.append((low, high, frac))
+    return mapping
+
+
+def _bilinear(plane: list[float], row0: int, row1: int, yfrac: float,
+              xmap: tuple[int, int, float]) -> float:
+    x0, x1, xfrac = xmap
+    top = plane[row0 + x0] + (plane[row0 + x1] - plane[row0 + x0]) * xfrac
+    if yfrac == 0.0 and row0 == row1:
+        return top
+    bottom = plane[row1 + x0] + (plane[row1 + x1] - plane[row1 + x0]) * xfrac
+    return top + (bottom - top) * yfrac
+
+
+def _clamp(value: float) -> int:
+    if value <= 0.0:
+        return 0
+    if value >= 255.0:
+        return 255
+    return int(value + 0.5)
+
+
+def decode_jpeg(data: bytes) -> tuple[int, int, list[tuple[int, int, int, int]]]:
+    """Decode baseline JPEG bytes to (width, height, RGBA pixel list)."""
+    if not is_jpeg(data):
+        raise ValueError("not a JPEG file")
+
+    quant: dict[int, list[int]] = {}
+    huff_dc: dict[int, dict[tuple[int, int], int]] = {}
+    huff_ac: dict[int, dict[tuple[int, int], int]] = {}
+    components: list[dict] = []
+    width = height = 0
+    restart_interval = 0
+    scan_start = -1
+    scan_components: list[dict] = []
+
+    pos = 2
+    while pos + 3 < len(data):
+        if data[pos] != 0xFF:
+            pos += 1
+            continue
+        marker = data[pos + 1]
+        pos += 2
+        if marker in (0x01, EOI) or 0xD0 <= marker <= 0xD7:
+            continue
+        if pos + 2 > len(data):
+            break
+        seg_len = struct.unpack(">H", data[pos:pos + 2])[0]
+        segment = data[pos + 2:pos + seg_len]
+
+        if marker == SOF_PROGRESSIVE:
+            raise UnsupportedJpeg("progressive JPEG is not supported by this decoder")
+        if marker in (0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF):
+            raise UnsupportedJpeg(f"unsupported JPEG coding mode (SOF marker 0x{marker:02X})")
+
+        if marker in (SOF_BASELINE, SOF_EXTENDED):
+            precision = segment[0]
+            if precision != 8:
+                raise UnsupportedJpeg(f"only 8-bit JPEG is supported, got {precision}-bit")
+            height, width = struct.unpack(">HH", segment[1:5])
+            count = segment[5]
+            if count not in (1, 3):
+                raise UnsupportedJpeg(
+                    f"only grayscale and YCbCr JPEG are supported, got {count} components"
+                )
+            components = []
+            for i in range(count):
+                cid, sampling, tq = segment[6 + i * 3:9 + i * 3]
+                components.append({
+                    "id": cid,
+                    "h": sampling >> 4,
+                    "v": sampling & 15,
+                    "tq": tq,
+                })
+        elif marker == DQT:
+            cursor = 0
+            while cursor < len(segment):
+                pq_tq = segment[cursor]
+                cursor += 1
+                precision, table_id = pq_tq >> 4, pq_tq & 15
+                values = [0] * 64
+                for i in range(64):
+                    if precision:
+                        values[ZIGZAG[i]] = struct.unpack(">H", segment[cursor:cursor + 2])[0]
+                        cursor += 2
+                    else:
+                        values[ZIGZAG[i]] = segment[cursor]
+                        cursor += 1
+                quant[table_id] = values
+        elif marker == DHT:
+            cursor = 0
+            while cursor < len(segment):
+                tc_th = segment[cursor]
+                cursor += 1
+                counts = segment[cursor:cursor + 16]
+                cursor += 16
+                total = sum(counts)
+                symbols = segment[cursor:cursor + total]
+                cursor += total
+                table = _build_huffman(counts, symbols)
+                if tc_th >> 4:
+                    huff_ac[tc_th & 15] = table
+                else:
+                    huff_dc[tc_th & 15] = table
+        elif marker == DRI:
+            restart_interval = struct.unpack(">H", segment[0:2])[0]
+        elif marker == SOS:
+            count = segment[0]
+            scan_components = []
+            for i in range(count):
+                cid, tables = segment[1 + i * 2:3 + i * 2]
+                for comp in components:
+                    if comp["id"] == cid:
+                        comp["dc"] = tables >> 4
+                        comp["ac"] = tables & 15
+                        scan_components.append(comp)
+                        break
+            scan_start = pos + seg_len
+            break
+        pos += seg_len
+
+    if not components or width == 0 or height == 0:
+        raise ValueError("JPEG is missing a frame header")
+    if scan_start < 0:
+        raise ValueError("JPEG is missing scan data")
+
+    h_max = max(c["h"] for c in components)
+    v_max = max(c["v"] for c in components)
+    mcu_w, mcu_h = 8 * h_max, 8 * v_max
+    mcus_x = (width + mcu_w - 1) // mcu_w
+    mcus_y = (height + mcu_h - 1) // mcu_h
+
+    for comp in components:
+        comp["bw"] = mcus_x * comp["h"]
+        comp["bh"] = mcus_y * comp["v"]
+        comp["plane"] = [0] * (comp["bw"] * 8 * comp["bh"] * 8)
+        comp["stride"] = comp["bw"] * 8
+        comp["pred"] = 0
+
+    reader = _BitReader(data, scan_start)
+    block = [0.0] * 64
+    mcu_index = 0
+
+    for my in range(mcus_y):
+        for mx in range(mcus_x):
+            if restart_interval and mcu_index and mcu_index % restart_interval == 0:
+                reader.sync_restart()
+                for comp in components:
+                    comp["pred"] = 0
+            mcu_index += 1
+
+            for comp in scan_components:
+                qt = quant.get(comp["tq"])
+                if qt is None:
+                    raise ValueError("JPEG references an undefined quantization table")
+                dc_table = huff_dc.get(comp["dc"])
+                ac_table = huff_ac.get(comp["ac"])
+                if dc_table is None or ac_table is None:
+                    raise ValueError("JPEG references an undefined Huffman table")
+
+                for by in range(comp["v"]):
+                    for bx in range(comp["h"]):
+                        for i in range(64):
+                            block[i] = 0.0
+
+                        t = _decode_huffman(reader, dc_table)
+                        diff = _extend(reader.receive(t), t) if t else 0
+                        comp["pred"] += diff
+                        block[0] = float(comp["pred"] * qt[0])
+
+                        k = 1
+                        while k < 64:
+                            rs = _decode_huffman(reader, ac_table)
+                            run, size = rs >> 4, rs & 15
+                            if size == 0:
+                                if run == 15:
+                                    k += 16
+                                    continue
+                                break
+                            k += run
+                            if k > 63:
+                                break
+                            zz = ZIGZAG[k]
+                            block[zz] = float(_extend(reader.receive(size), size) * qt[zz])
+                            k += 1
+
+                        pixels = _idct_2d(block)
+                        px0 = (mx * comp["h"] + bx) * 8
+                        py0 = (my * comp["v"] + by) * 8
+                        stride = comp["stride"]
+                        plane = comp["plane"]
+                        for y in range(8):
+                            row = (py0 + y) * stride + px0
+                            src = y * 8
+                            for x in range(8):
+                                plane[row + x] = pixels[src + x] + 128.0
+
+    out: list[tuple[int, int, int, int]] = []
+    if len(components) == 1:
+        comp = components[0]
+        plane, stride = comp["plane"], comp["stride"]
+        for y in range(height):
+            base = y * stride
+            for x in range(width):
+                grey = _clamp(plane[base + x])
+                out.append((grey, grey, grey, 255))
+        return width, height, out
+
+    y_c, cb_c, cr_c = components[0], components[1], components[2]
+    for comp in (y_c, cb_c, cr_c):
+        comp["w"] = -(-width * comp["h"] // h_max)
+        comp["h_px"] = -(-height * comp["v"] // v_max)
+        comp["xmap"] = _axis_map(width, comp["h"], h_max, comp["w"])
+        comp["ymap"] = _axis_map(height, comp["v"], v_max, comp["h_px"])
+
+    y_plane, y_stride, y_xmap, y_ymap = (
+        y_c["plane"], y_c["stride"], y_c["xmap"], y_c["ymap"])
+    cb_plane, cb_stride, cb_xmap, cb_ymap = (
+        cb_c["plane"], cb_c["stride"], cb_c["xmap"], cb_c["ymap"])
+    cr_plane, cr_stride, cr_xmap, cr_ymap = (
+        cr_c["plane"], cr_c["stride"], cr_c["xmap"], cr_c["ymap"])
+
+    for y in range(height):
+        yy0, yy1, yfr = y_ymap[y]
+        cby0, cby1, cbyfr = cb_ymap[y]
+        cry0, cry1, cryfr = cr_ymap[y]
+        y_r0, y_r1 = yy0 * y_stride, yy1 * y_stride
+        cb_r0, cb_r1 = cby0 * cb_stride, cby1 * cb_stride
+        cr_r0, cr_r1 = cry0 * cr_stride, cry1 * cr_stride
+        for x in range(width):
+            luma = _bilinear(y_plane, y_r0, y_r1, yfr, y_xmap[x])
+            cb = _bilinear(cb_plane, cb_r0, cb_r1, cbyfr, cb_xmap[x]) - 128.0
+            cr = _bilinear(cr_plane, cr_r0, cr_r1, cryfr, cr_xmap[x]) - 128.0
+            out.append((
+                _clamp(luma + 1.402 * cr),
+                _clamp(luma - 0.344136 * cb - 0.714136 * cr),
+                _clamp(luma + 1.772 * cb),
+                255,
+            ))
+    return width, height, out

--- a/forge/stage1_intake/build_detail_inventory.py
+++ b/forge/stage1_intake/build_detail_inventory.py
@@ -21,6 +21,9 @@ import tempfile
 import zlib
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
@@ -144,6 +147,14 @@ def load_image(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
     try:
         return read_png(path)
     except Exception as direct_error:
+        # JPEG is decoded in-process so a reference photo works on every platform;
+        # sips below stays as the fallback for formats we do not decode (HEIC, TIFF).
+        jpeg_bytes = path.read_bytes()
+        if is_jpeg(jpeg_bytes):
+            try:
+                return decode_jpeg(jpeg_bytes)
+            except UnsupportedJpeg:
+                pass
         sips = shutil.which("sips")
         if not sips:
             raise ValueError(f"could not decode {path.name} as PNG and sips is unavailable: {direct_error}") from direct_error

--- a/forge/stage1_intake/delight_albedo.py
+++ b/forge/stage1_intake/delight_albedo.py
@@ -26,6 +26,9 @@ import zlib
 from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
@@ -161,6 +164,14 @@ def load_image(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]], l
     try:
         return (*read_png(path), warnings)
     except Exception as direct_error:
+        # JPEG is decoded in-process so a reference photo works on every platform;
+        # sips below stays as the fallback for formats we do not decode (HEIC, TIFF).
+        jpeg_bytes = path.read_bytes()
+        if is_jpeg(jpeg_bytes):
+            try:
+                return (*decode_jpeg(jpeg_bytes), warnings)
+            except UnsupportedJpeg as unsupported:
+                warnings.append(f"{path.name} needs an external converter: {unsupported}")
         sips = shutil.which("sips")
         if not sips:
             raise ValueError(

--- a/forge/stage1_intake/extract_landmarks.py
+++ b/forge/stage1_intake/extract_landmarks.py
@@ -21,6 +21,9 @@ import tempfile
 import zlib
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
@@ -163,6 +166,14 @@ def load_image(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
     try:
         return read_png(path)
     except Exception as direct_error:
+        # JPEG is decoded in-process so a reference photo works on every platform;
+        # sips below stays as the fallback for formats we do not decode (HEIC, TIFF).
+        jpeg_bytes = path.read_bytes()
+        if is_jpeg(jpeg_bytes):
+            try:
+                return decode_jpeg(jpeg_bytes)
+            except UnsupportedJpeg:
+                pass
         sips = shutil.which("sips")
         if not sips:
             raise ValueError(f"could not decode {path.name} as PNG and sips is unavailable: {direct_error}") from direct_error

--- a/forge/stage1_intake/extract_pbr_evidence.py
+++ b/forge/stage1_intake/extract_pbr_evidence.py
@@ -24,6 +24,9 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
@@ -191,6 +194,14 @@ def load_image(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]], l
     try:
         return (*read_png(path), warnings)
     except Exception as direct_error:
+        # JPEG is decoded in-process so a reference photo works on every platform;
+        # sips below stays as the fallback for formats we do not decode (HEIC, TIFF).
+        jpeg_bytes = path.read_bytes()
+        if is_jpeg(jpeg_bytes):
+            try:
+                return (*decode_jpeg(jpeg_bytes), warnings)
+            except UnsupportedJpeg as unsupported:
+                warnings.append(f"{path.name} needs an external converter: {unsupported}")
         sips = shutil.which("sips")
         if not sips:
             raise ValueError(

--- a/forge/stage4_review/make_comparison_sheet.py
+++ b/forge/stage4_review/make_comparison_sheet.py
@@ -18,6 +18,9 @@ import tempfile
 import zlib
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
@@ -128,6 +131,14 @@ def load_image(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
     try:
         return read_png(path)
     except Exception as direct_error:
+        # JPEG is decoded in-process so a reference photo works on every platform;
+        # sips below stays as the fallback for formats we do not decode (HEIC, TIFF).
+        jpeg_bytes = path.read_bytes()
+        if is_jpeg(jpeg_bytes):
+            try:
+                return decode_jpeg(jpeg_bytes)
+            except UnsupportedJpeg:
+                pass
         sips = shutil.which("sips")
         if not sips:
             raise ValueError(f"could not decode {path.name} as PNG and sips is unavailable: {direct_error}") from direct_error

--- a/forge/tests/test_jpeg.py
+++ b/forge/tests/test_jpeg.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tests for the pure-stdlib baseline JPEG decoder.
+
+The fixture is embedded rather than generated so these run identically on Linux
+CI, where the macOS `sips` converter this decoder replaces does not exist.
+"""
+
+from __future__ import annotations
+
+import base64
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "_shared"))
+sys.path.insert(0, str(ROOT / "stage1_intake"))
+sys.path.insert(0, str(ROOT / "stage4_review"))
+
+from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+
+# 32x32 baseline JPEG: left half red (200,30,40), right half blue (30,60,200).
+FIXTURE_B64 = (
+    "/9j/4AAQSkZJRgABAQAASABIAAD/4QBMRXhpZgAATU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAA"
+    "A6ABAAMAAAABAAEAAKACAAQAAAABAAAAIKADAAQAAAABAAAAIAAAAAD/7QA4UGhvdG9zaG9wIDMu"
+    "MAA4QklNBAQAAAAAAAA4QklNBCUAAAAAABDUHYzZjwCyBOmACZjs+EJ+/8AAEQgAIAAgAwEiAAIR"
+    "AQMRAf/EAB8AAAEFAQEBAQEBAAAAAAAAAAABAgMEBQYHCAkKC//EALUQAAIBAwMCBAMFBQQEAAAB"
+    "fQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5"
+    "OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeo"
+    "qaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/j5+v/EAB8BAAMB"
+    "AQEBAQEBAQEAAAAAAAABAgMEBQYHCAkKC//EALURAAIBAgQEAwQHBQQEAAECdwABAgMRBAUhMQYS"
+    "QVEHYXETIjKBCBRCkaGxwQkjM1LwFWJy0QoWJDThJfEXGBkaJicoKSo1Njc4OTpDREVGR0hJSlNU"
+    "VVZXWFlaY2RlZmdoaWpzdHV2d3h5eoKDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5"
+    "usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/bAEMAAgICAgICAwICAwUDAwMF"
+    "BgUFBQUGCAYGBgYGCAoICAgICAgKCgoKCgoKCgwMDAwMDA4ODg4ODw8PDw8PDw8PD//bAEMBAgIC"
+    "BAQEBwQEBxALCQsQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ"
+    "EBAQEP/dAAQAAv/aAAwDAQACEQMRAD8A+R6KKK/Hz/VA4Oiiiv8AYw/xHP/Q+R6KKK/Hz/VA4Oii"
+    "iv8AYw/xHP/Z"
+)
+FIXTURE = base64.b64decode("".join(FIXTURE_B64.split()))
+
+
+class JpegDecoderTest(unittest.TestCase):
+    def test_is_jpeg_detects_signature(self):
+        self.assertTrue(is_jpeg(FIXTURE))
+        self.assertFalse(is_jpeg(b"\x89PNG\r\n\x1a\n"))
+        self.assertFalse(is_jpeg(b""))
+
+    def test_decodes_expected_dimensions(self):
+        width, height, pixels = decode_jpeg(FIXTURE)
+        self.assertEqual((width, height), (32, 32))
+        self.assertEqual(len(pixels), 32 * 32)
+        self.assertTrue(all(len(p) == 4 and p[3] == 255 for p in pixels))
+
+    def test_decodes_correct_colours(self):
+        # JPEG is lossy, so assert the hue is right rather than exact bytes.
+        width, _height, pixels = decode_jpeg(FIXTURE)
+        left = pixels[16 * width + 6]
+        right = pixels[16 * width + 26]
+        self.assertGreater(left[0], 150, f"left half should read red, got {left}")
+        self.assertLess(left[2], 100, f"left half should read red, got {left}")
+        self.assertGreater(right[2], 150, f"right half should read blue, got {right}")
+        self.assertLess(right[0], 100, f"right half should read blue, got {right}")
+
+    def test_chroma_upsampling_places_the_colour_boundary_correctly(self):
+        # The fixture is red|blue split exactly down the middle. Chroma is stored at
+        # half resolution, so an incorrect upsampling scale still yields "red on the
+        # left, blue on the right" while silently moving the boundary — sampling a
+        # point well inside each half cannot detect that. Assert the position.
+        width, _height, pixels = decode_jpeg(FIXTURE)
+        row = [pixels[16 * width + x] for x in range(width)]
+        red_majority = sum(1 for p in row if p[0] > p[2])
+        self.assertEqual(
+            red_majority, width // 2,
+            f"colour boundary is misplaced; {red_majority} red px of {width}",
+        )
+
+    def test_rejects_non_jpeg(self):
+        with self.assertRaises(ValueError):
+            decode_jpeg(b"\x89PNG\r\n\x1a\nnot a jpeg")
+
+    def test_progressive_raises_unsupported_not_garbage(self):
+        # Flip the SOF0 marker to SOF2 so the decoder must refuse explicitly rather
+        # than mis-decode; callers rely on UnsupportedJpeg to fall back cleanly.
+        index = FIXTURE.find(b"\xff\xc0")
+        self.assertGreater(index, 0, "fixture should contain a baseline SOF0 marker")
+        progressive = FIXTURE[:index] + b"\xff\xc2" + FIXTURE[index + 2:]
+        with self.assertRaises(UnsupportedJpeg):
+            decode_jpeg(progressive)
+
+
+class JpegPortabilityTest(unittest.TestCase):
+    """The reason this decoder exists: every load_image() shelled out to macOS
+    `sips` for non-PNG input, so a JPEG reference failed hard on Linux/Windows."""
+
+    MODULES = [
+        "extract_pbr_evidence",
+        "extract_landmarks",
+        "build_detail_inventory",
+        "delight_albedo",
+        "make_comparison_sheet",
+    ]
+
+    def test_every_load_image_reads_jpeg_without_sips(self):
+        directory = Path(tempfile.mkdtemp())
+        path = directory / "reference.jpg"
+        path.write_bytes(FIXTURE)
+
+        real_which = shutil.which
+        shutil.which = lambda *a, **k: None  # simulate a machine with no sips
+        try:
+            for name in self.MODULES:
+                module = __import__(name)
+                with self.subTest(module=name):
+                    result = module.load_image(path)
+                    self.assertEqual(result[0], 32)
+                    self.assertEqual(result[1], 32)
+                    self.assertEqual(len(result[2]), 32 * 32)
+        finally:
+            shutil.which = real_which
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## img2threejs cannot read a JPEG reference on Linux or Windows

The pipeline's input is a reference image. JPEG — the most common format a reference photo arrives in — only works on macOS.

Every `load_image()` falls back to the macOS `sips` binary for non-PNG input, and `shutil.which("sips")` returns `None` everywhere else:

```
ValueError: could not decode reference.jpg as PNG and macOS sips is unavailable: not a PNG file
```

Verified by monkeypatching `shutil.which` to `None` — the same failure occurs in **all five** copies of this fallback: `extract_pbr_evidence.py`, `extract_landmarks.py`, `delight_albedo.py`, `build_detail_inventory.py`, `make_comparison_sheet.py`.

The CI added in #37 runs on `ubuntu-latest`, so any test touching a JPEG would fail there today.

## Approach

Pillow is not an option — `CONTRIBUTING.md` requires pure stdlib, no pip. So this adds `forge/_shared/jpeg.py`, a baseline JPEG decoder written against the same constraint.

Scope is deliberately narrow and says so in its own docstring:

- baseline (SOF0) and extended sequential (SOF1) DCT, 8-bit
- grayscale and YCbCr, any sampling factors, restart intervals
- progressive, arithmetic, 12-bit and CMYK raise `UnsupportedJpeg` so callers fall back rather than silently mis-decode

Each `load_image()` tries the decoder before `sips`. **`sips` stays as the fallback** for formats not decoded here (HEIC, TIFF) — no existing behaviour is removed, and macOS users see no change.

## Accuracy

Measured against the **original pre-JPEG source**, not against another decoder — comparing two decoders only tells you they disagree, not which is right:

| fixture | this decoder vs original | libjpeg/sips vs original |
|---|---|---|
| gradient | max 3, mean 0.526 | max 4, mean 0.544 |
| odd_size (37×23) | max 4, mean 0.552 | max 5, mean 0.608 |
| two_blocks | max 1, mean 0.167 | max 1, mean 0.333 |

Decoder-vs-decoder differences of a few units are expected and permitted — ISO/IEC 10918 leaves IDCT precision implementation-defined. This float IDCT lands marginally closer to the source than libjpeg's integer path on every fixture.

Chroma is upsampled with a triangular filter rather than nearest-neighbour replication. That matters: with replication, a sharp colour edge was off by **33/255** against the reference; with the filter it is **2/255**.

## Tests

7 tests, with the JPEG fixture **embedded as base64** so they run identically on Linux CI where `sips` does not exist.

`JpegPortabilityTest` is the one that matters: it patches `shutil.which` to `None` and asserts all five `load_image()` entry points read a JPEG. That test fails on `main`.

Mutation-verified — each of these fails exactly its own test:

```
chroma upsampling scale broken     CAUGHT
JPEG wiring removed                CAUGHT
progressive guard removed          CAUGHT
```

One honest gap: the half-pixel chroma siting offset is spec conformance (it is what libjpeg's fancy upsampling does), but none of my fixtures discriminate it — removing it changes no measured output. I kept it as the standard-conformant behaviour rather than claim test coverage I do not have.

## Verification

```
245 -> 252 tests
```

The 3 failures on this branch are pre-existing on `main` (#33, fixed by #39) and untouched here. This PR is independent of #39 and #40 and can merge in any order.

## Deliberately not included

`read_png()` and `load_image()` are duplicated **verbatim across all five modules** — roughly 400 lines of copy-paste, which is why this bug had to be fixed in five places. Consolidating them into `_shared/` is the obvious follow-up, but it is a refactor of core I/O and should not ride along inside a bug fix. Happy to open it separately if you want it.
