### PR TITLE
fix: reject incomplete texture patch flags

### DIFF
--- a/forge/stage1_intake/analyze_texture.py
+++ b/forge/stage1_intake/analyze_texture.py
@@ -230,14 +230,14 @@ def main(argv=None) -> int:
     result = analyze(args.image)
 
     if has_patch_target:
-        spec = json.loads(args.spec.read_text())
+        spec = json.loads(args.spec.read_text(encoding="utf-8"))
         mats = [m for m in spec.get("materials", []) if m.get("id") == args.material_id]
         if not mats:
             print(f"material {args.material_id!r} not found in spec", file=sys.stderr)
             return 2
         apply_to_material(mats[0], result)
         if args.in_place:
-            args.spec.write_text(json.dumps(spec, indent=2))
+            args.spec.write_text(json.dumps(spec, indent=2), encoding="utf-8")
             print(f"applied {result['finishClass']} recipe to material {args.material_id!r} in {args.spec.name}")
         else:
             print(json.dumps(mats[0], indent=2))

--- a/forge/stage1_intake/analyze_texture.py
+++ b/forge/stage1_intake/analyze_texture.py
@@ -221,9 +221,15 @@ def main(argv=None) -> int:
     ap.add_argument("--material-id", help="material id to apply the recipe to (with --spec)")
     ap.add_argument("--in-place", action="store_true", help="write the spec back")
     args = ap.parse_args(argv)
+    has_patch_target = args.spec is not None and args.material_id is not None
+    if (args.spec is None) != (args.material_id is None):
+        ap.error("--spec and --material-id must be used together")
+    if args.in_place and not has_patch_target:
+        ap.error("--in-place requires --spec and --material-id")
+
     result = analyze(args.image)
 
-    if args.spec and args.material_id:
+    if has_patch_target:
         spec = json.loads(args.spec.read_text())
         mats = [m for m in spec.get("materials", []) if m.get("id") == args.material_id]
         if not mats:

--- a/forge/tests/test_analyze_texture.py
+++ b/forge/tests/test_analyze_texture.py
@@ -10,6 +10,7 @@ import unittest
 import zlib
 from contextlib import redirect_stderr
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "stage1_intake"))
 from analyze_texture import RECIPES, analyze, main  # noqa: E402
@@ -134,6 +135,35 @@ class AnalyzeTextureTest(unittest.TestCase):
 
         self.assertEqual(raised.exception.code, 2)
         self.assertIn("--in-place requires --spec and --material-id", stderr.getvalue())
+
+    def test_patch_target_uses_utf8_for_spec_io(self):
+        image = self._mk("paint3.png", lambda x, y: (230, 150, 50))
+        spec = self.d / "spec.json"
+        spec.write_text('{"materials": [{"id": "frame"}]}', encoding="utf-8")
+        read_encodings = []
+        write_encodings = []
+        original_read_text = Path.read_text
+        original_write_text = Path.write_text
+
+        def read_text(path, *args, **kwargs):
+            read_encodings.append(kwargs.get("encoding"))
+            return original_read_text(path, *args, **kwargs)
+
+        def write_text(path, data, *args, **kwargs):
+            write_encodings.append(kwargs.get("encoding"))
+            return original_write_text(path, data, *args, **kwargs)
+
+        with patch.object(Path, "read_text", autospec=True, side_effect=read_text):
+            with patch.object(Path, "write_text", autospec=True, side_effect=write_text):
+                main([
+                    str(image),
+                    "--spec", str(spec),
+                    "--material-id", "frame",
+                    "--in-place",
+                ])
+
+        self.assertEqual(read_encodings, ["utf-8"])
+        self.assertEqual(write_encodings, ["utf-8"])
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_analyze_texture.py
+++ b/forge/tests/test_analyze_texture.py
@@ -2,15 +2,17 @@
 """Tests for analyze_texture.py — finish classification + recipe. Pure stdlib, zero token.
 Run: python3 forge/tests/test_analyze_texture.py
 """
+import io
 import struct
 import sys
 import tempfile
 import unittest
 import zlib
+from contextlib import redirect_stderr
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "stage1_intake"))
-from analyze_texture import RECIPES, analyze  # noqa: E402
+from analyze_texture import RECIPES, analyze, main  # noqa: E402
 
 PNG_SIG = b"\x89PNG\r\n\x1a\n"
 
@@ -112,6 +114,26 @@ class AnalyzeTextureTest(unittest.TestCase):
                 "ior", "envMapIntensity", "anisotropy", "procedural"}
         for name, rec in RECIPES.items():
             self.assertTrue(keys <= set(rec), f"{name} missing keys")
+
+    def test_patch_target_requires_spec_and_material_id_together(self):
+        for args in (
+            ["missing.png", "--spec", "spec.json"],
+            ["missing.png", "--material-id", "frame"],
+        ):
+            with self.subTest(args=args), redirect_stderr(io.StringIO()) as stderr:
+                with self.assertRaises(SystemExit) as raised:
+                    main(args)
+
+                self.assertEqual(raised.exception.code, 2)
+                self.assertIn("--spec and --material-id must be used together", stderr.getvalue())
+
+    def test_in_place_requires_patch_target(self):
+        with redirect_stderr(io.StringIO()) as stderr:
+            with self.assertRaises(SystemExit) as raised:
+                main(["missing.png", "--in-place"])
+
+        self.assertEqual(raised.exception.code, 2)
+        self.assertIn("--in-place requires --spec and --material-id", stderr.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #54

Reject incomplete `--spec`/`--material-id` pairs and `--in-place` without a patch target before image analysis. Valid patch behavior stays unchanged.

Tests cover both missing-pair directions and standalone `--in-place`.