### PR TITLE
docs: split pipeline internals into docs/ARCHITECTURE.md, add sponsor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Quality-gated, animation-ready, and deliberately token-efficient — reconstruct
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Runtime](https://img.shields.io/badge/runtime-Three.js-000000.svg)](https://threejs.org)
 [![Tooling](https://img.shields.io/badge/tooling-Python%203.10%2B%20stdlib-3776ab.svg)](scripts)
+[![Sponsor](https://img.shields.io/badge/Sponsor-Buy%20Me%20A%20Coffee-FFDD00.svg?logo=buymeacoffee&logoColor=black)](https://www.buymeacoffee.com/hoainhowors)
 
 <table align="center">
   <tr>
@@ -80,47 +81,9 @@ It runs under Claude Code, Codex, or OpenCode. It is agent-agnostic: wherever th
 
 ## How it works
 
-The skill runs a staged sculpting pipeline. Scripts gate each stage; the agent's vision is the only thing that can approve a pass.
+A staged sculpting pipeline turns the reference image into a spec, then generates and vision-reviews one build pass at a time — `blockout → structural → form → material → surface → lighting → interaction → optimization` — self-correcting until every identity-defining feature clears its threshold. Deterministic Python scripts handle validation and gating; model tokens are spent only on visual judgment and code.
 
-```mermaid
-flowchart TD
-    A[Reference image] --> B[Probe and suitability gate]
-    B --> C[Pre-Spec Assessment: class, complexity, quality contract]
-    C --> D[Author ObjectSculptSpec: components, materials, sockets]
-    D --> E{Validate and strict-quality}
-    E -- too shallow --> D
-    E -- ok --> F[Locked build passes]
-    F --> G[Generate Three.js factory: current pass only]
-    G --> H[Render in browser and screenshot]
-    H --> I[Package one side-by-side sheet]
-    I --> J{Agent vision review}
-    J -- score below threshold --> K[Self-correct: refine-spec or refine-code]
-    K --> F
-    J -- pass --> L{More passes?}
-    L -- yes --> F
-    L -- no --> M[Animation-ready Three.js model]
-```
-
-### Build passes
-
-The model is sculpted in a fixed order; a pass unlocks only after the previous one is reviewed and accepted:
-
-`blockout → structural-pass → form-refinement → material-pass → surface-pass → lighting-pass → interaction-pass → optimization-pass`
-
-Each pass has its own acceptance criteria. A pass is marked `continue` only with a real render, a comparison sheet, an agent-vision score at or above threshold, and every identity-defining feature at or above its own threshold.
-
-### The gates
-
-- **Suitability** — is the image a viable 3D target at all.
-- **Pre-spec and strict-quality** — blocks code generation until the spec is deep enough for the object's complexity (no single-root spec for a compound object).
-- **Screenshot feedback** — `continue` requires a render plus a comparison sheet plus a passing vision score.
-- **Action-ready** — the model exposes a runtime hierarchy (pivots, sockets, colliders, destruction groups) via `root.userData.sculptRuntime`.
-- **Attachment correctness** — child parts (handles, limbs, tubes) declare how they join their parent, so nothing floats in mid-air.
-- **Material and lighting realism** — independent PBR channels and real lights, never albedo aliased into roughness.
-
-### Self-correction
-
-After every pass the agent chooses exactly one action: `continue`, `refine-spec`, `refine-code`, `request-input`, or `stop`. `refine-spec` fixes a wrong or shallow spec and re-validates; `refine-code` fixes geometry, material, or lighting that does not match a sound spec.
+**→ Full pipeline diagram, gates, self-correction logic, script reference, and the token-efficiency design: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**
 
 ---
 
@@ -178,53 +141,7 @@ python3 forge/stage2_spec/validate_sculpt_spec.py spec.json --strict-quality
 python3 forge/stage3_build/generate_threejs_factory.py spec.json --out src/createObjectModel.ts
 ```
 
----
-
-## Why it is token-efficient
-
-Most image-to-3D agent loops burn tokens by asking the model to do mechanical work — re-reading the whole model every pass, scoring pixels, validating JSON by hand, re-running steps it already did. img2threejs pushes all of that into deterministic scripts and spends model tokens only where judgment is actually required.
-
-- **Scripts enforce, the model judges.** The Python scripts handle validation, gating, spec authoring, PBR extraction, comparison-sheet packaging, and pipeline state. They never score visuals. The model's tokens go to one thing: looking at a single side-by-side sheet and deciding pass or fail.
-- **Zero dependencies, zero install churn.** Every script is pure Python 3.10+ standard library. No pip, no PIL, no numpy, no Playwright. PNG read/write is done with `struct` and `zlib`. Nothing to install means nothing to debug in-context.
-- **Pass-gated generation.** The code generator emits only the currently unlocked build pass. The model does not regenerate or re-read the entire model on every iteration — each step is small and scoped.
-- **Fail fast, before codegen.** A strict-quality gate blocks shallow specs before a single line of Three.js is generated, so you never spend tokens rendering a model that was underspecified from the start.
-- **One image per review.** Each pass is judged from exactly one packaged comparison sheet (reference beside render), not a scattering of screenshots.
-- **Text output, not binaries.** The result is diffable TypeScript plus a JSON spec — small, reviewable, and version-controllable, instead of multi-megabyte mesh files.
-
-The net effect: you still get a faithful 3D model from an image, but the expensive model context is reserved for visual judgment and code, not bookkeeping. For the full per-stage and per-cycle token breakdown, see [docs/TOKEN_COST.md](docs/TOKEN_COST.md).
-
----
-
-## Scripts
-
-| Script | Role |
-| --- | --- |
-| `stage1_intake/probe_image.py` | Image metadata and obvious technical issues (not a visual check). |
-| `stage2_spec/new_pre_spec_assessment.py` | Classify the object, score complexity, emit a quality contract. |
-| `stage2_spec/new_sculpt_spec.py` | Author the ObjectSculptSpec from the assessment. |
-| `stage2_spec/validate_sculpt_spec.py` | Validate the spec; `--strict-quality` blocks shallow specs before codegen. |
-| `stage1_intake/extract_pbr_evidence.py` | Reference-derived PBR evidence per crop (inference, not inverse rendering). |
-| `stage3_build/orchestrate_passes.py` | Locked pass state: status, check, sync. |
-| `stage3_build/generate_threejs_factory.py` | Emit the Three.js `Group` factory for the current unlocked pass. |
-| `stage4_review/make_comparison_sheet.py` | Package one reference-vs-render sheet for review. |
-| `stage4_review/append_review.py` | Record a per-pass review: scores, decision, evidence. |
-| `stage4_review/cs2_review.py` | Evaluate the blocking CS2 knife review contract and versioned scene thresholds. |
-| `_shared/feature_acceptance_policy.py` | Internal helper enforcing per-feature score thresholds. |
-| `stage1_intake/build_detail_inventory.py` | Slice the reference into zones and scaffold a detail inventory. |
-| `stage1_intake/extract_landmarks.py` | Overlay a landmark grid and scaffold an anatomy block for characters. |
-| `stage1_intake/solve_camera_pose.py` | Emit a reference-camera block so the render can be camera-matched. |
-| `stage1_intake/delight_albedo.py` | Approximate a neutral albedo from the photo before texture projection. |
-| `stage3_build/bake_projected_texture.py` | Emit a projection/UV-bake descriptor for photo-texture projection. |
-
-The `grimoire/` folder holds the detailed rubrics each gate applies (validation, pre-spec assessment, procedural patterns, material and lighting realism, attachment correctness, action-ready models, self-correction).
-
----
-
-## What you get
-
-- An `ObjectSculptSpec` JSON: the full component tree, materials, repetition systems, sockets, and a recorded review history for every pass.
-- A TypeScript `createObjectNameModel(spec, options)` factory returning a `THREE.Group`, with `root.userData.sculptRuntime` exposing nodes, sockets, colliders, and destruction groups.
-- A render plus comparison sheets documenting the fidelity at each pass.
+For the script-by-script reference and the full list of output artifacts, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ---
 
@@ -272,6 +189,16 @@ If img2threejs is useful to you, a star helps others find it.
     <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=hoainho/img2threejs&type=timeline&legend=top-left&sealed_token=HhzHOwb32twyQntl75HMLNf5E7hkH9aNTaSpn20ZThsyQC2Rt7fA_Wthz0osSgItW_WUiwA3MUa5-7GXquQCVL1uHLePUOUN9uVoiArBCm-l21DXJ51yVQ" width="600" />
   </picture>
 </a>
+
+---
+
+## Support the project
+
+img2threejs is free and open source. If it saved you time or found its way into your project, consider supporting continued development:
+
+<a href="https://www.buymeacoffee.com/hoainhowors" target="_blank" rel="noopener noreferrer"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-blue.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+
+VietQR / MoMo / PayPal also work — see the [donate page](https://img2threejs.github.io/img2threejs-showcase/donate.html).
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,97 @@
+# Architecture
+
+The full mechanism behind img2threejs: how the staged pipeline runs, why it stays token-efficient, what each script does, and what artifacts you get out the other end. The [README](../README.md) covers the pitch and quick start; this doc covers how it actually works.
+
+---
+
+## Pipeline overview
+
+The skill runs a staged sculpting pipeline. Scripts gate each stage; the agent's vision is the only thing that can approve a pass.
+
+```mermaid
+flowchart TD
+    A[Reference image] --> B[Probe and suitability gate]
+    B --> C[Pre-Spec Assessment: class, complexity, quality contract]
+    C --> D[Author ObjectSculptSpec: components, materials, sockets]
+    D --> E{Validate and strict-quality}
+    E -- too shallow --> D
+    E -- ok --> F[Locked build passes]
+    F --> G[Generate Three.js factory: current pass only]
+    G --> H[Render in browser and screenshot]
+    H --> I[Package one side-by-side sheet]
+    I --> J{Agent vision review}
+    J -- score below threshold --> K[Self-correct: refine-spec or refine-code]
+    K --> F
+    J -- pass --> L{More passes?}
+    L -- yes --> F
+    L -- no --> M[Animation-ready Three.js model]
+```
+
+### Build passes
+
+The model is sculpted in a fixed order; a pass unlocks only after the previous one is reviewed and accepted:
+
+`blockout → structural-pass → form-refinement → material-pass → surface-pass → lighting-pass → interaction-pass → optimization-pass`
+
+Each pass has its own acceptance criteria. A pass is marked `continue` only with a real render, a comparison sheet, an agent-vision score at or above threshold, and every identity-defining feature at or above its own threshold.
+
+### The gates
+
+- **Suitability** — is the image a viable 3D target at all.
+- **Pre-spec and strict-quality** — blocks code generation until the spec is deep enough for the object's complexity (no single-root spec for a compound object).
+- **Screenshot feedback** — `continue` requires a render plus a comparison sheet plus a passing vision score.
+- **Action-ready** — the model exposes a runtime hierarchy (pivots, sockets, colliders, destruction groups) via `root.userData.sculptRuntime`.
+- **Attachment correctness** — child parts (handles, limbs, tubes) declare how they join their parent, so nothing floats in mid-air.
+- **Material and lighting realism** — independent PBR channels and real lights, never albedo aliased into roughness.
+
+### Self-correction
+
+After every pass the agent chooses exactly one action: `continue`, `refine-spec`, `refine-code`, `request-input`, or `stop`. `refine-spec` fixes a wrong or shallow spec and re-validates; `refine-code` fixes geometry, material, or lighting that does not match a sound spec.
+
+---
+
+## Why it is token-efficient
+
+Most image-to-3D agent loops burn tokens by asking the model to do mechanical work — re-reading the whole model every pass, scoring pixels, validating JSON by hand, re-running steps it already did. img2threejs pushes all of that into deterministic scripts and spends model tokens only where judgment is actually required.
+
+- **Scripts enforce, the model judges.** The Python scripts handle validation, gating, spec authoring, PBR extraction, comparison-sheet packaging, and pipeline state. They never score visuals. The model's tokens go to one thing: looking at a single side-by-side sheet and deciding pass or fail.
+- **Zero dependencies, zero install churn.** Every script is pure Python 3.10+ standard library. No pip, no PIL, no numpy, no Playwright. PNG read/write is done with `struct` and `zlib`. Nothing to install means nothing to debug in-context.
+- **Pass-gated generation.** The code generator emits only the currently unlocked build pass. The model does not regenerate or re-read the entire model on every iteration — each step is small and scoped.
+- **Fail fast, before codegen.** A strict-quality gate blocks shallow specs before a single line of Three.js is generated, so you never spend tokens rendering a model that was underspecified from the start.
+- **One image per review.** Each pass is judged from exactly one packaged comparison sheet (reference beside render), not a scattering of screenshots.
+- **Text output, not binaries.** The result is diffable TypeScript plus a JSON spec — small, reviewable, and version-controllable, instead of multi-megabyte mesh files.
+
+The net effect: you still get a faithful 3D model from an image, but the expensive model context is reserved for visual judgment and code, not bookkeeping. For the full per-stage and per-cycle token breakdown, see [TOKEN_COST.md](TOKEN_COST.md).
+
+---
+
+## Scripts
+
+| Script | Role |
+| --- | --- |
+| `stage1_intake/probe_image.py` | Image metadata and obvious technical issues (not a visual check). |
+| `stage2_spec/new_pre_spec_assessment.py` | Classify the object, score complexity, emit a quality contract. |
+| `stage2_spec/new_sculpt_spec.py` | Author the ObjectSculptSpec from the assessment. |
+| `stage2_spec/validate_sculpt_spec.py` | Validate the spec; `--strict-quality` blocks shallow specs before codegen. |
+| `stage1_intake/extract_pbr_evidence.py` | Reference-derived PBR evidence per crop (inference, not inverse rendering). |
+| `stage3_build/orchestrate_passes.py` | Locked pass state: status, check, sync. |
+| `stage3_build/generate_threejs_factory.py` | Emit the Three.js `Group` factory for the current unlocked pass. |
+| `stage4_review/make_comparison_sheet.py` | Package one reference-vs-render sheet for review. |
+| `stage4_review/append_review.py` | Record a per-pass review: scores, decision, evidence. |
+| `stage4_review/cs2_review.py` | Evaluate the blocking CS2 knife review contract and versioned scene thresholds. |
+| `_shared/feature_acceptance_policy.py` | Internal helper enforcing per-feature score thresholds. |
+| `stage1_intake/build_detail_inventory.py` | Slice the reference into zones and scaffold a detail inventory. |
+| `stage1_intake/extract_landmarks.py` | Overlay a landmark grid and scaffold an anatomy block for characters. |
+| `stage1_intake/solve_camera_pose.py` | Emit a reference-camera block so the render can be camera-matched. |
+| `stage1_intake/delight_albedo.py` | Approximate a neutral albedo from the photo before texture projection. |
+| `stage3_build/bake_projected_texture.py` | Emit a projection/UV-bake descriptor for photo-texture projection. |
+
+The `grimoire/` folder holds the detailed rubrics each gate applies (validation, pre-spec assessment, procedural patterns, material and lighting realism, attachment correctness, action-ready models, self-correction).
+
+---
+
+## What you get
+
+- An `ObjectSculptSpec` JSON: the full component tree, materials, repetition systems, sockets, and a recorded review history for every pass.
+- A TypeScript `createObjectNameModel(spec, options)` factory returning a `THREE.Group`, with `root.userData.sculptRuntime` exposing nodes, sockets, colliders, and destruction groups.
+- A render plus comparison sheets documenting the fidelity at each pass.


### PR DESCRIPTION
## Summary
- Split "How it works", "Why it is token-efficient", the scripts table, and "What you get" out of README.md into a new docs/ARCHITECTURE.md, keeping README focused on the pitch, demos, quick start, and roadmap.
- Added a Sponsor badge and a "Support the project" section (Buy Me a Coffee) to README.md.

## Test plan
- [ ] Render README.md and docs/ARCHITECTURE.md on GitHub to confirm links and the mermaid diagram render correctly.