### PR TITLE
chore: install as a Claude Code plugin and via a cross-agent installer

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "img2threejs",
+  "description": "Image-to-procedural-Three.js reconstruction for coding agents.",
+  "owner": {
+    "name": "img2threejs",
+    "url": "https://github.com/img2threejs"
+  },
+  "plugins": [
+    {
+      "name": "img2threejs",
+      "source": "./",
+      "description": "Rebuild the object in a reference image as a code-only, procedural, quality-gated, animation-ready Three.js model.",
+      "category": "3d",
+      "tags": [
+        "threejs",
+        "3d",
+        "image-to-3d",
+        "procedural",
+        "webgl"
+      ],
+      "license": "Apache-2.0",
+      "homepage": "https://img2threejs.github.io/img2threejs-showcase/",
+      "repository": "https://github.com/img2threejs/img2threejs"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "img2threejs",
+  "displayName": "img2threejs",
+  "version": "1.5.0",
+  "description": "Rebuild the object in a reference image as a code-only, procedural, quality-gated, animation-ready Three.js model.",
+  "author": {
+    "name": "img2threejs",
+    "url": "https://github.com/img2threejs"
+  },
+  "homepage": "https://img2threejs.github.io/img2threejs-showcase/",
+  "repository": "https://github.com/img2threejs/img2threejs",
+  "license": "Apache-2.0",
+  "keywords": [
+    "threejs",
+    "3d",
+    "image-to-3d",
+    "procedural",
+    "webgl",
+    "game-assets"
+  ],
+  "skills": [
+    "./"
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add SKILL.md README.md CHANGELOG.md
+          git add SKILL.md README.md CHANGELOG.md .claude-plugin/plugin.json
           git commit -m "chore(release): v$VERSION"
           git tag -a "v$VERSION" -m "v$VERSION"
           git push origin HEAD:main --follow-tags

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ explicit, flagged, opt-in mode.
 
 - Scripts are pure Python 3.10+ standard library. No pip dependencies.
 - Run the test suite from the skill root: `python3 forge/tests/test_pipeline.py`.
+- After touching `.claude-plugin/`, check the manifests with `claude plugin validate . --strict`.
 - Validate a spec before generation: `python3 forge/stage2_spec/validate_sculpt_spec.py spec.json --strict-quality`.
 - Keep changes backward compatible: existing object specs must continue to validate.
 - No emojis in source, docs, or generated output.

--- a/README.md
+++ b/README.md
@@ -87,15 +87,39 @@ A staged sculpting pipeline turns the reference image into a spec, then generate
 
 ---
 
+## Install
+
+**Claude Code — as a plugin (recommended).** No clone, and `/plugin update img2threejs` pulls each release:
+
+```
+/plugin marketplace add img2threejs/img2threejs
+/plugin install img2threejs@img2threejs
+```
+
+The same two steps from a shell: `claude plugin marketplace add img2threejs/img2threejs && claude plugin install img2threejs@img2threejs`.
+
+**Codex CLI, OpenCode, and other SKILL.md hosts.** The installer detects which agents you have and installs into each of their skills directories:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/img2threejs/img2threejs/main/install.sh | sh
+```
+
+Re-run it to update. Add `-s -- --uninstall` to remove it, or `-s -- --target <dir>` to choose the directory yourself.
+
+**Manual.** Clone into whichever skills directory your agent reads:
+
+```bash
+git clone https://github.com/img2threejs/img2threejs.git ~/.claude/skills/img2threejs   # Claude Code, OpenCode
+git clone https://github.com/img2threejs/img2threejs.git ~/.codex/skills/img2threejs     # Codex CLI
+```
+
+Nothing to build and no dependencies: the pipeline scripts are Python 3.10+ standard library only.
+
+---
+
 ## Quick start
 
-1. **Install** — place this folder in your skills directory:
-
-   ```bash
-   git clone https://github.com/img2threejs/img2threejs.git ~/.claude/skills/img2threejs
-   ```
-
-2. **Invoke** — in Claude Code, attach or point to an object image and run:
+1. **Invoke** — attach or point to an object image and run:
 
    ```
    /img2threejs Rebuild this object as a Three.js model, keep the proportions, angles, and colours.
@@ -103,7 +127,7 @@ A staged sculpting pipeline turns the reference image into a spec, then generate
 
    That is enough: the skill classifies the subject, runs the detail inventory, and gates every pass on its own.
 
-3. **Follow the pipeline** — the skill validates the image, writes an assessment and spec, generates the factory pass by pass, and shows you a side-by-side comparison at each step until the render matches.
+2. **Follow the pipeline** — the skill validates the image, writes an assessment and spec, generates the factory pass by pass, and shows you a side-by-side comparison at each step until the render matches.
 
 ### Driving it harder
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Quality-gated, animation-ready, and deliberately token-efficient — reconstruct
 [![Version](https://img.shields.io/badge/version-1.5.0-green.svg)](CHANGELOG.md)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 [![Runtime](https://img.shields.io/badge/runtime-Three.js-000000.svg)](https://threejs.org)
+[![Claude Code plugin](https://img.shields.io/badge/Claude%20Code-plugin-d97757.svg)](#install)
 [![Tooling](https://img.shields.io/badge/tooling-Python%203.10%2B%20stdlib-3776ab.svg)](scripts)
 [![Sponsor](https://img.shields.io/badge/Sponsor-Buy%20Me%20A%20Coffee-FFDD00.svg?logo=buymeacoffee&logoColor=black)](https://www.buymeacoffee.com/hoainhowors)
 
@@ -155,7 +156,7 @@ Useful additions depending on the subject:
 - **A saturated anodized or candy finish** — `The coat is candy-coat, not gem-metal. Keep the hue; do not let the environment steal it.`
 - **A cost ceiling** — `Stay at low effort and skip the presentation composer; I only need the evaluation render.`
 
-The scripts run from the skill root and need only Python 3.10+ — nothing to install.
+The scripts run from the skill root — the directory holding `SKILL.md`, which on a plugin install is the plugin's own cache directory — and need only Python 3.10+.
 
 ```bash
 python3 forge/stage1_intake/probe_image.py <image>

--- a/SKILL.md
+++ b/SKILL.md
@@ -59,7 +59,9 @@ hidden sides or guarantee exact geometry — say so instead of faking confidence
 
 ## The Loop (scripts do enforcement; agent vision does judgment)
 
-Run scripts from the skill root (`forge/...`). Pure Python 3.10+ stdlib, no pip installs.
+Run scripts from the skill root — the directory holding this `SKILL.md`, which is
+`${CLAUDE_PLUGIN_ROOT}` on a plugin install. Every `forge/...` and `grimoire/...` path below is
+relative to it. Pure Python 3.10+ stdlib, no pip installs.
 Full flags: `grimoire/scripts.md`. Never let a script *score* visuals — that is the agent's job.
 
 1. **Analyze the image first** (agent vision, before any script): work the layered observation

--- a/forge/tests/test_release_metadata.py
+++ b/forge/tests/test_release_metadata.py
@@ -23,6 +23,12 @@ class ReleaseMetadataTests(unittest.TestCase):
             "[1.4.1]: https://github.com/img2threejs/img2threejs/releases/tag/v1.4.1\n",
             encoding="utf-8",
         )
+        manifest = directory / ".claude-plugin"
+        manifest.mkdir()
+        (manifest / "plugin.json").write_text(
+            '{\n  "name": "img2threejs",\n  "version": "1.4.1",\n  "skills": ["./"]\n}\n',
+            encoding="utf-8",
+        )
         commits = directory / "commits.txt"
         return directory, commits
 
@@ -59,6 +65,9 @@ class ReleaseMetadataTests(unittest.TestCase):
             self.assertEqual(json.loads(result.stdout)["version"], "1.5.0")
             self.assertIn("version: 1.5.0", (project / "SKILL.md").read_text(encoding="utf-8"))
             self.assertIn("version-1.5.0-green.svg", (project / "README.md").read_text(encoding="utf-8"))
+            manifest = (project / ".claude-plugin" / "plugin.json").read_text(encoding="utf-8")
+            self.assertIn('"version": "1.5.0"', manifest)
+            self.assertEqual(json.loads(manifest)["skills"], ["./"])
             changelog = (project / "CHANGELOG.md").read_text(encoding="utf-8")
             self.assertIn("## [1.5.0] — 2026-07-26", changelog)
             self.assertIn("[1.5.0]: https://github.com/img2threejs/img2threejs/compare/v1.4.1...v1.5.0", changelog)

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,179 @@
+#!/bin/sh
+# img2threejs installer for SKILL.md hosts (Claude Code, Codex CLI, OpenCode, and compatible agents).
+#
+#   curl -fsSL https://raw.githubusercontent.com/img2threejs/img2threejs/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/img2threejs/img2threejs/main/install.sh | sh -s -- --uninstall
+#
+# Claude Code users can install as a plugin instead, which needs no script:
+#   /plugin marketplace add img2threejs/img2threejs
+#   /plugin install img2threejs@img2threejs
+
+set -eu
+
+NAME="img2threejs"
+REPO_URL="${IMG2THREEJS_REPO:-https://github.com/img2threejs/img2threejs.git}"
+REF="${IMG2THREEJS_REF:-main}"
+
+TARGETS=""
+MODE="install"
+
+usage() {
+    cat <<'EOF'
+Usage: install.sh [--target DIR]... [--uninstall] [--help]
+
+  --target DIR   Install into DIR/img2threejs instead of the auto-detected
+                 skills directories. Repeatable.
+  --uninstall    Remove previously installed copies.
+  --help         Show this message.
+
+Environment:
+  IMG2THREEJS_REPO   Clone URL (default: the public GitHub repository)
+  IMG2THREEJS_REF    Branch or tag to install (default: main)
+
+Auto-detected skills directories:
+  ~/.claude/skills          Claude Code (also read by OpenCode)
+  ~/.codex/skills           Codex CLI
+  ~/.config/opencode/skills OpenCode, when ~/.claude/skills is not used
+  ~/.agents/skills          Generic agent skills directory
+EOF
+}
+
+log() {
+    printf '%s\n' "$*"
+}
+
+fail() {
+    printf 'error: %s\n' "$*" >&2
+    exit 1
+}
+
+# Space-separated list membership test; skills directories never contain spaces
+# in the paths this script builds.
+contains() {
+    for item in $1; do
+        if [ "$item" = "$2" ]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+add_target() {
+    if ! contains "$TARGETS" "$1"; then
+        TARGETS="$TARGETS $1"
+    fi
+}
+
+detect_targets() {
+    claude_selected=0
+    if [ -d "$HOME/.claude" ]; then
+        add_target "$HOME/.claude/skills"
+        claude_selected=1
+    fi
+    if [ -d "$HOME/.codex" ]; then
+        add_target "$HOME/.codex/skills"
+    fi
+    # OpenCode reads ~/.claude/skills as well, so only add its own directory
+    # when that shared location is not already covered.
+    if [ "$claude_selected" -eq 0 ] && { [ -d "$HOME/.config/opencode" ] || [ -d "$HOME/.opencode" ]; }; then
+        add_target "$HOME/.config/opencode/skills"
+    fi
+    if [ -d "$HOME/.agents" ]; then
+        add_target "$HOME/.agents/skills"
+    fi
+    if [ -z "$TARGETS" ]; then
+        log "No agent directory detected; defaulting to $HOME/.claude/skills."
+        add_target "$HOME/.claude/skills"
+    fi
+}
+
+is_our_checkout() {
+    dest="$1"
+    [ -f "$dest/SKILL.md" ] && [ -d "$dest/forge" ] && [ -d "$dest/grimoire" ]
+}
+
+install_one() {
+    dest="$1/$NAME"
+    if [ -d "$dest/.git" ]; then
+        is_our_checkout "$dest" || fail "$dest is a git checkout of something else; remove it first"
+        git -C "$dest" fetch --depth 1 origin "$REF" >/dev/null 2>&1 ||
+            fail "could not fetch $REF from $REPO_URL"
+        git -C "$dest" checkout --quiet --detach FETCH_HEAD
+        log "updated  $dest"
+        return
+    fi
+    if [ -e "$dest" ]; then
+        fail "$dest already exists and is not a git checkout; remove it first"
+    fi
+    mkdir -p "$1"
+    git clone --quiet --depth 1 --branch "$REF" "$REPO_URL" "$dest" ||
+        fail "could not clone $REPO_URL into $dest"
+    log "installed $dest"
+}
+
+uninstall_one() {
+    dest="$1/$NAME"
+    if [ ! -e "$dest" ]; then
+        return
+    fi
+    is_our_checkout "$dest" || fail "$dest does not look like an img2threejs checkout; not removing it"
+    rm -rf "$dest"
+    log "removed  $dest"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --target)
+            [ $# -ge 2 ] || fail "--target needs a directory"
+            add_target "$2"
+            shift 2
+            ;;
+        --target=*)
+            add_target "${1#--target=}"
+            shift
+            ;;
+        --uninstall)
+            MODE="uninstall"
+            shift
+            ;;
+        --help | -h)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1 (see --help)"
+            ;;
+    esac
+done
+
+command -v git >/dev/null 2>&1 || fail "git is required"
+
+if [ -z "$TARGETS" ]; then
+    detect_targets
+fi
+
+for target in $TARGETS; do
+    if [ "$MODE" = "uninstall" ]; then
+        uninstall_one "$target"
+    else
+        install_one "$target"
+    fi
+done
+
+if [ "$MODE" = "uninstall" ]; then
+    exit 0
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+    python3 -c 'import sys; sys.exit(0 if sys.version_info >= (3, 10) else 1)' ||
+        log "warning: the pipeline scripts need Python 3.10 or newer"
+else
+    log "warning: python3 not found; the pipeline scripts need Python 3.10 or newer"
+fi
+
+cat <<'EOF'
+
+Start a new agent session, then attach an object image and run:
+
+  /img2threejs Rebuild this object as a Three.js model, keep the proportions, angles, and colours.
+EOF

--- a/scripts/release_metadata.py
+++ b/scripts/release_metadata.py
@@ -13,6 +13,7 @@ from typing import Final
 
 VERSION_PATTERN: Final = re.compile(r"^version: (\d+)\.(\d+)\.(\d+)$", re.MULTILINE)
 BADGE_PATTERN: Final = re.compile(r"version-\d+\.\d+\.\d+-green\.svg")
+MANIFEST_VERSION_PATTERN: Final = re.compile(r'"version": "\d+\.\d+\.\d+"')
 HEADING_PATTERN: Final = re.compile(r"^## \[", re.MULTILINE)
 REFERENCE_PATTERN: Final = re.compile(r"^\[", re.MULTILINE)
 BREAKING_PATTERN: Final = re.compile(r"^[a-z]+(?:\([^\n]+\))?!:", re.MULTILINE)
@@ -124,18 +125,24 @@ def apply_release(request: ReleaseRequest) -> ReleasePlan | None:
     skill_path = request.root / "SKILL.md"
     readme_path = request.root / "README.md"
     changelog_path = request.root / "CHANGELOG.md"
+    manifest_path = request.root / ".claude-plugin" / "plugin.json"
     skill_text = skill_path.read_text(encoding="utf-8")
     current = parse_version(skill_text)
     plan = ReleasePlan(current=current, next=current.bump(level), level=level, commits=request.commits)
     updated_skill = replace_once(VERSION_PATTERN, skill_text, f"version: {plan.next}", "SKILL.md")
     readme_text = readme_path.read_text(encoding="utf-8")
     updated_readme = replace_once(BADGE_PATTERN, readme_text, f"version-{plan.next}-green.svg", "README.md")
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    updated_manifest = replace_once(
+        MANIFEST_VERSION_PATTERN, manifest_text, f'"version": "{plan.next}"', ".claude-plugin/plugin.json"
+    )
     changelog_text = changelog_path.read_text(encoding="utf-8")
     updated_changelog = update_changelog(changelog_text, plan, request.release_date, request.repository_url)
     if request.dry_run:
         return plan
     skill_path.write_text(updated_skill, encoding="utf-8")
     readme_path.write_text(updated_readme, encoding="utf-8")
+    manifest_path.write_text(updated_manifest, encoding="utf-8")
     changelog_path.write_text(updated_changelog, encoding="utf-8")
     return plan
 


### PR DESCRIPTION
## Problem

Installing the skill meant one manual clone into one hard-coded directory:

```bash
git clone https://github.com/img2threejs/img2threejs.git ~/.claude/skills/img2threejs
```

That is Claude-Code-shaped, has no update path, and says nothing to Codex CLI or OpenCode users even though the skill already runs under all three.

## What this adds

**Claude Code plugin install.** `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` make the repository its own single-plugin marketplace:

```
/plugin marketplace add img2threejs/img2threejs
/plugin install img2threejs@img2threejs
```

`/plugin update img2threejs` then pulls each release, and `/plugin uninstall` removes it cleanly.

The manifest declares `"skills": ["./"]`, which keeps the repository root as the skill root — no files move, `forge/` and `grimoire/` stay where every doc and script already expects them. That declaration is required rather than cosmetic: root-`SKILL.md` auto-detection only applies when a plugin has no `skills/` subdirectory, and this repo has one holding subject prompt templates (`skills/cs2-knife.md` and friends), which are not skills. Without the explicit path the plugin would load zero skills.

**Cross-agent installer.** `install.sh` covers every other SKILL.md host:

```bash
curl -fsSL https://raw.githubusercontent.com/img2threejs/img2threejs/main/install.sh | sh
```

It detects which agents are actually present and clones or updates the skill into each of `~/.claude/skills`, `~/.codex/skills`, `~/.config/opencode/skills`, and `~/.agents/skills`. OpenCode's own directory is skipped when `~/.claude/skills` is used, because OpenCode reads that location too and would otherwise see the skill twice. Re-running updates in place; `--uninstall` and `--target <dir>` are supported. Removal refuses to delete a directory that does not look like an img2threejs checkout.

**Version sync.** A `version` in `plugin.json` pins the plugin and keys its cache directory, so a stale value would strand users on an old copy. `scripts/release_metadata.py` now bumps it alongside `SKILL.md`, the README badge, and `CHANGELOG.md`, the release workflow stages it, and the existing release test asserts it.

**Skill-root wording.** Under a plugin install the skill lives in the plugin cache, not the working directory, so "run scripts from the skill root" now names that root explicitly (`${CLAUDE_PLUGIN_ROOT}`) in `SKILL.md` and the README. This is what keeps `forge/...` paths resolvable when the session's cwd is some other project.

## Verification

- `claude plugin validate . --strict` passes.
- Installed from a local marketplace: one skill registered, correct version, no component warnings.
- A live session confirms the skill is available, and on invocation resolves the absolute skill root and produces a runnable `python3 <root>/forge/stage1_intake/probe_image.py <image>` command. Running that command against a real PNG returns the expected probe JSON.
- A GitHub-source install clones the full tree, `forge/` and `grimoire/` included, into the versioned plugin cache.
- Codex CLI 0.146.0, end to end: `install.sh --target ~/.codex/skills` cloned this branch over HTTPS, Codex reported the skill as available with its absolute path, then loaded it and ran `python3 ~/.codex/skills/img2threejs/forge/stage1_intake/probe_image.py ref.png` against a real PNG, returning the expected JSON. Uninstall restored the directory to its prior contents.
- `install.sh` is shellcheck-clean; install, re-run/update, and uninstall were each exercised.
- Full suite green: 266 tests.

## Notes

- Committed as `chore:` so the release automation does not bump the minor version, which the roadmap reserves for v1.6, The Environment Update. The plugin publishes as 1.5.0.
- The `/plugin marketplace add img2threejs/img2threejs` shorthand only resolves once `.claude-plugin/marketplace.json` is on `main`, so the README documents it slightly ahead of the merge.
- The existing manual clone still works and is kept in the README for anyone who wants it.
