### PR TITLE
fix(stage3): emit the helper an instanced-cluster's baseGeometry needs

### DIFF
--- a/forge/stage3_build/generate_threejs_factory.py
+++ b/forge/stage3_build/generate_threejs_factory.py
@@ -254,6 +254,26 @@ _DEFAULT_CURVE_SWEEP = {
 }
 
 
+def resolve_base_primitive(primitive: str, component: dict[str, Any] | None = None) -> str:
+    """Resolve the primitive whose geometry is actually emitted for a component.
+
+    An instanced-cluster's *geometry* is its base shape (the instancing itself is
+    applied by the repetition-system emitter), so the generated call is the base
+    primitive's, not the cluster's. Everything else resolves to itself.
+
+    Both geometry_for() and the helper-emission gate call this, so the "which
+    primitive do we emit a call for" and "which helper functions do we define"
+    decisions can never disagree.
+    """
+    if primitive != "instanced-cluster":
+        return primitive
+    descriptor = component.get("geometryDescriptor") if isinstance(component, dict) and isinstance(component.get("geometryDescriptor"), dict) else {}
+    base = descriptor.get("baseGeometry") if isinstance(descriptor.get("baseGeometry"), str) else "box"
+    if base in ("instanced-cluster", "") or base not in VALID_PRIMITIVES:
+        base = "box"
+    return base
+
+
 def geometry_for(primitive: str, component: dict[str, Any] | None = None) -> str:
     if primitive == "box":
         return "new THREE.BoxGeometry(1, 1, 1, 12, 12, 12)"
@@ -291,13 +311,7 @@ def geometry_for(primitive: str, component: dict[str, Any] | None = None) -> str
         sweep = descriptor.get("curveSweep") if isinstance(descriptor.get("curveSweep"), dict) else _DEFAULT_CURVE_SWEEP
         return f"buildCurveSweepGeometry({json_literal(sweep)})"
     if primitive == "instanced-cluster":
-        # An instanced cluster's *geometry* is its base shape; the instancing itself is applied
-        # by the repetition-system emitter (THREE.InstancedMesh). Resolve the base primitive from
-        # the descriptor (default box); guard against self-reference so we never recurse.
-        base = descriptor.get("baseGeometry") if isinstance(descriptor.get("baseGeometry"), str) else "box"
-        if base in ("instanced-cluster", "") or base not in VALID_PRIMITIVES:
-            base = "box"
-        return geometry_for(base, component)
+        return geometry_for(resolve_base_primitive(primitive, component), component)
     raise GeometryNotImplementedError(primitive)
 
 
@@ -358,7 +372,10 @@ def generate(spec: dict[str, Any], pass_id: str) -> str:
     # projects commonly build with noUnusedLocals, and an always-emitted
     # buildLatheGeometry/buildTubeGeometry fails that build the moment a spec (or a
     # pass, since blockout only includes macro components) doesn't use them.
-    used_primitives = {str(component.get("primitive")) for component in components}
+    used_primitives = {
+        resolve_base_primitive(str(component.get("primitive")), component)
+        for component in components
+    }
     if "extrude" in used_primitives:
         lines.extend(
             [

--- a/forge/tests/test_pipeline.py
+++ b/forge/tests/test_pipeline.py
@@ -384,6 +384,53 @@ class PipelineTest(unittest.TestCase):
         self.assertEqual(r.returncode, 0, r.stderr)
         self.assertIn("BoxGeometry", out.read_text())
 
+    def test_instanced_cluster_base_geometry_emits_its_helper(self):
+        # Regression: two features that were correct on their own disagreed at their seam.
+        # geometry_for() resolves an instanced-cluster to its baseGeometry and emits that
+        # primitive's call (e.g. buildTubeGeometry), but the helper-emission gate read only
+        # the top-level "primitive" — so "tube" never entered used_primitives and the helper
+        # was never defined. The generated .ts referenced an undefined function and failed
+        # tsc in the consuming project.
+        #
+        # The existing instanced-cluster test only exercises the default box base, which
+        # needs no helper, so it could never catch this.
+        for base, builder in (
+            ("tube", "buildTubeGeometry"),
+            ("lathe", "buildLatheGeometry"),
+            ("extrude", "buildExtrudeGeometry"),
+        ):
+            with self.subTest(base=base):
+                run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
+                spec = json.loads(self.spec.read_text())
+                component = spec["componentTree"][0]
+                component["primitive"] = "instanced-cluster"
+                component["geometryDescriptor"]["baseGeometry"] = base
+                self.spec.write_text(json.dumps(spec))
+                out = self.dir / "createOakModel.ts"
+                r = run("stage3_build/generate_threejs_factory.py", self.spec, "--out", out, "--force")
+                self.assertEqual(r.returncode, 0, r.stderr)
+                ts = out.read_text()
+                self.assertIn(f"{builder}(", ts)
+                self.assertIn(f"function {builder}(", ts,
+                              f"{builder} is called but never defined — undefined function in generated output")
+
+    def test_instanced_cluster_still_omits_unrelated_helpers(self):
+        # The gate exists to keep noUnusedLocals builds passing; resolving the cluster's base
+        # must widen it by exactly one primitive, not disable it.
+        run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
+        spec = json.loads(self.spec.read_text())
+        component = spec["componentTree"][0]
+        component["primitive"] = "instanced-cluster"
+        component["geometryDescriptor"]["baseGeometry"] = "tube"
+        self.spec.write_text(json.dumps(spec))
+        out = self.dir / "createOakModel.ts"
+        r = run("stage3_build/generate_threejs_factory.py", self.spec, "--out", out)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        ts = out.read_text()
+        self.assertIn("function buildTubeGeometry", ts)
+        self.assertNotIn("function buildLatheGeometry", ts)
+        self.assertNotIn("function buildCurveSweepGeometry", ts)
+
     def test_repetition_system_emits_instanced_mesh(self):
         # Repeated parts (teeth/fasteners/spokes) must render as ONE THREE.InstancedMesh
         # (single draw call), not a per-instance Mesh clone loop (real-time perf principle).


### PR DESCRIPTION
Fixes #51.

## The bug

`geometry_for()` resolves an `instanced-cluster` to its `geometryDescriptor.baseGeometry` and emits *that* primitive's call, but the helper-emission gate read only the top-level `component["primitive"]`:

```python
# call site — recurses through the cluster
if primitive == "instanced-cluster":
    base = descriptor.get("baseGeometry") ...
    return geometry_for(base, component)     # -> buildTubeGeometry({...})

# helper gate — never sees the base
used_primitives = {str(component.get("primitive")) for component in components}
if "tube" in used_primitives:                # "tube" is not in there
    # emit function buildTubeGeometry(...)
```

So `primitive: "instanced-cluster"` + `baseGeometry: "tube"` generates a call to `buildTubeGeometry` with no such function in the file, and `tsc` fails in the consuming project.

Affects any `instanced-cluster` whose base is helper-backed: `extrude`, `ground-blade`, `lathe`, `tube`, `curve-sweep`.

## Why it slipped through

Both features are correct on their own; they disagree only at their seam.

`test_instanced_cluster_component_now_implemented` exercises the cluster path but leaves the base at its `box` default — and `box` needs no helper, so it never reaches the gate. `test_generate_factory_omits_unused_geometry_helpers` covers the gate but uses plain, non-clustered primitives. Nothing covered both at once.

## The fix

The cluster-resolution logic lived inside `geometry_for()`, so the gate had no way to see through it. Extracted it into `resolve_base_primitive()`, now called by both — the "which call do we emit" and "which helpers do we define" decisions read from one place and can't drift again.

The gate keeps doing its job: it widens by exactly the resolved base, so `noUnusedLocals` builds still pass. There's a test pinning that.

## Tests

Two added:

- `test_instanced_cluster_base_geometry_emits_its_helper` — parametrised over `tube` / `lathe` / `extrude`, asserts both that the builder is *called* and that it is *defined*. Verified it fails on `main` with `AssertionError: 'function buildTubeGeometry(' not found`.
- `test_instanced_cluster_still_omits_unrelated_helpers` — the gate must widen by one primitive, not switch off.

`python3 forge/tests/test_pipeline.py` → 58 tests, OK (56 before).

## How it surfaced

Rebuilding a Border Collie: the leg/tail feathering is correctly specced as an instanced cluster of tube strands. The generated factory looked fine in isolation, but broke the host Next.js app's production build — which is a rough way to find it, since the failure lands in a different project from the one that generated the file.
