### PR TITLE
fix: validate VLM sample files

### DIFF
--- a/forge/stage4_review/vlm_gate.py
+++ b/forge/stage4_review/vlm_gate.py
@@ -174,10 +174,15 @@ def main(argv: list[str]) -> int:
     try:
         eye = json.loads(args.eye.read_text(encoding="utf-8"))
         sampler = None
+        preloaded = None
         if args.samples:
             preloaded = json.loads(args.samples.read_text(encoding="utf-8"))
+            if not isinstance(preloaded, list) or not preloaded:
+                raise ValueError("--samples must contain a non-empty JSON list")
+            if not all(isinstance(sample, dict) for sample in preloaded):
+                raise ValueError("--samples entries must be JSON objects")
             sampler = lambda i: preloaded[i % len(preloaded)]  # noqa: E731
-        result = gate(eye, sampler, n_samples=len(json.loads(args.samples.read_text())) if args.samples else 3,
+        result = gate(eye, sampler, n_samples=len(preloaded) if preloaded else 3,
                       criteria_min=args.criteria_min, geometry_class=args.geometry_class)
     except Exception as exc:  # noqa: BLE001
         print(f"error: {exc}", file=sys.stderr)

--- a/forge/tests/test_vlm_gate.py
+++ b/forge/tests/test_vlm_gate.py
@@ -3,14 +3,18 @@
 
 from __future__ import annotations
 
+import io
+import json
 import sys
+import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "stage4_review"))
 
-from vlm_gate import aggregate_samples, calibrate, evidence_consistent, gate  # noqa: E402
+from vlm_gate import aggregate_samples, calibrate, evidence_consistent, gate, main  # noqa: E402
 
 
 def const_sampler(scores: dict):
@@ -19,6 +23,22 @@ def const_sampler(scores: dict):
 
 def high_all(claimed="knife"):
     return {"objectness": 0.9, "semantic": 0.88, "structural": 0.86, "specular": 0.85, "claimedClass": claimed}
+
+
+def run_main_with_samples(samples):
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        eye = root / "eye.json"
+        sample_file = root / "samples.json"
+        eye.write_text(json.dumps({
+            "verdict": "pass",
+            "action": "continue",
+            "hardGateFailures": [],
+        }), encoding="utf-8")
+        sample_file.write_text(json.dumps(samples), encoding="utf-8")
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            return main(["--eye", str(eye), "--samples", str(sample_file)]), stderr.getvalue()
 
 
 class VlmGateTest(unittest.TestCase):
@@ -95,6 +115,24 @@ class VlmGateTest(unittest.TestCase):
     def test_aggregate_median(self):
         agg = aggregate_samples([{"objectness": 0.2}, {"objectness": 0.8}, {"objectness": 0.6}])
         self.assertAlmostEqual(agg["criteria"]["objectness"], 0.6, places=5)
+
+    def test_cli_rejects_empty_samples(self):
+        return_code, stderr = run_main_with_samples([])
+
+        self.assertEqual(return_code, 2)
+        self.assertIn("--samples must contain a non-empty JSON list", stderr)
+
+    def test_cli_rejects_non_list_samples(self):
+        return_code, stderr = run_main_with_samples({})
+
+        self.assertEqual(return_code, 2)
+        self.assertIn("--samples must contain a non-empty JSON list", stderr)
+
+    def test_cli_rejects_non_object_sample_entries(self):
+        return_code, stderr = run_main_with_samples([1])
+
+        self.assertEqual(return_code, 2)
+        self.assertIn("--samples entries must be JSON objects", stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #53

Validate `--samples` as a non-empty JSON list of objects and reuse the single UTF-8 read for sampling and sample count. Invalid files now return a useful CLI error instead of division-by-zero or key errors.

Tests cover empty, non-list, and non-object samples.