### PR TITLE
fix: sponsor donate link + weekly and all-language Trendshift badges

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-custom: ['https://hoainho.github.io/img2threejs-showcase/donate.html']
+custom: ['https://img2threejs.github.io/img2threejs-showcase/donate.html']

--- a/README.md
+++ b/README.md
@@ -14,7 +14,23 @@ Quality-gated, animation-ready, and deliberately token-efficient — reconstruct
 [![Runtime](https://img.shields.io/badge/runtime-Three.js-000000.svg)](https://threejs.org)
 [![Tooling](https://img.shields.io/badge/tooling-Python%203.10%2B%20stdlib-3776ab.svg)](scripts)
 
-<a href="https://trendshift.io/repositories/83608?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-83608" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/83608/daily?language=Python" alt="hoainho%2Fimg2threejs | Trendshift" width="250" height="55"/></a>
+<table align="center">
+  <tr>
+    <td align="center"></td>
+    <td align="center"><sub><b>DAILY</b></sub></td>
+    <td align="center"><sub><b>WEEKLY</b></sub></td>
+  </tr>
+  <tr>
+    <td align="right"><sub><b>Python</b></sub></td>
+    <td><a href="https://trendshift.io/repositories/83608?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-83608" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/83608/daily?language=Python" alt="hoainho%2Fimg2threejs | Trendshift" width="250" height="55"/></a></td>
+    <td><a href="https://trendshift.io/repositories/83608?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-83608" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/83608/weekly?language=Python" alt="img2threejs%2Fimg2threejs | Trendshift" width="250" height="55"/></a></td>
+  </tr>
+  <tr>
+    <td align="right"><sub><b>All languages</b></sub></td>
+    <td><a href="https://trendshift.io/repositories/83608?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-83608" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/83608/daily" alt="img2threejs%2Fimg2threejs | Trendshift" width="250" height="55"/></a></td>
+    <td><a href="https://trendshift.io/repositories/83608?utm_source=trendshift-badge&amp;utm_medium=badge&amp;utm_campaign=badge-trendshift-83608" target="_blank" rel="noopener noreferrer"><img src="https://trendshift.io/api/badge/trendshift/repositories/83608/weekly" alt="img2threejs%2Fimg2threejs | Trendshift" width="250" height="55"/></a></td>
+  </tr>
+</table>
 
 </div>
 


### PR DESCRIPTION
Two small fixes after the move to the `img2threejs` GitHub Pages domain.

### 1. Sponsor link was still on the old domain
`.github/FUNDING.yml` pointed at `hoainho.github.io`, so the GitHub **Sponsor** button led to a dead page. Now `img2threejs.github.io`.

### 2. Trendshift badges: 1 → 4
Only the Python/daily badge was shown. Added the other three rankings (Python weekly, all-language daily, all-language weekly) as a labelled 2×2 grid.

Laid out as a table rather than a single row because 4 × 250px = 1000px overflows the GitHub content column and wraps awkwardly. The row/column labels also disambiguate the badges, which are visually near-identical.

All four badge endpoints verified returning `200 image/svg+xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)