### PR TITLE
feat: add cross-agent resumable state foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,10 @@ runtime/**/dist/
 runtime/**/.vite/
 
 .cache/spec-search/
+
+# Durable checkpoints are reviewable artifacts; leases and atomic-write remnants are local coordination state.
+.agent-state/items/*/lease.json
+.agent-state/items/*/.*.tmp
 # Demo GIFs/renders in assets/ stay local, but the README's logo must ship with the repo.
 # Note the trailing `*`: git cannot re-include a file whose parent directory is excluded,
 # so `assets/` + `!assets/logo.svg` would silently not work.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ For the script-by-script reference and the full list of output artifacts, see [d
 
 ---
 
+## Cross-agent resume
+
+Use a durable checkpoint when a reconstruction moves between Claude Code, Codex, OpenCode, or a fresh session. The state records only workflow position, artifact hashes, lease ownership, and handoff metadata; it never stores transcripts or credentials.
+
+```bash
+python3 forge/state.py init --item-id 2026-07-29-dragon --primary-reference assets/dragon.png --json
+python3 forge/state.py resume 2026-07-29-dragon --json
+python3 forge/state.py claim 2026-07-29-dragon --actor codex --json
+python3 forge/state.py acknowledge 2026-07-29-dragon 0 --actor codex --json
+python3 forge/state.py preflight 2026-07-29-dragon intake --actor codex --json
+```
+
+After an interrupted side effect, do not rerun it blindly. Use `read` to inspect the operation ID, then run `recover <item-id> --operation-id <id> --actor <actor> --json`. Checkpoints are under `.agent-state/items/<item-id>/`; `lease.json` and atomic-write leftovers stay local, while snapshots and event ledgers are safe to review and commit.
+
+---
+
 ## Roadmap
 
 **Shipped:**

--- a/SKILL.md
+++ b/SKILL.md
@@ -24,15 +24,47 @@ action-ready props, game objects, botanical/mechanical parts, and stylized recon
 ## Core Promise
 
 Sculpt from a photo, in order — never one-shot a mesh:
-1. **Run `python3 forge/next.py <spec>` first.** It reports the current unlocked pass, exact next command, and unmet acceptance criteria.
-2. **Validate** the image is a suitable 3D target (`grimoire/intake/validation_rubric.md`).
-3. **Assess** object class + complexity, then write a `qualityContract` before any code.
-3. **Spec** it: component hierarchy, materials, lighting, pivots, sockets, action anchors.
-4. **Build pass-by-pass** from blockout → structure → form → material → lighting → interaction → optimization.
-5. **Verify** each pass with a screenshot compared against the reference; fail a pass if an identity-defining feature is wrong even when the global score looks fine.
+1. **Run the mandatory `item-reconstruction-intake` skill first.** Do not run
+   `forge/next.py`, choose geometry/topology/UV/material routes, or write an assessment
+   until the intake skill has produced a saved intake record.
+2. **Run `python3 forge/next.py <spec>` only after intake passes.** It reports the current
+   unlocked pass, exact next command, and unmet acceptance criteria.
+3. **Validate** the image is a suitable 3D target (`grimoire/intake/validation_rubric.md`).
+4. **Assess** object class + complexity, then write a `qualityContract` before any code.
+5. **Spec** it: component hierarchy, materials, lighting, pivots, sockets, action anchors.
+6. **Build pass-by-pass** from blockout → structure → form → material → lighting → interaction → optimization.
+7. **Verify** each pass with a screenshot compared against the reference; fail a pass if an identity-defining feature is wrong even when the global score looks fine.
 
 State explicitly when output is approximate/stylized/low-poly. A single image cannot reveal
 hidden sides or guarantee exact geometry — say so instead of faking confidence.
+
+## Mandatory Intake Gate
+
+Before any reconstruction work or pipeline intake, invoke the `item-reconstruction-intake` skill
+and follow it completely. This is a hard dependency, not optional guidance. If the host cannot
+invoke that skill, stop and report the missing dependency. The skill must create or update
+`item-intake.json` (or the project-approved equivalent) with the target/evidence boundary,
+observation labels (`OBSERVED`, `SUPPORTED`, `INFERRED`, `UNKNOWN`, `IMPLEMENTATION`),
+macro-to-micro decomposition, topology/surface routes, quality contract, and open findings.
+
+The next stage is permitted only when the record has a final status of `PASS` or an explicitly
+accepted `REQUEST`/`REFINE` handoff. `BLOCKED`, `STOP`, rejected references, missing required
+views, unavailable required source review, unresolved topology conflicts, and missing intake
+records are terminal for this turn: report the blocker and request the smallest missing input.
+
+For CS2, `cs2-intake.json` is the specialized classification/route manifest and must be linked
+from the general intake record; it does not replace the mandatory intake gate. Preserve the
+intake record and its evidence references through assessment, spec, build, and review.
+
+## Compaction-Safe Resume Gate
+
+Conversation history is disposable. After a fresh agent start, context compaction, provider switch,
+or interruption, the agent MUST treat persisted item state as the only continuity source. The
+first action is `forge/state.py list --status incomplete --json`; after the user selects an item,
+run `forge/state.py resume <itemId> --json` and validate its artifact hashes and next safe action
+before reading old transcripts or touching project files. If state is missing, corrupt, stale, or
+contradictory, stop at `recover`/`request-input`; do not reconstruct context from memory or guess
+the next pass.
 
 ## Transparency and Process Debugging (Critical — from Bowie Knife reconstruction)
 
@@ -62,7 +94,9 @@ hidden sides or guarantee exact geometry — say so instead of faking confidence
 Run scripts from the skill root (`forge/...`). Pure Python 3.10+ stdlib, no pip installs.
 Full flags: `grimoire/scripts.md`. Never let a script *score* visuals — that is the agent's job.
 
-1. **Analyze the image first** (agent vision, before any script): work the layered observation
+0. **Complete the mandatory intake gate first** (see above). No image analysis, script, or
+   domain decision may bypass it; the intake record is the handoff into this loop.
+1. **Analyze the image** (agent vision, after intake): work the layered observation
    protocol in `grimoire/intake/image_analysis.md` — identify/classify, decompose macro→meso→micro,
    map part relationships, name materials in PBR terms, list identity-defining features, and flag
    what the single view hides. Observation before inference; controlled 3D vocabulary; 3D
@@ -157,15 +191,22 @@ Full flags: `grimoire/scripts.md`. Never let a script *score* visuals — that i
    `forge/stage3_build/generate_threejs_factory.py object-sculpt-spec.json --out src/createObjectModel.ts`
    (generator is pass-gated: a future `--pass-id` fails until prior passes are reviewed `continue`).
 7. Render the current pass in a browser/preview, capture a screenshot at a review viewpoint.
-8. Package one side-by-side sheet, then inspect it with agent vision:
+8. **NotebookLM review continuity gate** — when the intake record contains NotebookLM analysis,
+   use the same notebook and source-role registry for review. Upload the settled render as
+   `QA_RENDER` (and the side-by-side result as `QA_COMPARISON`) before asking comparison
+   questions. Ask NotebookLM to compare reference versus render using `OBSERVED / SUPPORTED /
+   INFERRED / UNKNOWN` labels, record citations, contradictions, confidence, and the next action
+   in the intake/review record. If the required notebook or source review is unavailable, return
+   `request-input` or an explicitly documented lower-confidence fallback; never silently skip it.
+9. Package one side-by-side sheet, then inspect it with agent vision:
    `forge/stage4_review/make_comparison_sheet.py --reference <img> --render <shot> --out cmp.png --json`.
-9. Record the review (overall + per-layer + per-feature scores + decision):
+10. Record the review (overall + per-layer + per-feature scores + decision):
     `forge/stage4_review/append_review.py object-sculpt-spec.json --pass-id <pass> --fidelity <0-1> --action <continue|refine-spec|refine-code|request-input|stop> --summary "..." --render-screenshot <shot> --comparison-image cmp.png --ai-vision-score <0-1> --layer-scores-json '{...}' --feature-reviews-json <f.json> --in-place`.
    For the CS2 knife path, also attach the versioned report with
    `--cs2-review-json cs2-review.json --review-scene-json forge/tests/fixtures/knife_review_scene.json`.
    A failed family, painted-region, projection-coverage, critical-detail, or orbit gate blocks
    `continue` even when the global score passes. See `docs/cs2/review-gates.md`.
-10. Sync pipeline state after manual review edits:
+11. Sync pipeline state after manual review edits:
     `forge/stage3_build/orchestrate_passes.py sync object-sculpt-spec.json --in-place`.
 
 ## CS2 image-matched rule

--- a/forge/_state/__init__.py
+++ b/forge/_state/__init__.py
@@ -1,0 +1,3 @@
+from .service import StateService
+
+__all__ = ["StateService"]

--- a/forge/_state/cli.py
+++ b/forge/_state/cli.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .model import EXIT_CODES, JsonObject, StateProblem, error_payload
+from .service import StateService
+
+
+def parser() -> argparse.ArgumentParser:
+    json_option = argparse.ArgumentParser(add_help=False)
+    json_option.add_argument("--json", action="store_true", default=argparse.SUPPRESS)
+    root = argparse.ArgumentParser(add_help=False)
+    root.add_argument("--root", type=Path, default=Path.cwd())
+    command = argparse.ArgumentParser(parents=[root, json_option], description="Portable reconstruction state CLI")
+    subcommands = command.add_subparsers(dest="command", required=True)
+    initialized = subcommands.add_parser("init", parents=[json_option])
+    initialized.add_argument("--item-id", required=True)
+    initialized.add_argument("--primary-reference", required=True)
+    initialized.add_argument("--from-artifacts", action="store_true")
+    listed = subcommands.add_parser("list", parents=[json_option])
+    listed.add_argument("--status")
+    for name in ("read", "validate", "resume"):
+        child = subcommands.add_parser(name, parents=[json_option])
+        child.add_argument("item_id")
+    for name in ("claim", "release"):
+        child = subcommands.add_parser(name, parents=[json_option])
+        child.add_argument("item_id")
+        child.add_argument("--actor", required=True)
+    heartbeat = subcommands.add_parser("heartbeat", parents=[json_option])
+    heartbeat.add_argument("item_id")
+    heartbeat.add_argument("--actor", required=True)
+    heartbeat.add_argument("--lease-token", required=True)
+    acknowledged = subcommands.add_parser("acknowledge", parents=[json_option])
+    acknowledged.add_argument("item_id")
+    acknowledged.add_argument("revision", type=int)
+    acknowledged.add_argument("--actor", required=True)
+    preflight = subcommands.add_parser("preflight", parents=[json_option])
+    preflight.add_argument("item_id")
+    preflight.add_argument("action")
+    preflight.add_argument("--actor", default="anonymous")
+    committed = subcommands.add_parser("commit", parents=[json_option])
+    committed.add_argument("item_id")
+    committed.add_argument("--operation-id", required=True)
+    committed.add_argument("--actor", required=True)
+    committed.add_argument("--next-action", required=True)
+    handoff = subcommands.add_parser("handoff", parents=[json_option])
+    handoff.add_argument("item_id")
+    handoff.add_argument("--actor", required=True)
+    handoff.add_argument("--recipient", required=True)
+    handoff.add_argument("--summary", required=True)
+    recover = subcommands.add_parser("recover", parents=[json_option])
+    recover.add_argument("item_id")
+    recover.add_argument("--operation-id", required=True)
+    recover.add_argument("--actor", required=True)
+    return command
+
+
+def run(arguments: argparse.Namespace) -> JsonObject:
+    service = StateService(arguments.root)
+    match arguments.command:
+        case "init":
+            return service.initialize(arguments.item_id, arguments.primary_reference, arguments.from_artifacts)
+        case "list":
+            return service.list_items()
+        case "read":
+            return service.read(arguments.item_id)
+        case "validate":
+            return service.validate(arguments.item_id)
+        case "resume":
+            return service.resume(arguments.item_id)
+        case "claim":
+            return service.claim(arguments.item_id, arguments.actor)
+        case "heartbeat":
+            return service.heartbeat(arguments.item_id, arguments.actor, arguments.lease_token)
+        case "acknowledge":
+            return service.acknowledge(arguments.item_id, arguments.revision, arguments.actor)
+        case "preflight":
+            return service.preflight(arguments.item_id, arguments.action, arguments.actor)
+        case "commit":
+            return service.commit(arguments.item_id, arguments.operation_id, arguments.actor, arguments.next_action)
+        case "handoff":
+            return service.handoff(arguments.item_id, arguments.actor, arguments.recipient, arguments.summary)
+        case "recover":
+            return service.recover(arguments.item_id, arguments.operation_id, arguments.actor)
+        case "release":
+            return service.release(arguments.item_id, arguments.actor)
+        case unmatched:
+            raise StateProblem("USAGE", f"unsupported command: {unmatched}")
+
+
+def main(argv: list[str]) -> int:
+    arguments = parser().parse_args(argv)
+    try:
+        result = run(arguments)
+    except StateProblem as problem:
+        print(json.dumps(error_payload(problem), ensure_ascii=False) if arguments.json else str(problem))
+        return EXIT_CODES[problem.code]
+    print(json.dumps({"ok": True, **result}, ensure_ascii=False) if arguments.json else result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/forge/_state/model.py
+++ b/forge/_state/model.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, NewType, TypeAlias
+
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+ItemId = NewType("ItemId", str)
+
+SCHEMA_VERSION: Final = "1.0"
+ITEM_ID_PATTERN: Final = re.compile(r"^\d{4}-\d{2}-\d{2}-[a-z0-9]+(?:-[a-z0-9]+)*$")
+EXIT_CODES: Final = {
+    "OK": 0,
+    "USAGE": 2,
+    "STATE_INVALID": 10,
+    "RESUME_REQUIRED": 11,
+    "ARTIFACT_DRIFT": 12,
+    "LEASE_CONFLICT": 13,
+    "NOTEBOOKLM_REVIEW_REQUIRED": 14,
+    "RECOVERY_REQUIRED": 15,
+    "INVALID_TRANSITION": 16,
+    "OPERATION_CONFLICT": 17,
+    "PATH_SECURITY": 18,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class StateProblem(Exception):
+    code: str
+    message: str
+    item_id: str | None = None
+    revision: int | None = None
+    operation_id: str | None = None
+    recovery_command: str | None = None
+
+    def __str__(self) -> str:
+        return self.message
+
+
+def canonical_json(value: JsonValue) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def hash_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def hash_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def parse_item_id(value: str) -> ItemId:
+    normalized = value.strip().lower()
+    if not ITEM_ID_PATTERN.fullmatch(normalized):
+        raise StateProblem("USAGE", "item ID must match yyyy-mm-dd-item-name-slug")
+    return ItemId(normalized)
+
+
+def parse_json_object(text: str, source: str) -> JsonObject:
+    try:
+        value: JsonValue = json.loads(text)
+    except json.JSONDecodeError as error:
+        raise StateProblem("STATE_INVALID", f"invalid JSON in {source}") from error
+    if not isinstance(value, dict):
+        raise StateProblem("STATE_INVALID", f"{source} must contain a JSON object")
+    return value
+
+
+def error_payload(problem: StateProblem) -> JsonObject:
+    recovery: JsonObject = {
+        "command": problem.recovery_command or "",
+        "destructive": False,
+        "requiresInput": False,
+    }
+    return {
+        "ok": False,
+        "code": problem.code,
+        "itemId": problem.item_id,
+        "revision": problem.revision,
+        "operationId": problem.operation_id,
+        "message": problem.message,
+        "recovery": recovery,
+    }

--- a/forge/_state/service.py
+++ b/forge/_state/service.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import secrets
+from pathlib import Path
+
+from .model import ItemId, JsonObject, JsonValue, StateProblem, canonical_json, hash_bytes, hash_file, parse_item_id
+from .store import StateStore, now
+
+
+class StateService:
+    def __init__(self, root: Path) -> None:
+        self.store = StateStore(root)
+
+    def initialize(self, raw_item_id: str, primary_reference: str, from_artifacts: bool = False) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        if self.store.snapshot_path(item_id).exists():
+            raise StateProblem("OPERATION_CONFLICT", "item state already exists", str(item_id))
+        reference = self.store.bound_path(item_id, primary_reference)
+        if not reference.is_file():
+            raise StateProblem("USAGE", "primary reference must be an existing file", str(item_id))
+        relative = str(reference.relative_to(self.store.root))
+        snapshot: JsonObject = {
+            "schemaVersion": "1.0",
+            "itemId": str(item_id),
+            "revision": -1,
+            "phase": "initialized",
+            "nextAction": "intake",
+            "blockers": ["INTAKE_REQUIRED"],
+            "gates": {"intakeAccepted": False, "genericHandoffReady": False, "specializedAdapterEligible": False},
+            "artifacts": [{"path": relative, "role": "primary-reference", "sha256": hash_file(reference), "schemaVersion": ""}],
+            "operations": [],
+            "provenance": {"repositoryRoot": str(self.store.root), "initializedAt": now(), "fromArtifacts": from_artifacts},
+            "ledgerWatermark": {"seq": -1, "hash": ""},
+        }
+        self.store.persist(item_id, snapshot, "initialized", "system")
+        snapshot["revision"] = 0
+        self.store.write_json(self.store.snapshot_path(item_id), snapshot)
+        return self.summary(snapshot)
+
+    def list_items(self) -> JsonObject:
+        items: list[JsonValue] = []
+        if self.store.items_root.exists():
+            for directory in sorted(self.store.items_root.iterdir()):
+                if directory.is_dir():
+                    try:
+                        snapshot = self.store.read_snapshot(parse_item_id(directory.name))
+                    except StateProblem:
+                        continue
+                    items.append(self.summary(snapshot))
+        return {"ok": True, "items": items}
+
+    def read(self, raw_item_id: str) -> JsonObject:
+        snapshot = self.store.read_snapshot(parse_item_id(raw_item_id))
+        return {"ok": True, "snapshot": snapshot}
+
+    def validate(self, raw_item_id: str) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        snapshot = self.store.read_snapshot(item_id)
+        drift = self.store.artifact_drift(item_id, snapshot)
+        if drift:
+            raise StateProblem("ARTIFACT_DRIFT", f"artifact changed: {drift}", str(item_id), self.revision(snapshot))
+        self.store.read_events(item_id)
+        return {"ok": True, **self.summary(snapshot)}
+
+    def resume(self, raw_item_id: str) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        self.validate(str(item_id))
+        snapshot = self.store.read_snapshot(item_id)
+        return {"ok": True, **self.summary(snapshot), "recovery": {"command": f"forge/state.py acknowledge {item_id} {self.revision(snapshot)}", "destructive": False, "requiresInput": False}}
+
+    def claim(self, raw_item_id: str, actor: str) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        snapshot = self.store.read_snapshot(item_id)
+        existing = self.store.read_lease(item_id)
+        if existing and existing.get("actor") != actor:
+            raise StateProblem("LEASE_CONFLICT", "item is leased by another actor", str(item_id), self.revision(snapshot))
+        epoch = existing.get("epoch") if existing else 0
+        if not isinstance(epoch, int):
+            raise StateProblem("STATE_INVALID", "lease epoch must be an integer", str(item_id), self.revision(snapshot))
+        lease: JsonObject = {
+            "actor": actor,
+            "token": secrets.token_hex(16),
+            "epoch": epoch + 1,
+            "createdAt": now(),
+        }
+        self.store.write_lease(item_id, lease)
+        return {"ok": True, "itemId": str(item_id), "revision": self.revision(snapshot), "lease": lease}
+
+    def acknowledge(self, raw_item_id: str, revision: int, actor: str) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        snapshot = self.store.read_snapshot(item_id)
+        if revision != self.revision(snapshot):
+            raise StateProblem("RESUME_REQUIRED", "acknowledgement revision is stale", str(item_id), self.revision(snapshot))
+        lease = self.require_lease(item_id, actor, snapshot)
+        acknowledgement: JsonObject = {"actor": actor, "revision": revision, "epoch": lease["epoch"], "token": lease["token"], "acknowledgedAt": now()}
+        self.store.write_json(self.store.acknowledgement_path(item_id, actor), acknowledgement)
+        return {"ok": True, "itemId": str(item_id), "revision": revision, "actor": actor}
+
+    def heartbeat(self, raw_item_id: str, actor: str, token: str) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        snapshot = self.store.read_snapshot(item_id)
+        lease = self.require_lease(item_id, actor, snapshot)
+        if lease.get("token") != token:
+            raise StateProblem("LEASE_CONFLICT", "lease token is stale", str(item_id), self.revision(snapshot))
+        lease["heartbeatAt"] = now()
+        self.store.write_lease(item_id, lease)
+        return {"ok": True, "itemId": str(item_id), "revision": self.revision(snapshot), "lease": lease}
+
+    def preflight(self, raw_item_id: str, action: str, actor: str) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        snapshot = self.store.read_snapshot(item_id)
+        existing = self.operation_for_action(snapshot, action)
+        if existing:
+            raise StateProblem("OPERATION_CONFLICT", "an operation intent already exists for this action", str(item_id), self.revision(snapshot), self.text(existing, "operationId"))
+        drift = self.store.artifact_drift(item_id, snapshot)
+        if drift:
+            raise StateProblem("ARTIFACT_DRIFT", f"artifact changed: {drift}", str(item_id), self.revision(snapshot))
+        acknowledgement_path = self.store.acknowledgement_path(item_id, actor)
+        if not acknowledgement_path.is_file():
+            raise StateProblem("RESUME_REQUIRED", "resume acknowledgement is missing or stale", str(item_id), self.revision(snapshot), recovery_command=f"forge/state.py resume {item_id}")
+        acknowledgement = self.store.read_json(acknowledgement_path, item_id)
+        lease = self.require_lease(item_id, actor, snapshot)
+        if acknowledgement.get("revision") != self.revision(snapshot) or acknowledgement.get("epoch") != lease.get("epoch"):
+            raise StateProblem("RESUME_REQUIRED", "resume acknowledgement is missing or stale", str(item_id), self.revision(snapshot), recovery_command=f"forge/state.py resume {item_id}")
+        if snapshot.get("nextAction") != action:
+            raise StateProblem("INVALID_TRANSITION", f"action {action!r} is not the next safe action", str(item_id), self.revision(snapshot))
+        operation_id = secrets.token_hex(16)
+        operation: JsonObject = {"operationId": operation_id, "action": action, "status": "planned", "baseRevision": self.revision(snapshot), "actor": actor, "leaseEpoch": lease["epoch"], "inputHash": hash_bytes(canonical_json(snapshot.get("artifacts", [])).encode("utf-8")), "createdAt": now()}
+        operations = snapshot.get("operations")
+        if not isinstance(operations, list):
+            raise StateProblem("STATE_INVALID", "snapshot operations must be an array", str(item_id))
+        operations.append(operation)
+        self.store.persist(item_id, snapshot, "operation-planned", actor, operation_id)
+        return {"ok": True, "itemId": str(item_id), "action": action, "operationId": operation_id, "revision": self.revision(snapshot), "fencingEpoch": lease["epoch"]}
+
+    def commit(self, raw_item_id: str, operation_id: str, actor: str, next_action: str) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        snapshot = self.store.read_snapshot(item_id)
+        self.require_lease(item_id, actor, snapshot)
+        operation = self.operation_by_id(snapshot, operation_id)
+        if operation.get("status") != "planned":
+            raise StateProblem("OPERATION_CONFLICT", "operation intent is unavailable", str(item_id), self.revision(snapshot), operation_id)
+        operation["status"] = "completed"
+        operation["completedAt"] = now()
+        snapshot["phase"] = operation["action"]
+        snapshot["nextAction"] = next_action
+        snapshot["blockers"] = []
+        self.store.persist(item_id, snapshot, "operation-completed", actor, operation_id)
+        return {"ok": True, **self.summary(snapshot), "operationId": operation_id}
+
+    def handoff(self, raw_item_id: str, actor: str, recipient: str, summary: str) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        snapshot = self.store.read_snapshot(item_id)
+        self.require_lease(item_id, actor, snapshot)
+        snapshot["handoff"] = {"handoffId": secrets.token_hex(16), "sender": actor, "recipient": recipient, "summary": summary, "revision": self.revision(snapshot), "createdAt": now()}
+        self.store.persist(item_id, snapshot, "handoff-recorded", actor)
+        return {"ok": True, **self.summary(snapshot), "handoff": snapshot["handoff"]}
+
+    def release(self, raw_item_id: str, actor: str) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        snapshot = self.store.read_snapshot(item_id)
+        self.require_lease(item_id, actor, snapshot)
+        self.store.lease_path(item_id).unlink()
+        return {"ok": True, "itemId": str(item_id), "revision": self.revision(snapshot)}
+
+    def recover(self, raw_item_id: str, operation_id: str, actor: str) -> JsonObject:
+        item_id = parse_item_id(raw_item_id)
+        snapshot = self.store.read_snapshot(item_id)
+        self.require_lease(item_id, actor, snapshot)
+        operation = self.operation_by_id(snapshot, operation_id)
+        if operation.get("status") != "planned":
+            raise StateProblem("RECOVERY_REQUIRED", "only planned operations can be recovered", str(item_id), self.revision(snapshot), operation_id)
+        operation["status"] = "unknown"
+        operation["recoveredAt"] = now()
+        snapshot["nextAction"] = "recover"
+        snapshot["blockers"] = ["RECOVERY_REQUIRED"]
+        self.store.persist(item_id, snapshot, "operation-recovered", actor, operation_id)
+        return {"ok": True, **self.summary(snapshot), "operationId": operation_id}
+
+    def summary(self, snapshot: JsonObject) -> JsonObject:
+        return {"itemId": snapshot["itemId"], "revision": snapshot["revision"], "phase": snapshot["phase"], "nextAction": snapshot["nextAction"], "blockers": snapshot["blockers"], "artifacts": snapshot["artifacts"]}
+
+    def revision(self, snapshot: JsonObject) -> int:
+        revision = snapshot.get("revision")
+        if not isinstance(revision, int):
+            raise StateProblem("STATE_INVALID", "snapshot revision must be an integer")
+        return revision
+
+    def require_lease(self, item_id: ItemId, actor: str, snapshot: JsonObject) -> JsonObject:
+        lease = self.store.read_lease(item_id)
+        if not lease or lease.get("actor") != actor:
+            raise StateProblem("LEASE_CONFLICT", "active lease for actor is required", str(item_id), self.revision(snapshot))
+        return lease
+
+    def operation_for_action(self, snapshot: JsonObject, action: str) -> JsonObject | None:
+        operations = snapshot.get("operations")
+        if not isinstance(operations, list):
+            raise StateProblem("STATE_INVALID", "snapshot operations must be an array")
+        for value in operations:
+            if isinstance(value, dict) and value.get("action") == action and value.get("status") == "planned":
+                return value
+        return None
+
+    def operation_by_id(self, snapshot: JsonObject, operation_id: str) -> JsonObject:
+        operations = snapshot.get("operations")
+        if not isinstance(operations, list):
+            raise StateProblem("STATE_INVALID", "snapshot operations must be an array")
+        for value in operations:
+            if isinstance(value, dict) and value.get("operationId") == operation_id:
+                return value
+        raise StateProblem("OPERATION_CONFLICT", "operation intent does not exist", operation_id=operation_id)
+
+    def text(self, value: JsonObject, key: str) -> str | None:
+        field = value.get(key)
+        return field if isinstance(field, str) else None

--- a/forge/_state/store.py
+++ b/forge/_state/store.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+import secrets
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .model import ItemId, JsonObject, JsonValue, StateProblem, canonical_json, hash_bytes, hash_file, parse_json_object
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class StateStore:
+    def __init__(self, root: Path) -> None:
+        self.root = root.resolve()
+        self.items_root = self.root / ".agent-state" / "items"
+
+    def item_directory(self, item_id: ItemId) -> Path:
+        return self.items_root / str(item_id)
+
+    def snapshot_path(self, item_id: ItemId) -> Path:
+        return self.item_directory(item_id) / "snapshot.json"
+
+    def events_path(self, item_id: ItemId) -> Path:
+        return self.item_directory(item_id) / "events.jsonl"
+
+    def lease_path(self, item_id: ItemId) -> Path:
+        return self.item_directory(item_id) / "lease.json"
+
+    def acknowledgement_path(self, item_id: ItemId, actor: str) -> Path:
+        return self.item_directory(item_id) / "acknowledgements" / f"{actor}.json"
+
+    def bound_path(self, item_id: ItemId, raw_path: str) -> Path:
+        candidate = Path(raw_path).expanduser()
+        resolved = candidate.resolve() if candidate.is_absolute() else (self.root / candidate).resolve()
+        item_root = self.item_directory(item_id).resolve()
+        if not resolved.is_relative_to(self.root) or resolved.is_relative_to(item_root / "lease.json"):
+            raise StateProblem("PATH_SECURITY", "artifact path must remain inside repository", str(item_id))
+        return resolved
+
+    def write_json(self, path: Path, value: JsonObject) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.tmp")
+        encoded = (canonical_json(value) + "\n").encode("utf-8")
+        with temporary.open("wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+
+    def read_json(self, path: Path, item_id: ItemId) -> JsonObject:
+        if not path.is_file():
+            raise StateProblem("STATE_INVALID", f"missing {path.name}", str(item_id))
+        return parse_json_object(path.read_text(encoding="utf-8"), str(path))
+
+    def read_snapshot(self, item_id: ItemId) -> JsonObject:
+        snapshot = self.read_json(self.snapshot_path(item_id), item_id)
+        self.validate_snapshot(snapshot, item_id)
+        return snapshot
+
+    def validate_snapshot(self, snapshot: JsonObject, item_id: ItemId) -> None:
+        if snapshot.get("schemaVersion") != "1.0":
+            raise StateProblem("STATE_INVALID", "unsupported state schema", str(item_id))
+        if snapshot.get("itemId") != str(item_id):
+            raise StateProblem("STATE_INVALID", "snapshot item ID does not match directory", str(item_id))
+        if not isinstance(snapshot.get("revision"), int):
+            raise StateProblem("STATE_INVALID", "snapshot revision must be an integer", str(item_id))
+
+    def append_event(self, item_id: ItemId, event: JsonObject) -> JsonObject:
+        path = self.events_path(item_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing = self.read_events(item_id)
+        event["seq"] = len(existing)
+        event["hash"] = hash_bytes(canonical_json(event).encode("utf-8"))
+        with path.open("ab") as handle:
+            handle.write((canonical_json(event) + "\n").encode("utf-8"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        return event
+
+    def read_events(self, item_id: ItemId) -> list[JsonObject]:
+        path = self.events_path(item_id)
+        if not path.exists():
+            return []
+        events: list[JsonObject] = []
+        for index, line in enumerate(path.read_text(encoding="utf-8").splitlines()):
+            event = parse_json_object(line, f"{path}:{index + 1}")
+            if event.get("seq") != index:
+                raise StateProblem("RECOVERY_REQUIRED", "ledger sequence gap", str(item_id))
+            events.append(event)
+        return events
+
+    def persist(self, item_id: ItemId, snapshot: JsonObject, event_type: str, actor: str, operation_id: str | None = None) -> JsonObject:
+        revision = snapshot.get("revision")
+        if not isinstance(revision, int):
+            raise StateProblem("STATE_INVALID", "snapshot revision must be an integer", str(item_id))
+        snapshot["revision"] = revision + 1
+        event: JsonObject = {
+            "eventId": secrets.token_hex(16),
+            "type": event_type,
+            "itemId": str(item_id),
+            "actor": actor,
+            "operationId": operation_id,
+            "baseRevision": revision,
+            "resultRevision": revision + 1,
+            "timestamp": now(),
+        }
+        written = self.append_event(item_id, event)
+        snapshot["ledgerWatermark"] = {"seq": written["seq"], "hash": written["hash"]}
+        snapshot["updatedAt"] = now()
+        self.write_json(self.snapshot_path(item_id), snapshot)
+        return written
+
+    def artifact_drift(self, item_id: ItemId, snapshot: JsonObject) -> str | None:
+        artifacts = snapshot.get("artifacts")
+        if not isinstance(artifacts, list):
+            raise StateProblem("STATE_INVALID", "snapshot artifacts must be an array", str(item_id))
+        for value in artifacts:
+            if not isinstance(value, dict):
+                raise StateProblem("STATE_INVALID", "artifact reference is invalid", str(item_id))
+            path = value.get("path")
+            expected = value.get("sha256")
+            if not isinstance(path, str) or not isinstance(expected, str):
+                raise StateProblem("STATE_INVALID", "artifact reference is incomplete", str(item_id))
+            resolved = self.bound_path(item_id, path)
+            if not resolved.is_file() or hash_file(resolved) != expected:
+                return path
+        return None
+
+    def read_lease(self, item_id: ItemId) -> JsonObject | None:
+        path = self.lease_path(item_id)
+        return self.read_json(path, item_id) if path.exists() else None
+
+    def write_lease(self, item_id: ItemId, lease: JsonObject) -> None:
+        self.write_json(self.lease_path(item_id), lease)

--- a/forge/state.py
+++ b/forge/state.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from forge._state.cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/forge/tests/test_cross_agent_state.py
+++ b/forge/tests/test_cross_agent_state.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+STATE_CLI = ROOT / "forge" / "state.py"
+ITEM_ID = "2026-07-29-test-dragon"
+
+
+class CrossAgentStateCliTests(unittest.TestCase):
+    def run_state(self, root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(STATE_CLI), "--root", str(root), "--json", *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_resume_acknowledgement_authorizes_one_intake_operation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory)
+            reference = repository / "reference.txt"
+            reference.write_text("reference bytes", encoding="utf-8")
+
+            initialized = self.run_state(
+                repository,
+                "init",
+                "--item-id",
+                ITEM_ID,
+                "--primary-reference",
+                str(reference),
+            )
+            self.assertEqual(initialized.returncode, 0, initialized.stderr)
+            self.assertEqual(json.loads(initialized.stdout)["revision"], 0)
+
+            resumed = self.run_state(repository, "resume", ITEM_ID)
+            self.assertEqual(resumed.returncode, 0, resumed.stderr)
+            self.assertEqual(json.loads(resumed.stdout)["nextAction"], "intake")
+
+            blocked = self.run_state(repository, "preflight", ITEM_ID, "intake")
+            self.assertEqual(blocked.returncode, 11, blocked.stderr)
+            self.assertEqual(json.loads(blocked.stdout)["code"], "RESUME_REQUIRED")
+
+            claimed = self.run_state(repository, "claim", ITEM_ID, "--actor", "codex")
+            self.assertEqual(claimed.returncode, 0, claimed.stderr)
+
+            acknowledged = self.run_state(repository, "acknowledge", ITEM_ID, "0", "--actor", "codex")
+            self.assertEqual(acknowledged.returncode, 0, acknowledged.stderr)
+
+            authorized = self.run_state(repository, "preflight", ITEM_ID, "intake", "--actor", "codex")
+            self.assertEqual(authorized.returncode, 0, authorized.stderr)
+            receipt = json.loads(authorized.stdout)
+            self.assertEqual(receipt["action"], "intake")
+            self.assertTrue(receipt["operationId"])
+
+            replay = self.run_state(repository, "preflight", ITEM_ID, "intake", "--actor", "codex")
+            self.assertEqual(replay.returncode, 17, replay.stderr)
+            self.assertEqual(json.loads(replay.stdout)["code"], "OPERATION_CONFLICT")
+
+    def test_artifact_drift_blocks_preflight_without_mutating_state(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory)
+            reference = repository / "reference.txt"
+            reference.write_text("before", encoding="utf-8")
+            self.assertEqual(
+                self.run_state(repository, "init", "--item-id", ITEM_ID, "--primary-reference", str(reference)).returncode,
+                0,
+            )
+            self.assertEqual(self.run_state(repository, "claim", ITEM_ID, "--actor", "claude").returncode, 0)
+            self.assertEqual(self.run_state(repository, "acknowledge", ITEM_ID, "0", "--actor", "claude").returncode, 0)
+            reference.write_text("after", encoding="utf-8")
+
+            drift = self.run_state(repository, "preflight", ITEM_ID, "intake", "--actor", "claude")
+            self.assertEqual(drift.returncode, 12, drift.stderr)
+            self.assertEqual(json.loads(drift.stdout)["code"], "ARTIFACT_DRIFT")
+
+    def test_commit_invalidates_acknowledgement_and_preserves_handoff(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory)
+            reference = repository / "reference.txt"
+            reference.write_text("reference", encoding="utf-8")
+            self.assertEqual(
+                self.run_state(repository, "init", "--item-id", ITEM_ID, "--primary-reference", str(reference)).returncode,
+                0,
+            )
+            self.assertEqual(self.run_state(repository, "claim", ITEM_ID, "--actor", "claude").returncode, 0)
+            self.assertEqual(self.run_state(repository, "acknowledge", ITEM_ID, "0", "--actor", "claude").returncode, 0)
+            authorized = json.loads(self.run_state(repository, "preflight", ITEM_ID, "intake", "--actor", "claude").stdout)
+            committed = self.run_state(
+                repository,
+                "commit",
+                ITEM_ID,
+                "--operation-id",
+                authorized["operationId"],
+                "--actor",
+                "claude",
+                "--next-action",
+                "assessment",
+            )
+            self.assertEqual(committed.returncode, 0, committed.stderr)
+            self.assertEqual(json.loads(committed.stdout)["nextAction"], "assessment")
+
+            stale = self.run_state(repository, "preflight", ITEM_ID, "assessment", "--actor", "claude")
+            self.assertEqual(stale.returncode, 11, stale.stderr)
+            current_revision = json.loads(self.run_state(repository, "resume", ITEM_ID).stdout)["revision"]
+            self.assertEqual(self.run_state(repository, "acknowledge", ITEM_ID, str(current_revision), "--actor", "claude").returncode, 0)
+            handoff = self.run_state(
+                repository,
+                "handoff",
+                ITEM_ID,
+                "--actor",
+                "claude",
+                "--recipient",
+                "codex",
+                "--summary",
+                "intake accepted",
+            )
+            self.assertEqual(handoff.returncode, 0, handoff.stderr)
+            self.assertEqual(json.loads(handoff.stdout)["handoff"]["recipient"], "codex")
+
+    def test_recover_marks_an_interrupted_operation_unknown(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory)
+            reference = repository / "reference.txt"
+            reference.write_text("reference", encoding="utf-8")
+            self.assertEqual(
+                self.run_state(repository, "init", "--item-id", ITEM_ID, "--primary-reference", str(reference)).returncode,
+                0,
+            )
+            self.assertEqual(self.run_state(repository, "claim", ITEM_ID, "--actor", "codex").returncode, 0)
+            self.assertEqual(self.run_state(repository, "acknowledge", ITEM_ID, "0", "--actor", "codex").returncode, 0)
+            authorized = json.loads(self.run_state(repository, "preflight", ITEM_ID, "intake", "--actor", "codex").stdout)
+
+            recovered = self.run_state(
+                repository,
+                "recover",
+                ITEM_ID,
+                "--operation-id",
+                authorized["operationId"],
+                "--actor",
+                "codex",
+            )
+            self.assertEqual(recovered.returncode, 0, recovered.stderr)
+            snapshot = json.loads(self.run_state(repository, "read", ITEM_ID).stdout)["snapshot"]
+            self.assertEqual(snapshot["operations"][0]["status"], "unknown")
+
+    def test_second_agent_cannot_claim_an_active_item(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory)
+            reference = repository / "reference.txt"
+            reference.write_text("reference", encoding="utf-8")
+            self.assertEqual(
+                self.run_state(repository, "init", "--item-id", ITEM_ID, "--primary-reference", str(reference)).returncode,
+                0,
+            )
+            first = self.run_state(repository, "claim", ITEM_ID, "--actor", "claude")
+            self.assertEqual(first.returncode, 0, first.stderr)
+            lease = json.loads(first.stdout)["lease"]
+            self.assertEqual(
+                self.run_state(
+                    repository,
+                    "heartbeat",
+                    ITEM_ID,
+                    "--actor",
+                    "claude",
+                    "--lease-token",
+                    lease["token"],
+                ).returncode,
+                0,
+            )
+
+            second = self.run_state(repository, "claim", ITEM_ID, "--actor", "codex")
+            self.assertEqual(second.returncode, 13, second.stderr)
+            self.assertEqual(json.loads(second.stdout)["code"], "LEASE_CONFLICT")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openspec/changes/cross-agent-resumable-state/.openspec.yaml
+++ b/openspec/changes/cross-agent-resumable-state/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/cross-agent-resumable-state/design.md
+++ b/openspec/changes/cross-agent-resumable-state/design.md
@@ -1,0 +1,228 @@
+# Design: Cross-Agent Resumable Reconstruction State
+
+## Context
+
+The project already has domain artifacts with their own authority and schemas: intake manifests,
+assessment/spec JSON, sculpt pipeline state, and review history. Agents currently infer the next
+step from those artifacts and their private transcript memory. That is insufficient when a task
+moves between providers or a process exits between side effects and checkpoint writes.
+
+The design adds a thin orchestration layer. It does not replace or copy domain truth.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let any filesystem-capable agent read the same run checkpoint and produce the same safe next
+  action without access to another agent's transcript.
+- Preserve an auditable transition history and recover after crashes, stale writers, and partial
+  writes.
+- Prevent concurrent agents from silently overwriting each other's state.
+- Make intake gating and handoff machine-checkable.
+- Keep state portable, JSON-based, provider-neutral, bounded, and safe to commit to Git.
+
+**Non-Goals:**
+
+- Persisting full conversations, tool output, credentials, or provider sessions.
+- Replacing `cs2-intake.json`, assessment/spec JSON, `reviewHistory`, or other domain artifacts.
+- Providing a distributed database or cross-machine lock service.
+- Making every external side effect exactly-once; unknown external effects require reconciliation.
+
+## Decisions
+
+### 1. Item-scoped storage
+
+Use `.agent-state/items/<itemId>/` with an item ID in the form
+`<yyyy-mm-dd>-<item-name-slug>`, for example `2026-05-01-abx`, with:
+
+- `snapshot.json`: latest materialized orchestration state, committed to Git when durable.
+- `events.jsonl`: append-only transition/recovery ledger, committed with durable transitions.
+- `lease.json`: volatile lease and fencing metadata, ignored by Git.
+- `research/`: redacted, content-addressed research records referenced by hash.
+
+`itemId` is generated once for the reconstruction item and is not tied to an agent, provider,
+branch, or worktree. If the same item needs a separate attempt, use an explicit attempt field or
+an intentional suffix such as `2026-05-01-abx-attempt-02`; do not silently overwrite the prior
+attempt. Agents are recorded only as logical actor and process/lease metadata. The snapshot
+records normalized repository root, optional worktree ID, branch, commit, target source hashes,
+and artifact references. Symlinks resolving outside the repository/item root are rejected.
+
+`git worktree` is optional code isolation and is never the state namespace. Resuming an item from
+another worktree is allowed when the referenced artifacts and commit policy are compatible;
+branch/worktree drift is reported and may require explicit recovery, but it does not create a new
+item automatically.
+
+### 2. Snapshot plus ledger boundary
+
+The snapshot is the fast read model. The ledger is the authoritative history of orchestration
+transitions, not a second domain database. Event records contain typed allow-listed metadata,
+operation IDs, artifact references, and hashes; they never contain raw transcripts or arbitrary
+provider payloads.
+
+Each snapshot stores `ledgerWatermark.seq` and `ledgerWatermark.hash`. A normal commit appends and
+fsyncs the event first, then atomically replaces the snapshot with a temp file and `os.replace`.
+If the ledger is ahead after a crash, replay events after the watermark and rebuild the snapshot.
+If the snapshot claims an event not present in the ledger, quarantine the snapshot and block.
+Only complete newline-delimited JSON events are replayed; a truncated final line is quarantined,
+while a malformed middle event blocks recovery. Duplicate event IDs or sequence gaps block unless
+an explicit recovery event proves the correction. Compaction may remove events only after a
+snapshot watermark and an integrity-checked archive are recorded.
+
+### 3. Concurrency and leases
+
+Every snapshot write uses revision compare-and-swap. A writer first atomically acquires
+`lease.json` with a random lease token and monotonically increasing fencing epoch. Commit requires
+both the expected snapshot revision and current fencing epoch/token. Renewal is conditional on
+the same token. Takeover requires an expired lease plus a new epoch and emits a durable takeover
+event. A late writer fails even if its wall-clock view says the old lease is valid.
+
+The lease is a coordination aid, not proof of progress. Durable state survives lease cleanup.
+Wall-clock timestamps are informational; expiry uses a monotonic local deadline plus a bounded
+clock-skew policy recorded in the lease.
+
+### 4. Operations and idempotent resume
+
+Every side-effecting action has an `operationId` and deterministic idempotency key derived from
+item, action type, input hashes, and intended output paths. Its lifecycle is:
+`planned → started → completed | failed | unknown`.
+
+Completed operations are no-ops when inputs and output hashes still match. Failed operations may
+retry only when their action declares retry-safe behavior. Unknown operations never retry
+automatically; the resume command requests revalidation or explicit recovery. Output references
+include path, role, schema version, and SHA-256 hash.
+
+### 5. Domain reconciliation
+
+Domain artifacts remain authoritative for domain fields. The state layer stores only a reference,
+content hash, schema version, and observed revision. On resume, missing or changed artifacts mark
+dependent operations stale and block the next action until rebuilt or explicitly invalidated.
+The state layer is authoritative only for orchestration transitions and lease/operation metadata.
+
+### 6. NotebookLM review continuity
+
+When the item intake used NotebookLM, every review pass SHALL use the same notebook and preserve
+the intake source-role registry. After the render settles, upload the render as `QA_RENDER` and
+the comparison sheet as `QA_COMPARISON` before asking NotebookLM comparison questions. The review
+record stores the notebook ID, source IDs/roles, prompt or prompt hash, answer/citations,
+contradictions, confidence, and action. QA sources are cleaned up by role after the review while
+origin references and technical sources remain. NotebookLM review unavailability is a
+`request-input` condition unless an explicitly recorded lower-confidence fallback is accepted.
+
+### 7. Portable command contract
+
+Implement a Python stdlib reference CLI at `forge/state.py` with stable JSON output and exit codes:
+`init`, `list`, `read`, `validate`, `claim`, `heartbeat`, `commit`, `handoff`, `resume`,
+`acknowledge`, `preflight`, `recover`, and `release`. `list` enumerates item IDs and their
+resumable status; `resume <itemId>` opens the selected item state and reports its next safe action;
+`acknowledge <itemId> <revision>` records that the current context loaded the persisted handoff;
+`preflight <itemId> <action>` is called by every downstream pipeline command and rejects missing or
+stale acknowledgement. Agents may invoke the CLI or implement the same JSON contract. Provider
+names are opaque metadata, not branching behavior.
+
+### 8. Executable enforcement boundary
+
+`SKILL.md`, `AGENTS.md`, and provider prompts document the workflow but are not authorization
+boundaries. `forge/state.py preflight` is the authorization boundary. `forge/next.py`, intake/spec
+commands, pass orchestration, generation, and review persistence must call it before side effects.
+The gate rejects `RESUME_REQUIRED`, `STATE_INVALID`, `ARTIFACT_DRIFT`, `LEASE_CONFLICT`, or
+`NOTEBOOKLM_REVIEW_REQUIRED` with stable exit codes and JSON output. A successful continuation
+must leave a persisted operation intent and the current item revision.
+
+When intake records NotebookLM provenance, review continuation additionally requires a validated
+NotebookLM review receipt containing the same notebook ID, registered `QA_RENDER` and
+`QA_COMPARISON` source IDs, prompt/answer hashes, citations, confidence, and action. A text claim
+that NotebookLM was used is never sufficient.
+
+The receipt is trusted only when issued by the authenticated NotebookLM adapter or verified by a
+designated signature/MAC verifier. A manually authored JSON file is not evidence of an actual
+NotebookLM interaction. The receipt binds notebook/session ID, source IDs and content hashes,
+QA render/comparison hashes, prompt/answer hashes, response ID, citations, action, confidence,
+and timestamp. Semantic confidence remains a review judgment, not a cryptographic fact.
+
+The enforcement threat model is explicit: canonical persistence commands cannot advance without
+preflight, and direct edits are detected by artifact/hash drift and block the next gated action.
+An actor with unrestricted filesystem/root access can still edit local files; preventing that
+requires a separate trusted service or external authorization boundary and is out of scope.
+
+### 9. Command integration matrix
+
+Every command that persists or mutates data is gated and requires `--item-id` or a state-owned
+manifest that resolves exactly one item. Pure readers/validators are ungated only when they have
+no mutation mode.
+
+| Command family | Mutation examples | Required preflight action | Result/commit |
+| --- | --- | --- | --- |
+| Intake/manifests | `cs2_manifest.py`, admission reports | `intake` | artifact reference + operation result |
+| Assessment/spec | `new_pre_spec_assessment.py`, `new_sculpt_spec.py` | `assessment` / `spec` | output hash + domain reconciliation |
+| Build/generation | `generate_threejs_factory.py`, generated files | `build:<pass>` | registered output hashes |
+| Diagnostics/evidence | `diagnose_render.py --in-place`, texture/detail/camera outputs, comparison sheets | `evidence` | evidence artifact hashes |
+| Review/pipeline | `append_review.py`, `orchestrate_passes.py sync --in-place` | `review` / `sync` | review receipt, reviewHistory reconciliation |
+| NotebookLM | source registration and review receipt | `notebooklm-review` | trusted receipt + QA source roles |
+
+Each gated command executes `preflight → persisted single-use operation intent → side effect →
+commit/reconcile`. The authorization binds item ID, action, base revision, fencing epoch/token,
+input hashes, registered output paths, actor/session, and operation ID. `--force-out-of-order` is
+not a state bypass; if retained it becomes an explicit `reopen-review` recovery transition with
+reason, actor, lease, and durable audit event.
+
+### 10. CLI and error contract
+
+All commands support `--json`; successful JSON goes to stdout and errors go to stderr with the
+same envelope on stdout only when `--json` is requested. Numeric exits are stable:
+
+| Exit | Code | Meaning |
+| --- | --- | --- |
+| 0 | `OK` | success |
+| 2 | `USAGE` | invalid CLI input |
+| 10 | `STATE_INVALID` | malformed/unsupported state |
+| 11 | `RESUME_REQUIRED` | missing/stale acknowledgement |
+| 12 | `ARTIFACT_DRIFT` | bound artifact changed |
+| 13 | `LEASE_CONFLICT` | ownership/fencing conflict |
+| 14 | `NOTEBOOKLM_REVIEW_REQUIRED` | missing/untrusted receipt |
+| 15 | `RECOVERY_REQUIRED` | explicit recovery needed |
+| 16 | `INVALID_TRANSITION` | action not allowed by state |
+| 17 | `OPERATION_CONFLICT` | intent reused/stale |
+| 18 | `PATH_SECURITY` | unsafe or unbound path |
+
+Error JSON is `{ok:false, code, itemId, revision, operationId, message, recovery:{command,
+destructive, requiresInput}}`.
+
+### 11. Safety, migration, and Git
+
+The schema has a major/minor version. Unknown major versions fail closed; unknown fields in the
+same major are preserved. Migrations validate into a backup, atomically promote the new snapshot,
+and retain rollback data. Snapshot, durable events, and redacted research records are tracked by
+Git; leases and transient backups are ignored. Secret/PII protection is an allow-list, normalized
+path policy, and testable rejection of raw prompts, credentials, arbitrary tool payloads, and
+unsafe paths. Hashes are integrity identifiers, not anonymization.
+
+## Risks / Trade-offs
+
+- [Ledger growth] → Compact only at a verified watermark and keep a bounded archive record.
+- [Cross-file crash window] → Use event intent/result lifecycle and reconciliation; do not claim
+  distributed atomicity.
+- [Git merge conflict] → Record branch/worktree identity and require explicit recovery/merge; do
+  not auto-merge divergent run snapshots.
+- [Provider divergence] → Conformance fixtures exercise only the portable CLI/schema.
+- [Sensitive metadata leakage] → Allow-list state fields and run secret/path fixture tests.
+- [Stale lease after clock changes] → Use fencing epochs and conditional commit, not expiry alone.
+
+## Migration Plan
+
+1. Add the schema, validator, and read-only `list`/`resume`/`validate` commands.
+2. Require explicit `state init --from-artifacts --item-id <itemId>` for existing artifacts;
+   never implicitly treat legacy files as initialized state. Ambiguous or drifted artifacts block.
+3. Add the shared preflight library, operation intents, and writer integration matrix entries.
+4. Enable claim/commit integration in intake, pass orchestration, generation, and review.
+5. Add handoff/recovery, trusted NotebookLM adapter receipts, and conformance fixtures.
+6. Roll back by removing integration calls; preserve domain artifacts and leave state artifacts
+   readable. Never downgrade or overwrite a newer major state schema.
+
+## Open Questions
+
+- Durable snapshots, events, and redacted research records are committed by default; volatile
+  leases/backups are ignored.
+- All listed mutation-capable command families are in scope; pure readers remain ungated only
+  when they cannot write through an output option.
+- Same-host writers use an OS/process lock where supported, with CAS and fencing as the portable
+  correctness mechanism; unsupported network filesystems return `LEASE_CONFLICT` or `RECOVERY_REQUIRED`.

--- a/openspec/changes/cross-agent-resumable-state/github-issue-44-body.md
+++ b/openspec/changes/cross-agent-resumable-state/github-issue-44-body.md
@@ -1,0 +1,204 @@
+## Problem
+
+When reconstruction work moves between Claude Code, Codex, OpenCode, or another coding agent,
+progress currently lives in several domain files plus private agent memory and transcripts. The
+next agent cannot reliably know:
+
+- which reconstruction run it is resuming;
+- which intake gates and evidence have passed;
+- which artifacts are authoritative and whether they changed;
+- which operation was interrupted or already completed;
+- who currently owns the work and whether that owner is stale;
+- the exact next safe action or blocker.
+
+As a result, agents can repeat expensive work, resume from the wrong stage, overwrite another
+agent's progress, or continue before the mandatory `item-reconstruction-intake` gate is complete.
+
+## Goal
+
+Create a repository-local, vendor-neutral state and handoff contract that lets any compatible
+agent resume the same reconstruction safely without access to another provider's transcript.
+The state must be portable JSON/JSONL, auditable in Git, recoverable after interruption, and
+strictly separated from domain truth.
+
+## Proposed architecture
+
+Use an item-scoped hybrid store. The item ID is the coordination key, not the agent or worktree:
+
+```text
+.agent-state/
+└── items/<itemId>/
+    ├── snapshot.json       # latest materialized resume view
+    ├── events.jsonl        # append-only workflow transition/recovery ledger
+    ├── lease.json          # volatile lease/fencing metadata; not committed
+    └── research/           # redacted, content-addressed research records
+```
+
+Example item ID: `2026-05-01-abx`.
+
+The ID uses the item creation date plus an item-name slug. If the same item needs another
+attempt, use an explicit attempt field or suffix such as `2026-05-01-abx-attempt-02`; never
+silently overwrite the prior attempt.
+
+### Snapshot responsibility
+
+`snapshot.json` stores orchestration metadata only:
+
+- `schemaVersion`, immutable `itemId`, revision, and ledger watermark;
+- target/source hashes and repository, branch, worktree, and commit provenance;
+- current workflow phase and exact next safe action;
+- blockers and recovery instructions;
+- intake predicates:
+  - `intakeAccepted`;
+  - `genericHandoffReady`;
+  - `specializedAdapterEligible`;
+- references to authoritative domain artifacts, including path, role, SHA-256, schema version,
+  and observed revision;
+- current operation and handoff summaries.
+
+The state file must not duplicate `cs2-intake.json`, assessment/spec JSON, sculpt pipeline state,
+review history, raw transcripts, arbitrary tool output, credentials, or provider-specific session
+data.
+
+### Event ledger responsibility
+
+`events.jsonl` records only durable orchestration events:
+
+- initialization and state transitions;
+- claims, handoffs, acknowledgements, takeovers, and recovery;
+- operation lifecycle: `planned → started → completed | failed | unknown`;
+- artifact invalidation and reconciliation.
+
+Each event includes a unique event ID, monotonic sequence, run ID, actor/process identity,
+operation ID when relevant, base/result revision, timestamp, fencing epoch when relevant, and
+allow-listed artifact references. The ledger is the authoritative history of item orchestration
+transitions, but existing domain artifacts remain authoritative for domain content.
+
+## Concurrency and recovery contract
+
+- Every write uses revision compare-and-swap.
+- A writer acquires an atomic lease with a unique token and fencing epoch.
+- Commit requires both the expected revision and current fencing token.
+- Lease takeover advances the fencing epoch and records a durable takeover event.
+- A late writer is rejected even if it believes its old lease is still valid.
+- The event is durably appended before the snapshot is atomically replaced.
+- If the ledger is ahead after a crash, valid events after the snapshot watermark are replayed.
+- If the snapshot claims an event missing from the ledger, recovery blocks and quarantines it.
+- Truncated final JSONL records are quarantined; malformed middle records block recovery.
+- Unknown external side effects are never retried automatically; they require revalidation or
+  explicit recovery.
+
+## Portable command contract
+
+Implement a Python stdlib reference CLI at `forge/state.py`:
+
+```text
+init       create an item state
+list       list active/incomplete item IDs and their resumable status
+read       print current state
+validate   validate schema, hashes, ledger, and gates
+claim      acquire lease/fencing ownership
+heartbeat  renew lease
+commit     append transition and update snapshot with CAS
+handoff    create or acknowledge a provider-neutral handoff
+resume     report the next safe action and recovery state for one exact item ID
+recover    reconcile stale/interrupted/corrupt state explicitly
+release    release the current lease
+```
+
+Every command must support stable JSON output and stable machine-readable exit codes. Provider
+names are metadata only; Claude, Codex, OpenCode, and a minimal Python client must consume the
+same contract.
+
+## Pipeline integration
+
+Before intake, assessment, spec, build, or review work, the agent must:
+
+1. list or select the item state;
+2. read and validate the item state;
+3. verify referenced artifact hashes;
+4. claim the item before side effects;
+5. record an operation intent;
+6. perform or resume the action idempotently;
+7. record completion, failure, unknown result, or reconciliation;
+8. produce a handoff when another agent should continue.
+
+The state layer must enforce the mandatory `item-reconstruction-intake` gate. Generic intake
+acceptance must not imply CS2 or family-adapter eligibility.
+
+## NotebookLM review continuity
+
+If item intake used NotebookLM, review must invoke the same NotebookLM notebook again. The review
+flow must:
+
+1. wait until the render settles;
+2. register/upload the render as `QA_RENDER`;
+3. register/upload the side-by-side comparison as `QA_COMPARISON`;
+4. ask NotebookLM to compare reference versus render using `OBSERVED / SUPPORTED / INFERRED /
+   UNKNOWN` labels;
+5. persist notebook ID, source IDs/roles, prompt, citations, contradictions, confidence, and
+   next action in the review evidence;
+6. remove only QA-role sources after the review, preserving origin references and technical sources.
+
+If the notebook or required source review is unavailable, review returns `request-input` or an
+explicitly accepted lower-confidence fallback. It must not silently claim a normal NotebookLM
+review.
+
+## Security and Git policy
+
+- Use an allow-listed state schema and repository/item-root path containment.
+- Resolve symlinks and reject paths outside the allowed root.
+- Do not store secrets, PII, raw prompts, raw transcripts, credentials, or arbitrary provider
+  payloads.
+- Hashes are integrity identifiers, not anonymization.
+- Durable snapshots, events, and redacted research records may be committed to Git.
+- Volatile leases and transient backups remain ignored.
+- Branch/worktree/commit divergence requires explicit recovery; Git must not silently merge
+  divergent item state. A Git worktree is optional code isolation, not a state namespace.
+
+## Acceptance criteria
+
+- [ ] A fresh run creates a valid deterministic snapshot and initialization event.
+- [ ] A minimal client can resume work using only the repository state, with no provider transcript.
+- [ ] Claude, Codex, OpenCode, and the minimal client produce equivalent state transitions.
+- [ ] Concurrent claims and stale writes are rejected deterministically.
+- [ ] Lease expiry and takeover are fenced and auditable.
+- [ ] Completed idempotent operations resume as no-ops when outputs still match.
+- [ ] Unknown external effects require explicit revalidation/recovery.
+- [ ] Intake, generic handoff, and specialized adapter eligibility are distinct machine-checkable gates.
+- [ ] Artifact hash drift invalidates dependent work instead of silently continuing.
+- [ ] Snapshot/ledger crash windows, corruption, replay, migration, rollback, and Git worktree
+      divergence are covered by tests.
+- [ ] State rejects secrets, unsafe paths, raw transcripts, and arbitrary provider payloads.
+- [ ] `forge/state.py` exposes the documented commands, JSON output, and exit codes.
+
+## Research and design review
+
+NotebookLM research was completed in notebook
+`140cddad-1e06-40c6-aa7b-eefca053e455` (task
+`1007493b-d1b8-4ae4-ad14-1d2626ae4a98`). It supports checkpoint persistence, atomic writes,
+optimistic concurrency, idempotent resume, and explicit stale-owner handling. Repository-specific
+decisions were then reviewed by two independent architecture and delivery adversarial subagents.
+
+Debate resolution:
+
+- Keep the ledger, but scope it to orchestration transitions and recovery rather than domain data.
+- Keep existing intake/spec/review artifacts as domain authority.
+- Require run identity, artifact hashes, CAS, fencing, operation lifecycle, recovery, migration,
+  allow-listing, and provider-neutral conformance fixtures.
+
+## OpenSpec artifacts
+
+- `openspec/changes/cross-agent-resumable-state/proposal.md`
+- `openspec/changes/cross-agent-resumable-state/design.md`
+- `openspec/changes/cross-agent-resumable-state/specs/cross-agent-resumable-state/spec.md`
+- `openspec/changes/cross-agent-resumable-state/specs/cross-agent-pipeline-integration/spec.md`
+- `openspec/changes/cross-agent-resumable-state/tasks.md`
+
+Validation result: `openspec validate cross-agent-resumable-state --strict` passes.
+
+## Scope boundary
+
+This issue updates the design and contract only. Implementation should follow through the
+OpenSpec apply workflow after maintainer review of the storage root, Git policy, and first
+integration slice.

--- a/openspec/changes/cross-agent-resumable-state/proposal.md
+++ b/openspec/changes/cross-agent-resumable-state/proposal.md
@@ -1,0 +1,70 @@
+# Cross-Agent Resumable Reconstruction State
+
+## Why
+
+The reconstruction pipeline currently stores progress across separate manifests, specs, review
+history, agent transcripts, and implicit agent memory. When work moves between Claude Code,
+Codex, OpenCode, or another compatible agent, the next agent cannot reliably determine the
+authoritative stage, completed evidence, active blocker, or safe next action. This causes loops
+to stop early, repeat completed work, or continue past an intake/review gate.
+
+The project needs a repository-local, vendor-neutral checkpoint and handoff contract that can
+be read and updated by every supported agent, survives process interruption, and remains
+auditable in Git.
+
+## What Changes
+
+- Add a versioned repository-local state contract keyed by a stable item ID such as
+  `2026-05-01-abx`, containing the current workflow state, artifact references, evidence ledger,
+  blocker, next action, and resumability metadata.
+- Use a hybrid persistence model: an atomic latest snapshot for fast resume plus an append-only
+  event ledger for audit and recovery.
+- Define a portable agent identity and handoff record independent of Claude, Codex, OpenCode, or
+  any provider-specific transcript format. Agents are actors on an item, not state namespaces.
+- Enforce optimistic concurrency with a revision/compare-and-swap check and a short-lived lease
+  for active writers; stale leases become recoverable rather than silently overwritten.
+- Make every state transition explicit and gate downstream commands on the persisted state,
+  especially the mandatory `item-reconstruction-intake` result.
+- Define idempotent resume behavior: completed evidence-producing actions are not rerun unless
+  explicitly invalidated, and interrupted actions are resumed or marked unknown.
+- Keep secrets, credentials, raw transcripts, and PII out of the shared state by default; store
+  redacted references and hashes instead.
+- Add migration/versioning rules, validation commands, recovery guidance, and cross-agent
+  contract tests.
+- Treat OpenSpec completion as design readiness only; executable enforcement is complete only
+  after `forge/state.py`, shared writer integration, and black-box rejection tests exist.
+
+## Capabilities
+
+### New Capabilities
+
+- `cross-agent-resumable-state`: Portable checkpoint, handoff, concurrency, resume, validation,
+  and recovery behavior for multi-agent reconstruction work.
+- `cross-agent-pipeline-integration`: State-aware preflight and transition recording across
+  intake, assessment, spec, build, review, and agent-facing instructions.
+- `executable-state-gates`: Command-level preflight, resume acknowledgement, and NotebookLM
+  review-receipt enforcement that cannot be bypassed by forgetting or ignoring skill text.
+
+### Modified Capabilities
+
+- None. The repository has no base capability specs under `openspec/specs/`; integration changes
+  are therefore specified as the second new capability. Existing intake, spec, build, and review
+  artifacts remain authoritative for their own domain data; the new state contract records their
+  linkage and workflow position.
+
+## Impact
+
+- New state schema and validation/persistence code under `forge/`.
+- New repository-local item state artifacts under `.agent-state/items/<itemId>/`.
+- `SKILL.md` and agent-facing workflow instructions gain a mandatory state read/write and
+  handoff protocol.
+- `forge/next.py`, intake, pass orchestration, and review commands gain state-aware preflight
+  and transition recording without duplicating their existing domain schemas.
+- New tests cover atomic writes, schema validation, stale-agent recovery, concurrent update
+  rejection, interrupted-action resume, and interoperability using fixtures representing Claude,
+  Codex, and OpenCode clients.
+- All persistence-capable commands must receive or resolve an unambiguous `--item-id`; read-only
+  commands may remain ungated only when they cannot write through an output flag.
+- NotebookLM research notebook: `140cddad-1e06-40c6-aa7b-eefca053e455`; research task:
+  `1007493b-d1b8-4ae4-ad14-1d2626ae4a98`. Research was used as input to the design and will be
+  preserved with source URLs and confidence notes in the change artifacts.

--- a/openspec/changes/cross-agent-resumable-state/research/notebooklm-summary.md
+++ b/openspec/changes/cross-agent-resumable-state/research/notebooklm-summary.md
@@ -1,0 +1,31 @@
+# NotebookLM Research Record
+
+## Provenance
+
+- Notebook: `140cddad-1e06-40c6-aa7b-eefca053e455`
+- Research task: `1007493b-d1b8-4ae4-ad14-1d2626ae4a98`
+- Research query: portable repository-local state for resumable work across Claude Code, Codex,
+  OpenCode, and other coding agents, including checkpointing, concurrency, leases, provenance,
+  idempotent resume, and Git/OpenSpec compatibility.
+- Sources: ten web sources imported by NotebookLM; source IDs and URLs are preserved in the
+  NotebookLM task output and should be registered by the eventual intake/research implementation.
+
+## Findings used
+
+- `SUPPORTED`: checkpointing persists volatile agent state so a process can resume after failure.
+- `SUPPORTED`: atomic replacement and optimistic concurrency reduce corruption and lost updates.
+- `SUPPORTED`: idempotent resume must distinguish intended, started, completed, failed, and
+  unknown side effects; completed tool effects must not be blindly repeated.
+- `SUPPORTED`: durable event history and a materialized snapshot address different recovery and
+  read-performance needs.
+- `SUPPORTED`: multi-agent writers need explicit ownership, stale-owner recovery, and fencing or
+  equivalent protection against late writes.
+- `IMPLEMENTATION`: this repository should use a hybrid snapshot plus append-only transition
+  ledger, with existing domain artifacts referenced by hash rather than copied into the ledger.
+
+## Qualification
+
+NotebookLM research is supporting evidence, not authority over this repository. Repository
+inspection and adversarial review overruled generic suggestions that would duplicate domain state,
+store raw provider payloads, or assume a live OpenCode-style server. The design below is portable
+filesystem/JSON/JSONL behavior with no provider-specific runtime dependency.

--- a/openspec/changes/cross-agent-resumable-state/specs/cross-agent-pipeline-integration/spec.md
+++ b/openspec/changes/cross-agent-resumable-state/specs/cross-agent-pipeline-integration/spec.md
@@ -1,0 +1,100 @@
+# cross-agent-pipeline-integration Specification
+
+## ADDED Requirements
+
+### Requirement: Mandatory state-aware preflight
+
+The reconstruction workflow SHALL read and validate the selected item state before executing intake,
+assessment, spec, build, or review actions. Missing, corrupt, stale, blocked, or incompatible
+state SHALL stop the action with a stable machine-readable reason and exact recovery/next-input
+guidance.
+
+#### Scenario: Intake has not passed
+
+- **WHEN** a client attempts assessment or spec work without a valid intake record reference and
+  accepted intake predicate
+- **THEN** preflight SHALL block the action and identify the missing intake artifact/status
+
+#### Scenario: State is ready for the next action
+
+- **WHEN** the state and all referenced artifact hashes are valid and the requested action matches
+  the persisted next safe action
+- **THEN** preflight SHALL allow the action and record an operation intent before side effects
+
+### Requirement: Explicit intake predicates
+
+The workflow SHALL distinguish `intakeAccepted`, `genericHandoffReady`, and
+`specializedAdapterEligible`. A generic accepted intake SHALL NOT imply eligibility for a CS2 or
+other family-specific adapter.
+
+#### Scenario: Generic intake has no identity
+
+- **WHEN** the primary reference is technically admitted but identity enrichment is unavailable
+- **THEN** the state SHALL allow generic handoff when its evidence contract passes and SHALL keep
+  specialized adapter eligibility false
+
+#### Scenario: CS2 adapter evidence is incomplete
+
+- **WHEN** a CS2 manifest lacks required authoritative classification or supported family evidence
+- **THEN** adapter work SHALL remain blocked even if generic intake is accepted
+
+### Requirement: Cross-agent resume and handoff
+
+The workflow SHALL expose provider-neutral resume and handoff summaries containing item ID, phase,
+artifact references/hashes, gates, blocker, next safe action, operation status, and state revision.
+Handoff acceptance SHALL be recorded separately from workflow advancement.
+
+#### Scenario: Codex resumes work handed off by Claude
+
+- **WHEN** Codex reads a valid handoff without Claude's transcript
+- **THEN** Codex SHALL identify the same item, phase, next action, evidence, and blocker and SHALL
+  claim the item before writing
+
+#### Scenario: Handoff is acknowledged
+
+- **WHEN** a recipient accepts a handoff at the current revision
+- **THEN** the system SHALL record sender, recipient role, handoff ID, acceptance revision, and
+  acknowledgement without falsely marking the downstream build/review complete
+
+### Requirement: Transition recording around domain artifacts
+
+The workflow SHALL use an intent/result/reconciliation protocol around domain writes because
+ordinary repository files do not provide a cross-file transaction.
+
+#### Scenario: Domain write succeeds before state commit
+
+- **WHEN** a domain artifact is written but the state commit fails
+- **THEN** resume SHALL detect the artifact by hash, record reconciliation evidence, and either
+  complete the matching operation or block for explicit recovery without repeating blindly
+
+### Requirement: NotebookLM continuity review
+
+When the item intake record contains NotebookLM analysis, the workflow SHALL invoke the same
+NotebookLM notebook for review comparison. It SHALL register the settled render as `QA_RENDER`
+and the comparison sheet as `QA_COMPARISON` before asking comparison questions, and SHALL persist
+the review prompt, citations, contradictions, confidence, and action with the review evidence.
+
+#### Scenario: NotebookLM-backed review compares a render
+
+- **WHEN** intake NotebookLM provenance is valid and a settled render and comparison sheet exist
+- **THEN** review SHALL upload/register both QA sources, ask a reference-versus-render comparison
+  using `OBSERVED|SUPPORTED|INFERRED|UNKNOWN` labels, and persist the answer provenance before
+  allowing a pass decision
+
+#### Scenario: NotebookLM review is unavailable
+
+- **WHEN** the intake used NotebookLM but the notebook or required source review cannot be reached
+- **THEN** review SHALL return `request-input` or record an explicitly accepted lower-confidence
+  fallback and SHALL NOT claim a normal NotebookLM-backed review
+
+### Requirement: Provider-neutral conformance
+
+The workflow SHALL define stable JSON output and exit behavior for `list`, `read`, `validate`, `claim`,
+`heartbeat`, `commit`, `handoff`, `resume`, `recover`, and `release`, and SHALL provide fixtures
+that a minimal client and provider adapters can consume equivalently.
+
+#### Scenario: Minimal client consumes a checkpoint
+
+- **WHEN** a client with no vendor transcript invokes `resume 2026-05-01-abx --json`
+- **THEN** it SHALL receive the current phase, safe next action, gates, blocker, revision, and
+  artifact hashes using only the portable contract

--- a/openspec/changes/cross-agent-resumable-state/specs/cross-agent-resumable-state/spec.md
+++ b/openspec/changes/cross-agent-resumable-state/specs/cross-agent-resumable-state/spec.md
@@ -1,0 +1,146 @@
+# cross-agent-resumable-state Specification
+
+## ADDED Requirements
+
+### Requirement: Item-scoped portable snapshot
+
+The system SHALL store a versioned JSON snapshot under `.agent-state/items/<itemId>/`, where
+`itemId` is a stable `<yyyy-mm-dd>-<item-name-slug>` identifier independent of the agent or
+provider. The snapshot SHALL include the stable `itemId`, schema version, workflow phase, next safe action,
+blockers, revision, repository/worktree provenance, artifact references, intake gate predicates,
+and the ledger watermark, without copying domain payloads.
+
+#### Scenario: Fresh item is initialized
+
+- **WHEN** a valid primary reference and item ID such as `2026-05-01-abx` are supplied
+- **THEN** the system SHALL create `.agent-state/items/2026-05-01-abx/` with a deterministic
+  snapshot at revision `0`, no active lease,
+  explicit unresolved gates, and an initialization artifact/event reference
+
+#### Scenario: Snapshot is read by another provider
+
+- **WHEN** a provider-neutral client reads a valid snapshot without access to the original
+  transcript
+- **THEN** it SHALL recover the run identity, authoritative artifact paths/hashes, current phase,
+  blocker, and next safe action
+
+### Requirement: Append-only transition ledger
+
+The system SHALL append typed, newline-delimited JSON events for durable workflow transitions,
+claims, handoffs, operation lifecycle changes, invalidation, takeover, and recovery. Each event
+MUST include an item ID, unique event ID, monotonic sequence, actor/process identity, operation ID
+when applicable, base/result revisions, timestamp, fencing epoch when applicable, and allow-listed
+artifact references.
+
+#### Scenario: Transition is committed
+
+- **WHEN** a writer commits a valid transition against the current revision and fencing token
+- **THEN** the system SHALL durably append one event and advance the snapshot watermark and
+  revision without duplicating domain payloads
+
+#### Scenario: Ledger has a truncated final line
+
+- **WHEN** recovery encounters an incomplete final JSONL record after the last complete event
+- **THEN** the system SHALL quarantine the incomplete record, preserve complete prior events, and
+  return a recoverable status rather than silently treating it as a valid transition
+
+### Requirement: Atomic snapshot and replay recovery
+
+The system SHALL write snapshots through a temporary file and atomic replacement, and SHALL
+reconcile a snapshot against its ledger watermark before allowing resume.
+
+#### Scenario: Ledger is ahead after interruption
+
+- **WHEN** the ledger contains a complete event after the snapshot watermark
+- **THEN** the system SHALL replay valid events in sequence, rebuild the materialized snapshot,
+  and record the recovered watermark before resuming
+
+#### Scenario: Snapshot claims a missing event
+
+- **WHEN** the snapshot watermark references an event absent from the ledger
+- **THEN** the system SHALL quarantine the snapshot and return a blocking recovery error without
+  advancing workflow state
+
+### Requirement: Fenced optimistic concurrency
+
+The system SHALL reject writes whose expected snapshot revision or fencing token is stale. Lease
+acquisition, renewal, takeover, and release SHALL be conditional operations with unique tokens;
+takeover SHALL advance a fencing epoch and produce a durable event.
+
+#### Scenario: Two agents claim the same run
+
+- **WHEN** two agents attempt to claim an unleased run concurrently
+- **THEN** exactly one claim SHALL succeed and the other SHALL receive a machine-readable lease
+  conflict without changing the snapshot
+
+#### Scenario: Old agent writes after takeover
+
+- **WHEN** an expired lease is taken over and the old agent later attempts a commit
+- **THEN** the commit SHALL be rejected because its fencing token/epoch is stale
+
+### Requirement: Idempotent operation lifecycle
+
+The system SHALL record side-effecting operations using deterministic idempotency keys, input
+hashes, intended outputs, lifecycle status `planned|started|completed|failed|unknown`, and output
+hashes where available.
+
+#### Scenario: Completed operation is resumed
+
+- **WHEN** an operation is `completed` and all referenced inputs and outputs still match
+- **THEN** resume SHALL perform a deterministic no-op and return the existing result
+
+#### Scenario: Operation outcome is unknown
+
+- **WHEN** a process ended after an external side effect may have occurred but before completion
+  was recorded
+- **THEN** resume SHALL require revalidation or explicit recovery and SHALL NOT retry automatically
+
+### Requirement: Artifact authority and invalidation
+
+The system SHALL treat intake, assessment, spec, build, and review artifacts as domain authority;
+state SHALL store only normalized path, role, SHA-256 hash, schema version, and observed revision.
+
+#### Scenario: Referenced artifact changes
+
+- **WHEN** an artifact hash differs from the state reference at resume
+- **THEN** dependent operations SHALL become stale and the system SHALL block or require explicit
+  invalidation before continuing
+
+### Requirement: Item listing and explicit resume
+
+The system SHALL enumerate resumable items independently of which agent created or last modified
+them, and SHALL resume only the item selected by its exact `itemId`.
+
+#### Scenario: List interrupted items
+
+- **WHEN** a user requests active or incomplete items
+- **THEN** the system SHALL list item IDs, current phase, status, blocker, last revision, and
+  last update without loading provider transcripts
+
+#### Scenario: Resume a selected item
+
+- **WHEN** the user requests `resume 2026-05-01-abx`
+- **THEN** the system SHALL open only that item directory, validate its snapshot/ledger/artifacts,
+  and return its next safe action or a blocking recovery reason
+
+### Requirement: Safe schema migration
+
+The system SHALL validate schema versions, preserve unknown fields within a supported major
+version, reject unsupported future major versions, and perform migrations through backup and
+atomic promotion with rollback availability.
+
+#### Scenario: Future major version is encountered
+
+- **WHEN** a client reads a snapshot with a higher unsupported major schema version
+- **THEN** it SHALL fail closed with a stable error and SHALL NOT overwrite the snapshot
+
+### Requirement: Allow-listed portable state
+
+The system SHALL reject arbitrary provider payloads, raw transcripts, credentials, unsafe paths,
+and unapproved metadata from shared state. State paths SHALL remain within the repository/item root
+after symlink resolution.
+
+#### Scenario: State payload contains a credential
+
+- **WHEN** a write includes a field or value matching the forbidden secret/credential policy
+- **THEN** validation SHALL reject the write and leave the prior snapshot and ledger unchanged

--- a/openspec/changes/cross-agent-resumable-state/specs/executable-state-gates/spec.md
+++ b/openspec/changes/cross-agent-resumable-state/specs/executable-state-gates/spec.md
@@ -1,0 +1,140 @@
+# executable-state-gates Specification
+
+## ADDED Requirements
+
+### Requirement: Executable preflight authorization
+
+The system SHALL provide `forge/state.py preflight <itemId> <action>` as the command-level
+authorization boundary. Every intake, assessment, spec, build, generation, and review persistence
+command SHALL invoke equivalent preflight before side effects. Skill text, agent prompts, and
+transcript claims SHALL NOT satisfy preflight.
+
+#### Scenario: Agent skips the skill text
+
+- **WHEN** an agent invokes a downstream command without a valid item snapshot and persisted
+  resume acknowledgement
+- **THEN** the command SHALL refuse the action with exit code `RESUME_REQUIRED` and machine-readable
+  JSON identifying the item and required recovery command
+
+#### Scenario: Preflight succeeds
+
+- **WHEN** the item snapshot, acknowledgement revision, artifact hashes, lease, and requested
+  transition are valid
+- **THEN** preflight SHALL return an authorization receipt containing item ID, action, revision,
+  fencing epoch, and operation ID before the command performs side effects
+
+### Requirement: Persisted resume acknowledgement
+
+The system SHALL require an explicit acknowledgement of the exact snapshot revision returned by
+`resume <itemId>`. Acknowledgement SHALL be invalidated when the item revision, artifact hashes,
+lease fencing epoch, or recovery status changes.
+
+#### Scenario: Context compacts after resume
+
+- **WHEN** a new agent runs `resume 2026-05-01-abx --json` and acknowledges revision `17`
+- **THEN** downstream commands SHALL be authorized using the persisted acknowledgement without
+  requiring the old transcript
+
+#### Scenario: Stale acknowledgement is used
+
+- **WHEN** an agent attempts build or review using acknowledgement revision `17` after the item
+  has advanced to revision `18`
+- **THEN** preflight SHALL reject with `RESUME_REQUIRED` and require a new resume/acknowledge pair
+
+### Requirement: Stable machine-readable gate failures
+
+The gate SHALL return stable JSON errors and non-zero exit codes for missing or invalid state,
+including `RESUME_REQUIRED`, `STATE_INVALID`, `ARTIFACT_DRIFT`, `LEASE_CONFLICT`,
+`NOTEBOOKLM_REVIEW_REQUIRED`, and `RECOVERY_REQUIRED`.
+
+#### Scenario: Artifact drift is detected
+
+- **WHEN** a referenced intake, spec, render, or review artifact hash differs from the item snapshot
+- **THEN** preflight SHALL return `ARTIFACT_DRIFT` and SHALL NOT allow the next action
+
+### Requirement: NotebookLM review receipt enforcement
+
+When intake provenance says NotebookLM was used, a review continuation SHALL require a validated
+receipt containing the same notebook ID, source-role registry, `QA_RENDER` source ID,
+`QA_COMPARISON` source ID, prompt/answer hashes, citations, confidence, and review action.
+
+#### Scenario: Review has no NotebookLM receipt
+
+- **WHEN** `append_review.py` requests `continue` for an item whose intake used NotebookLM but no
+  valid review receipt is linked
+- **THEN** the command SHALL reject with `NOTEBOOKLM_REVIEW_REQUIRED`
+
+#### Scenario: Receipt belongs to another notebook
+
+- **WHEN** a review receipt references a different notebook or missing QA source role
+- **THEN** validation SHALL reject the receipt and preserve the prior review state
+
+### Requirement: Gate integration cannot be advisory-only
+
+The canonical pipeline commands SHALL call the executable gate internally and SHALL NOT accept an
+agent-provided flag that disables, bypasses, or downgrades preflight in normal operation.
+
+#### Scenario: Bypass flag is supplied
+
+- **WHEN** a caller supplies an undocumented or explicit bypass option to a gated command
+- **THEN** the command SHALL reject the option and retain the normal gate requirements
+
+### Requirement: Single-use operation authorization
+
+The gate SHALL persist a single-use operation intent before a gated side effect. The intent SHALL
+bind item ID, action, base revision, fencing epoch/token, actor/session identity, input hashes,
+registered output paths, and operation ID. Final commit SHALL consume the intent and reject reuse,
+stale revision, changed fencing, changed paths, or changed inputs.
+
+#### Scenario: Operation intent is replayed
+
+- **WHEN** a caller submits a previously consumed authorization receipt
+- **THEN** commit SHALL return `OPERATION_CONFLICT` and SHALL NOT mutate the snapshot, ledger, or
+  domain artifact
+
+#### Scenario: Another agent advances the item
+
+- **WHEN** another agent advances the item after preflight but before the side effect commits
+- **THEN** the original operation SHALL become unknown/recovery-required and SHALL NOT silently
+  commit against the newer revision
+
+### Requirement: Item and artifact binding
+
+Every gated mutation command SHALL require `--item-id` or a state-owned manifest that resolves one
+item. Preflight SHALL bind all input and output paths to the item, reject unsafe/symlink escapes,
+and record canonical SHA-256 hashes over the declared artifact bytes and metadata.
+
+#### Scenario: Spec belongs to another item
+
+- **WHEN** a command supplies item A with a spec or output registered to item B
+- **THEN** preflight SHALL return `PATH_SECURITY` or `ARTIFACT_DRIFT` and SHALL not write either item
+
+### Requirement: Trusted NotebookLM receipt
+
+The NotebookLM adapter SHALL issue review receipts only after authenticated notebook interaction
+and QA source registration. A receipt SHALL bind notebook/session ID, source IDs and content
+hashes, `QA_RENDER`/`QA_COMPARISON` hashes, prompt/answer hashes, response ID, citations,
+confidence, action, and timestamp. A manually authored receipt SHALL NOT satisfy the review gate.
+
+#### Scenario: Adapter receipt is valid
+
+- **WHEN** the designated authenticated adapter issues a receipt matching the intake notebook and
+  the current render/comparison hashes
+- **THEN** review preflight SHALL accept the receipt and bind it to the operation
+
+#### Scenario: Receipt is manually fabricated
+
+- **WHEN** a local JSON file contains plausible NotebookLM fields but lacks adapter verification
+- **THEN** review SHALL return `NOTEBOOKLM_REVIEW_REQUIRED` and SHALL preserve prior state
+
+### Requirement: Stable command error contract
+
+The CLI SHALL use numeric exits `0` success, `2` usage, `10` state invalid, `11` resume required,
+`12` artifact drift, `13` lease conflict, `14` NotebookLM review required, `15` recovery required,
+`16` invalid transition, `17` operation conflict, and `18` path/security violation. With `--json`,
+errors SHALL use `{ok:false,code,itemId,revision,operationId,message,recovery}`.
+
+#### Scenario: Missing resume acknowledgement
+
+- **WHEN** a gated command is called with `--json` without a current acknowledgement
+- **THEN** it SHALL exit `11`, emit `RESUME_REQUIRED`, and include an idempotent recovery command

--- a/openspec/changes/cross-agent-resumable-state/tasks.md
+++ b/openspec/changes/cross-agent-resumable-state/tasks.md
@@ -1,0 +1,42 @@
+## 1. Contract and fixtures
+
+- [ ] 1.1 Define the versioned item snapshot, event, lease, operation, artifact-reference, handoff, recovery, and error schemas from the two capability specs.
+- [ ] 1.2 Define the transition matrix, intake predicates, forbidden transitions, invalidation causes, and recovery decision table.
+- [ ] 1.2a Define item ID normalization/collision rules, artifact hashing rules, numeric exit codes, JSON envelopes, and the complete writer integration matrix.
+- [ ] 1.3 Add provider-neutral fixtures for fresh, intake-blocked, generic-ready, specialized-ready, handoff, conflict, stale lease, interrupted operation, and recovery states.
+- [ ] 1.4 Record the redacted NotebookLM research provenance and source-role registry without copying raw provider payloads into shared state.
+
+## 2. Persistence and concurrency
+
+- [ ] 2.1 Implement dedicated state persistence with canonical JSON, atomic snapshot replacement, durable JSONL append, watermarking, and validation.
+- [ ] 2.2 Implement sequence/order checks, duplicate detection, truncated-final-line quarantine, malformed-middle-event blocking, replay, rebuild, compaction, and archive verification.
+- [ ] 2.3 Implement revision compare-and-swap and lease acquisition, renewal, release, takeover, fencing epoch, and stale-writer rejection.
+- [ ] 2.4 Enforce repository/item-root containment, symlink policy, allow-listed fields, redaction, secret/PII rejection, and Git tracking/ignore policy.
+
+## 3. Operations and CLI
+
+- [ ] 3.1 Implement `forge/state.py init|list|read|validate|claim|heartbeat|commit|handoff|resume|recover|release` with stable JSON output and exit codes; `list` enumerates items and `resume <itemId>` selects exactly one item.
+- [ ] 3.1a Add `forge/state.py acknowledge` and `preflight`, including stable gate error codes and authorization receipts.
+- [ ] 3.1b Implement `state init --from-artifacts --item-id` as the only legacy initialization path; reject implicit legacy state.
+- [ ] 3.2 Implement operation idempotency keys, input/output hash verification, lifecycle transitions, no-op resume, unknown-side-effect blocking, and explicit recovery.
+- [ ] 3.2a Persist single-use operation intents and bind final commit to operation ID, revision, fencing token, actor/session, input hashes, output paths, and output hashes.
+- [ ] 3.3 Implement schema migration, backup, atomic promotion, rollback, future-major refusal, unknown-field preservation, and compatibility checks.
+
+## 4. Pipeline integration
+
+- [ ] 4.1 Update `SKILL.md` to require state read, claim, operation intent, result/reconciliation, and handoff recording across agent providers.
+- [ ] 4.2 Add state-aware preflight and transition recording to intake and generic/CS2 handoff paths without duplicating domain payloads.
+- [ ] 4.3 Integrate `forge/next.py` and pass orchestration with persisted phase/next-action checks while retaining domain artifacts as authority.
+- [ ] 4.4 Integrate review/evidence completion and recovery boundaries, including browser/NotebookLM side-effect operations.
+- [ ] 4.5 Enforce NotebookLM review continuity when intake used NotebookLM; register `QA_RENDER` and `QA_COMPARISON`, persist citations/confidence/action, and clean up only QA-role sources after review.
+- [ ] 4.6 Integrate executable preflight into intake, `forge/next.py`, pass checks, generation, and review persistence; no normal bypass flag is permitted.
+- [ ] 4.7 Validate NotebookLM review receipts against intake notebook/source provenance before allowing `continue`.
+- [ ] 4.8 Integrate every mutation-capable writer in the command matrix; classify pure readers and reject mutation through un-gated output flags.
+
+## 5. Verification and handoff
+
+- [ ] 5.1 Add unit and fault-injection tests for atomic writes, replay, torn files, divergence, CAS, leases, fencing, migration, and secret rejection.
+- [ ] 5.1a Add black-box no-mutation tests for every gate error, stable numeric exit/JSON contracts, stale/replayed operation intents, and item/artifact binding.
+- [ ] 5.2 Add black-box conformance tests using the same fixtures for a minimal Python client and Claude/Codex/OpenCode-shaped adapters.
+- [ ] 5.3 Test multiple agents sharing one item, optional Git worktrees, branch/commit drift, missing artifacts, changed artifact hashes, duplicate events, and explicit recovery.
+- [ ] 5.4 Update README and workflow documentation with fresh/resume/handoff/recover examples and exact apply/rollback behavior.


### PR DESCRIPTION
# Cross-Agent Resumable Reconstruction State

## Why

The reconstruction pipeline currently stores progress across separate manifests, specs, review
history, agent transcripts, and implicit agent memory. When work moves between Claude Code,
Codex, OpenCode, or another compatible agent, the next agent cannot reliably determine the
authoritative stage, completed evidence, active blocker, or safe next action. This causes loops
to stop early, repeat completed work, or continue past an intake/review gate.

The project needs a repository-local, vendor-neutral checkpoint and handoff contract that can
be read and updated by every supported agent, survives process interruption, and remains
auditable in Git.

## What Changes

- Add a versioned repository-local state contract keyed by a stable item ID such as
  `2026-05-01-abx`, containing the current workflow state, artifact references, evidence ledger,
  blocker, next action, and resumability metadata.
- Use a hybrid persistence model: an atomic latest snapshot for fast resume plus an append-only
  event ledger for audit and recovery.
- Define a portable agent identity and handoff record independent of Claude, Codex, OpenCode, or
  any provider-specific transcript format. Agents are actors on an item, not state namespaces.
- Enforce optimistic concurrency with a revision/compare-and-swap check and a short-lived lease
  for active writers; stale leases become recoverable rather than silently overwritten.
- Make every state transition explicit and gate downstream commands on the persisted state,
  especially the mandatory `item-reconstruction-intake` result.
- Define idempotent resume behavior: completed evidence-producing actions are not rerun unless
  explicitly invalidated, and interrupted actions are resumed or marked unknown.
- Keep secrets, credentials, raw transcripts, and PII out of the shared state by default; store
  redacted references and hashes instead.
- Add migration/versioning rules, validation commands, recovery guidance, and cross-agent
  contract tests.
- Treat OpenSpec completion as design readiness only; executable enforcement is complete only
  after `forge/state.py`, shared writer integration, and black-box rejection tests exist.

## Capabilities

### New Capabilities

- `cross-agent-resumable-state`: Portable checkpoint, handoff, concurrency, resume, validation,
  and recovery behavior for multi-agent reconstruction work.
- `cross-agent-pipeline-integration`: State-aware preflight and transition recording across
  intake, assessment, spec, build, review, and agent-facing instructions.
- `executable-state-gates`: Command-level preflight, resume acknowledgement, and NotebookLM
  review-receipt enforcement that cannot be bypassed by forgetting or ignoring skill text.

### Modified Capabilities

- None. The repository has no base capability specs under `openspec/specs/`; integration changes
  are therefore specified as the second new capability. Existing intake, spec, build, and review
  artifacts remain authoritative for their own domain data; the new state contract records their
  linkage and workflow position.

## Impact

- New state schema and validation/persistence code under `forge/`.
- New repository-local item state artifacts under `.agent-state/items/<itemId>/`.
- `SKILL.md` and agent-facing workflow instructions gain a mandatory state read/write and
  handoff protocol.
- `forge/next.py`, intake, pass orchestration, and review commands gain state-aware preflight
  and transition recording without duplicating their existing domain schemas.
- New tests cover atomic writes, schema validation, stale-agent recovery, concurrent update
  rejection, interrupted-action resume, and interoperability using fixtures representing Claude,
  Codex, and OpenCode clients.
- All persistence-capable commands must receive or resolve an unambiguous `--item-id`; read-only
  commands may remain ungated only when they cannot write through an output flag.
- NotebookLM research notebook: `140cddad-1e06-40c6-aa7b-eefca053e455`; research task:
  `1007493b-d1b8-4ae4-ad14-1d2626ae4a98`. Research was used as input to the design and will be
  preserved with source URLs and confidence notes in the change artifacts.