### PR TITLE
Generalize CS2 family support beyond knife-only

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -175,9 +175,45 @@ item: silhouette, proportions, edge profile, hardware layout, coating colour, pa
 wear, roughness response, and camera framing. Every decision must be traceable to evidence or be
 labelled as an approximation.
 
-The initial CS2 family boundary is **knife only**. Pistol, rifle, SMG, sniper, heavy, glove, and
-unknown knife subtypes must stop with `unsupported-family` or `unsupported-subtype`; they must not
-receive the knife component tree as a generic fallback.
+CS2 intake supports all seven Market-category families, each with its own dedicated geometry
+adapter (`forge/stage2_spec/cs2_adapters.py`) — no family is ever handed the knife (or any other
+family's) component tree as a generic fallback:
+
+| Family | Subtypes registered | Notes |
+| --- | --- | --- |
+| knife | 20 (karambit, butterfly, bayonet, m9, flip, gut, falchion, bowie, navaja, talon, classic, huntsman, kukri, nomad, paracord, shadow-daggers, skeleton, stiletto, survival, ursus) | shadow-daggers is a paired-blade outlier within this family |
+| pistol | 10 (glock-18, usp-s, p2000, dual-berettas, p250, cz75-auto, five-seven, tec-9, desert-eagle, r8-revolver) | dual-berettas is two guns; r8-revolver is a cylinder, not a slide |
+| sniper | 4 (awp, ssg08, g3sg1, scar-20) | CS2's "Sniper Rifles" category; only AWP is built against a real reference so far |
+| rifle | 7 (ak-47, m4a4, m4a1-s, famas, galil-ar, sg-553, aug) | CS2's "Rifles" category — semi/full-auto, no detachable scope |
+| smg | 7 (mac-10, mp9, mp7, mp5-sd, ump-45, p90, pp-bizon) | p90/pp-bizon have non-box-magazine topology (top-mount / drum) |
+| heavy | 6 (nova, xm1014, sawed-off, mag-7, m249, negev) | shotguns and machine guns are genuinely different shapes sharing one Market category |
+| glove | 8 (bloodhound, broken-fang, driver, hand-wraps, hydra, moto, specialist, sport) | hand/wrist topology, not a weapon or a full character |
+
+An unlisted subtype of a supported family (e.g. rifle/ak47 without the hyphen, sniper/m24) stops
+with `unsupported-subtype`; an unlisted family (e.g. `equipment` — Zeus x27, C4, defuse kit,
+Kevlar — has real CS2 skins but no adapter yet) stops with `unsupported-family`. Registering a
+family/subtype here only unblocks *intake* — it does not generate geometry. The actual component
+tree still has to be measured from real reference image(s) and hand-authored the way
+`src/demos/awp-medusa/createAwpMedusaModel.ts` (img2threejs-showcase) was built; `new_sculpt_spec.py`
+seeds a topology-appropriate starter skeleton per family (barrel/receiver/stock for a rifle,
+slide/frame for a pistol, cuff/back-of-hand/fingers/palm for a glove, etc.) via `--family`/
+`--subtype`, but that skeleton is still a placeholder to replace, not a finished spec.
+
+Extending support to a genuinely new family/subtype means adding a real `FamilyAdapter` + subtype
+entry in `cs2_adapters.py` **and** the matching entry in `cs2_manifest.py`'s
+`SUPPORTED_FAMILIES`/`FAMILY_SUBTYPES` — the two subtype sets must stay identical (a mismatch lets
+intake proceed into a spec-authoring call that then raises for a family/subtype `cs2_adapters.py`
+doesn't recognize, a worse failure mode than catching it at intake). Never bypass the gate for a
+one-off item.
+
+**Identity resolution — do this by default, not just for exact-texture work.** Whenever a skin
+name is given or suspected, run `forge/stage1_intake/fetch_cs2_metadata.py` against the public
+CSGO-API index to resolve the real paint index, float range, and rarity — it needs no local game
+install and costs nothing, so there is no reason to leave float/paint-seed as "unknown" in a spec
+when this would resolve it. This is a *different, much cheaper* step than
+`grimoire/intake/cs2_texture_acquisition.md`'s VPK/texture-extraction steps, which stay an
+optional Tier-3 exactness upgrade requiring the user's own local CS2 install — do not conflate
+the two or skip the cheap one because the expensive one is optional.
 
 ### Layer contract
 

--- a/forge/stage1_intake/cs2_manifest.py
+++ b/forge/stage1_intake/cs2_manifest.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+"""CS2 intake manifest: admission, classification-gated family/subtype routing, and identity
+resolution for a CS2 weapon/glove skin reference.
+
+Canonical taxonomy source: the community-maintained `ByMykel/CSGO-API` skins.json
+(https://github.com/ByMykel/CSGO-API), reachable via forge/stage1_intake/fetch_cs2_metadata.py.
+That script resolves per-skin identity (paint index, float range, rarity) from the same index
+and is cheap and safe to run by default whenever a skin name is given or suspected, even with no
+local CS2 install -- see grimoire/intake/cs2_texture_acquisition.md step 1. It is a different,
+much smaller ask than that doc's VPK/texture-extraction steps 2-3, which stay an optional Tier-3
+exactness upgrade requiring the user's own local game install.
+
+Family/subtype support here must stay in sync with forge/stage2_spec/cs2_adapters.py (the
+FamilyAdapter registered per family) -- a family/subtype supported here with no adapter there
+raises at spec-authoring time instead of at intake, which is a worse failure mode.
+"""
 from __future__ import annotations
 
 import argparse
@@ -9,23 +24,72 @@ import tempfile
 from pathlib import Path
 from typing import Any, Final
 
-from forge.stage1_intake.check_reference_admission import check_admission
-from forge.stage1_intake.cs2_foundation import enrich_manifest_with_metadata, normalize_cs2_metadata, resolve_identity
-from forge.stage1_intake.cs2_review_contract import build_review_scene
-from forge.stage1_intake.detect_cs2 import detect_cs2_signals
+# Insert the skill root so the absolute `forge.X.Y` imports below resolve under direct script
+# execution (`python3 forge/stage1_intake/cs2_manifest.py ...` from any cwd), not just when
+# PYTHONPATH already includes it or the module is imported as a package (e.g. by pytest).
+# Pre-existing gap: this file was the only forge.stage1_intake module doing cross-package
+# `from forge.X` imports without it, so it silently only ever worked via `-m` invocation or
+# under pytest's own import machinery -- never as a plain script, until a test exercised that.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from forge.stage1_intake.check_reference_admission import check_admission  # noqa: E402
+from forge.stage1_intake.cs2_foundation import enrich_manifest_with_metadata, normalize_cs2_metadata, resolve_identity  # noqa: E402
+from forge.stage1_intake.cs2_review_contract import build_review_scene  # noqa: E402
+from forge.stage1_intake.detect_cs2 import detect_cs2_signals  # noqa: E402
 from forge.stage1_intake.probe_image import probe
 
 SCHEMA_VERSION: Final[int] = 1
-SUPPORTED_FAMILIES: Final[frozenset[str]] = frozenset({"knife"})
-UNSUPPORTED_FAMILIES: Final[frozenset[str]] = frozenset(
-    {"pistol", "rifle", "smg", "sniper", "heavy", "glove"}
+SUPPORTED_FAMILIES: Final[frozenset[str]] = frozenset(
+    {"knife", "pistol", "sniper", "rifle", "smg", "heavy", "glove"}
 )
-# Knife subtypes that have a dedicated geometry adapter. A subtype absent here is
-# `unsupported-subtype`, never silently routed through another subtype's tree.
-KNIFE_SUBTYPES: Final[frozenset[str]] = frozenset(
-    {"karambit", "butterfly", "bayonet", "m9", "flip", "gut", "falchion", "bowie", "navaja",
-     "talon", "classic"}
+# Physical CS2 items with their own skins but no adapter yet (Zeus x27, C4, defuse kit, Kevlar).
+# Not a weapon/knife/glove topology at all -- distinct from an unrecognized/junk classification.
+UNSUPPORTED_FAMILIES: Final[frozenset[str]] = frozenset({"equipment"})
+# Subtypes with a dedicated geometry adapter, per family (see forge/stage2_spec/cs2_adapters.py
+# -- keep these two files' subtype sets identical; a mismatch lets intake proceed into a spec
+# author call that then raises for a family/subtype cs2_adapters.py doesn't recognize).
+# A subtype absent from its family's set is `unsupported-subtype`, never silently routed
+# through another subtype's tree.
+KNIFE_SUBTYPES: Final[frozenset[str]] = frozenset({
+    "karambit", "butterfly", "bayonet", "m9", "flip", "gut", "falchion", "bowie", "navaja",
+    "talon", "classic",
+    "huntsman", "kukri", "nomad", "paracord", "shadow-daggers", "skeleton", "stiletto",
+    "survival", "ursus",
+})
+PISTOL_SUBTYPES: Final[frozenset[str]] = frozenset({
+    "glock-18", "usp-s", "p2000", "dual-berettas", "p250", "cz75-auto", "five-seven", "tec-9",
+    "desert-eagle", "r8-revolver",
+})
+# CS2's "Sniper Rifles" Market category -- bolt-action AWP plus the semi-auto SSG08/G3SG1/
+# SCAR-20. AWP is the only one built against a real reference so far (see
+# src/demos/awp-medusa/createAwpMedusaModel.ts in the img2threejs-showcase project); the other
+# three are gate-registered only, per this file's module docstring.
+SNIPER_SUBTYPES: Final[frozenset[str]] = frozenset({"awp", "ssg08", "g3sg1", "scar-20"})
+# CS2's "Rifles" Market category (semi/full-auto, no detachable scope) -- distinct from Sniper
+# Rifles above. None built against a real reference yet.
+RIFLE_SUBTYPES: Final[frozenset[str]] = frozenset(
+    {"ak-47", "m4a4", "m4a1-s", "famas", "galil-ar", "sg-553", "aug"}
 )
+SMG_SUBTYPES: Final[frozenset[str]] = frozenset(
+    {"mac-10", "mp9", "mp7", "mp5-sd", "ump-45", "p90", "pp-bizon"}
+)
+# CS2's "Heavy" Market category covers both shotguns and machine guns -- genuinely different
+# shapes; see the _HEAVY comment in cs2_adapters.py.
+HEAVY_SUBTYPES: Final[frozenset[str]] = frozenset(
+    {"nova", "xm1014", "sawed-off", "mag-7", "m249", "negev"}
+)
+GLOVE_SUBTYPES: Final[frozenset[str]] = frozenset(
+    {"bloodhound", "broken-fang", "driver", "hand-wraps", "hydra", "moto", "specialist", "sport"}
+)
+FAMILY_SUBTYPES: Final[dict[str, frozenset[str]]] = {
+    "knife": KNIFE_SUBTYPES,
+    "pistol": PISTOL_SUBTYPES,
+    "sniper": SNIPER_SUBTYPES,
+    "rifle": RIFLE_SUBTYPES,
+    "smg": SMG_SUBTYPES,
+    "heavy": HEAVY_SUBTYPES,
+    "glove": GLOVE_SUBTYPES,
+}
 ROUTES: Final[frozenset[str]] = frozenset(
     {"reference-projection", "authored-texture", "procedural-finish"}
 )
@@ -157,12 +221,12 @@ def build_manifest(
     if family not in SUPPORTED_FAMILIES:
         manifest["state"] = "unsupported-family"
         manifest["unsupportedReason"] = f"no adapter registered for {family}"
-    elif subtype and subtype not in KNIFE_SUBTYPES:
+    elif subtype and subtype not in FAMILY_SUBTYPES[family]:
         manifest["state"] = "unsupported-subtype"
-        manifest["unsupportedReason"] = f"no knife adapter fixture for {subtype}"
+        manifest["unsupportedReason"] = f"no {family} adapter fixture for {subtype}"
     else:
         manifest["state"] = "proceed"
-        manifest["componentAdapter"] = "cs2-knife-v1"
+        manifest["componentAdapter"] = f"cs2-{family}-v1"
     if metadata:
         manifest = enrich_manifest_with_metadata(manifest, {"status": "resolved", "identity": metadata})
         manifest["metadata"] = normalize_cs2_metadata(metadata)
@@ -180,7 +244,7 @@ def validate_manifest(manifest: dict[str, Any]) -> bool:
         return False
     if not isinstance(manifest["sourceViews"], list) or not isinstance(manifest["warnings"], list):
         return False
-    if manifest["state"] == "proceed" and manifest.get("itemFamily") != "knife":
+    if manifest["state"] == "proceed" and manifest.get("itemFamily") not in SUPPORTED_FAMILIES:
         return False
     return True
 

--- a/forge/stage2_spec/cs2_adapters.py
+++ b/forge/stage2_spec/cs2_adapters.py
@@ -1,4 +1,19 @@
 #!/usr/bin/env python3
+"""Per-family geometry-topology adapters for CS2 weapon/glove skins.
+
+Each FamilyAdapter is a QUALITATIVE CONTRACT (topology hints, painted-region names, feature
+targets) for a human/agent to build a componentTree against -- it does not generate geometry
+itself. The real component tree still has to be measured from the actual reference image(s)
+and hand-authored, the same way src/demos/awp-medusa/createAwpMedusaModel.ts was built in the
+img2threejs-showcase project: registering a family/subtype here only stops the intake gate from
+rejecting the item before that work starts.
+
+Canonical taxonomy source: the community-maintained `ByMykel/CSGO-API` skins.json
+(https://github.com/ByMykel/CSGO-API), fetched via forge/stage1_intake/fetch_cs2_metadata.py.
+Each record's `weapon.name` gives the authoritative weapon name; cross-check the *_SUBTYPES
+frozensets below against the distinct weapon names per category if Valve ships a new weapon,
+rather than trusting this file's hardcoded list to stay current on its own.
+"""
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
@@ -28,7 +43,13 @@ _KNIFE = FamilyAdapter(
     ("guard-to-blade", "grip-to-guard", "pommel-to-grip"),
     ("reference", "orbit-left", "orbit-right"),
 )
-SUPPORTED_KNIFE_SUBTYPES = frozenset({"karambit", "butterfly", "bayonet", "m9", "flip", "gut", "falchion", "bowie", "navaja", "talon", "classic"})
+SUPPORTED_KNIFE_SUBTYPES = frozenset({
+    "karambit", "butterfly", "bayonet", "m9", "flip", "gut", "falchion", "bowie", "navaja",
+    "talon", "classic",
+    # Added when generalizing CS2 family support beyond the original knife-only fast path:
+    "huntsman", "kukri", "nomad", "paracord", "shadow-daggers", "skeleton", "stiletto",
+    "survival", "ursus",
+})
 
 # A pistol is not a knife with different proportions: it is a two-body assembly (slide riding a
 # frame) with a through-hole in the trigger guard, an internal mechanism the shell may reveal,
@@ -47,9 +68,128 @@ _PISTOL = FamilyAdapter(
      "grip-panel-to-frame", "internals-inside-shell"),
     ("reference", "orbit-left", "orbit-right", "muzzle-on", "top-down"),
 )
-SUPPORTED_PISTOL_SUBTYPES = frozenset({"glock-18"})
+SUPPORTED_PISTOL_SUBTYPES = frozenset({
+    "glock-18", "usp-s", "p2000", "dual-berettas", "p250", "cz75-auto", "five-seven", "tec-9",
+    "desert-eagle", "r8-revolver",
+})
 
-_ADAPTERS = {"knife": (_KNIFE, SUPPORTED_KNIFE_SUBTYPES), "pistol": (_PISTOL, SUPPORTED_PISTOL_SUBTYPES)}
+# A bolt-action sniper rifle is neither a knife nor a pistol: barrel and scope are true
+# surfaces of revolution (silhouette height == diameter along their whole length, unlike the
+# pistol's traced-outline slide), the receiver/stock is one boxy extruded shell with a genuine
+# boolean thumbhole rather than a two-body slide/frame assembly, and small attached
+# appendages (bolt handle, bipod leg, scope rings) need their own attachment contracts rather
+# than being folded into the body silhouette. This is CS2's "Sniper Rifles" Market category
+# (AWP/SSG08/G3SG1/SCAR-20), distinct from the semi-auto "Rifles" category below -- they were
+# a single 'rifle' family in an earlier revision of this file (built against AWP only), split
+# out once non-sniper rifles were added so an AK-47 request can't collide with AWP's adapter.
+_SNIPER = FamilyAdapter(
+    "sniper", "generic-supported",
+    ("revolve", "extrude-traced-outline", "outline-with-hole", "assembled-solid", "bent-rod"),
+    ("receiver-painted", "stock-painted", "scope-bell-painted-partial",
+     "barrel-bare-metal", "scope-tube-bare-metal", "magazine-bare-metal", "buttplate-bare-rubber"),
+    ("skin-finish", "substrate"),
+    ("silhouette", "barrel-and-muzzle-device", "receiver-and-ejection-port",
+     "scope-bell-tube-turret-profile", "scope-ring-mounts", "magazine-and-well",
+     "trigger-and-guard", "thumbhole-or-grip", "bolt-handle-or-bipod", "buttplate"),
+    ("scope-to-rail", "magazine-to-magwell", "trigger-to-receiver",
+     "bolt-handle-to-receiver", "bipod-to-barrel"),
+    ("reference", "orbit-left", "orbit-right", "muzzle-on", "top-down"),
+)
+# AWP is bolt-action (the shape above was measured against it). SSG08/G3SG1/SCAR-20 are not yet
+# built against a real reference and may need adapter adjustments (G3SG1/SCAR-20 are semi-auto
+# with a gas system and a larger detachable magazine, closer to the rifle family below) once one
+# is actually attempted -- registering the subtype here only unblocks intake, per this file's
+# module docstring.
+SUPPORTED_SNIPER_SUBTYPES = frozenset({"awp", "ssg08", "g3sg1", "scar-20"})
+
+# A semi/full-auto rifle (CS2's "Rifles" Market category: AK-47, M4A4, M4A1-S, FAMAS, Galil AR,
+# SG 553, AUG) differs from the sniper family above mainly by NOT carrying a separate scope
+# assembly (SG553/AUG have an integrated low-power scope molded into the receiver instead of a
+# detachable rail-mounted unit) and by usually showing a distinct muzzle device (compensator/
+# birdcage), a pistol grip separate from the stock, and a shorter, plainer buttstock.
+_RIFLE = FamilyAdapter(
+    "rifle", "generic-supported",
+    ("revolve", "extrude-traced-outline", "outline-with-hole", "assembled-solid", "bent-rod"),
+    ("receiver-painted", "handguard-painted", "stock-painted", "pistol-grip-painted",
+     "barrel-bare-metal", "gas-block-bare-metal", "magazine-bare-metal", "sights-bare-metal"),
+    ("skin-finish", "substrate"),
+    ("silhouette", "barrel-and-muzzle-device", "gas-block-and-handguard",
+     "receiver-and-ejection-port", "front-and-rear-sights-or-integrated-scope",
+     "magazine-and-well", "trigger-and-guard", "pistol-grip", "stock-and-buttplate"),
+    ("magazine-to-magwell", "trigger-to-receiver", "pistol-grip-to-receiver",
+     "stock-to-receiver", "handguard-to-barrel"),
+    ("reference", "orbit-left", "orbit-right", "muzzle-on", "top-down"),
+)
+SUPPORTED_RIFLE_SUBTYPES = frozenset({"ak-47", "m4a4", "m4a1-s", "famas", "galil-ar", "sg-553", "aug"})
+
+# An SMG shares the rifle family's broad silhouette grammar (barrel/receiver/stock/magazine)
+# but is shorter, more often has a folding or fixed wire/skeleton stock (or none, on some
+# models), and several subtypes have genuinely distinct magazine topology worth calling out
+# explicitly rather than assuming a generic box magazine: P90 feeds from a horizontal
+# top-mounted magazine, PP-Bizon from a vertical helical drum -- both are a form-affecting
+# silhouette feature, not a texture detail.
+_SMG = FamilyAdapter(
+    "smg", "generic-supported",
+    ("revolve", "extrude-traced-outline", "outline-with-hole", "assembled-solid", "bent-rod"),
+    ("receiver-painted", "handguard-painted", "stock-painted",
+     "barrel-bare-metal", "magazine-bare-metal", "sights-bare-metal"),
+    ("skin-finish", "substrate"),
+    ("silhouette", "barrel-and-muzzle-device", "receiver-and-ejection-port",
+     "magazine-and-well-or-top-mount-or-drum", "trigger-and-guard", "pistol-grip",
+     "stock-fixed-or-folding-or-absent", "sights"),
+    ("magazine-to-magwell", "trigger-to-receiver", "stock-to-receiver"),
+    ("reference", "orbit-left", "orbit-right", "muzzle-on", "top-down"),
+)
+SUPPORTED_SMG_SUBTYPES = frozenset({"mac-10", "mp9", "mp7", "mp5-sd", "ump-45", "p90", "pp-bizon"})
+
+# "Heavy" is CS2's Market category for shotguns AND machine guns, which are not one shape:
+# shotguns (Nova, XM1014, Sawed-Off, MAG-7) center on a pump/tube magazine under the barrel and
+# often a shorter, wider receiver; machine guns (M249, Negev) are belt/box-fed with a bipod and
+# a much longer, heavier barrel shroud. This adapter's topology/feature lists cover the union;
+# expect to specialize per subtype (e.g. drop 'bipod' for a shotgun, drop 'pump-slide-and-tube'
+# for a machine gun) once a specific reference is attempted, per this file's module docstring.
+_HEAVY = FamilyAdapter(
+    "heavy", "generic-supported",
+    ("revolve", "extrude-traced-outline", "outline-with-hole", "assembled-solid", "bent-rod"),
+    ("receiver-painted", "stock-painted", "handguard-painted",
+     "barrel-bare-metal", "magazine-or-feed-bare-metal"),
+    ("skin-finish", "substrate"),
+    ("silhouette", "barrel-and-muzzle-device", "receiver", "pump-slide-and-tube-or-belt-feed",
+     "magazine-or-ammo-box", "trigger-and-guard", "stock-and-buttplate", "bipod-if-present"),
+    ("magazine-or-feed-to-receiver", "trigger-to-receiver", "stock-to-receiver",
+     "bipod-to-barrel"),
+    ("reference", "orbit-left", "orbit-right", "muzzle-on", "top-down"),
+)
+SUPPORTED_HEAVY_SUBTYPES = frozenset({"nova", "xm1014", "sawed-off", "mag-7", "m249", "negev"})
+
+# Gloves are worn on the player model's hands -- they are not a weapon topology (no barrel,
+# receiver, or blade) and not a full humanoid character either (no face/torso/proportions).
+# This is its own hand/wrist-specific contract rather than being forced through either the
+# weapon adapters above or the skill's separate humanoid character track.
+_GLOVE = FamilyAdapter(
+    "glove", "generic-supported",
+    ("extrude-traced-outline", "outline-with-hole", "assembled-solid", "curve-sweep"),
+    ("cuff-painted", "back-of-hand-painted", "knuckle-painted", "palm-bare-material",
+     "finger-segments-painted", "stitching-bare-material"),
+    ("skin-finish", "substrate"),
+    ("silhouette", "cuff-and-wrist-strap", "back-of-hand-panel", "knuckle-plate-or-padding",
+     "finger-and-thumb-segmentation", "palm-grip-texture", "stitching-and-seams"),
+    ("finger-segments-to-palm", "cuff-to-wrist"),
+    ("reference", "palm-side", "back-of-hand-side"),
+)
+SUPPORTED_GLOVE_SUBTYPES = frozenset({
+    "bloodhound", "broken-fang", "driver", "hand-wraps", "hydra", "moto", "specialist", "sport",
+})
+
+_ADAPTERS = {
+    "knife": (_KNIFE, SUPPORTED_KNIFE_SUBTYPES),
+    "pistol": (_PISTOL, SUPPORTED_PISTOL_SUBTYPES),
+    "sniper": (_SNIPER, SUPPORTED_SNIPER_SUBTYPES),
+    "rifle": (_RIFLE, SUPPORTED_RIFLE_SUBTYPES),
+    "smg": (_SMG, SUPPORTED_SMG_SUBTYPES),
+    "heavy": (_HEAVY, SUPPORTED_HEAVY_SUBTYPES),
+    "glove": (_GLOVE, SUPPORTED_GLOVE_SUBTYPES),
+}
 
 
 def get_family_adapter(family: str, subtype: str | None = None) -> FamilyAdapter:

--- a/forge/stage2_spec/new_sculpt_spec.py
+++ b/forge/stage2_spec/new_sculpt_spec.py
@@ -11,6 +11,11 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
 from status_banner import emit_status
+# Insert the skill root (matching new_pre_spec_assessment.py's PROJECT_ROOT pattern) so the
+# absolute `forge.X.Y` import below resolves under both direct script execution and pytest's
+# package-style import of this module.
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from forge.stage2_spec.cs2_adapters import get_family_adapter  # noqa: E402
 
 
 def slugify(value: str) -> str:
@@ -711,23 +716,15 @@ def _cs2node(cid, name, primitive, position, scale, material, role, level,
                   local_features=local_features or [], evidence=["full-object"])
 
 
-CS2_KNIFE_SUBTYPES = frozenset(
-    {"karambit", "butterfly", "bayonet", "m9", "flip", "gut", "falchion", "bowie", "navaja",
-     "talon", "classic"}
-)
-
-
-def make_cs2_component_tree(item_family: str = "knife", subtype: str | None = None) -> list:
-    if item_family != "knife":
-        raise ValueError(f"unsupported CS2 family {item_family!r}; only knife is implemented")
-    if subtype and subtype not in CS2_KNIFE_SUBTYPES:
-        raise ValueError(f"unsupported CS2 knife subtype {subtype!r}")
-    # Root is an organizing group only: use the invisible 'hidden' material (opacity 0) exactly
-    # like the character template, so the generator's per-component mesh for root never renders as
-    # a stray box over the weapon -- no generic generator change needed.
-    root = _cnode("root", "Weapon (root)", "box", None, (0, 0, 0), (1, 1, 1),
-                  material="hidden", role="body", level="macro", importance=1.0, anim_role="root")
-    parts = [
+# Per-family starter parts. Every one of these is a placeholder skeleton for the agent to
+# measure and replace against the real reference image(s) -- exactly like the knife tree
+# always was, and exactly how src/demos/awp-medusa/createAwpMedusaModel.ts (img2threejs-showcase)
+# was actually built: this scaffold only stops the agent from being handed knife-shaped parts
+# (blade/grip/guard/pommel/bolster) for a pistol or a rifle, which is strictly worse than a
+# family-appropriate placeholder because it has to be recognized as wrong before the real
+# measuring work can even start.
+def _knife_parts() -> list:
+    return [
         _cs2node("blade", "Blade", "ground-blade", (0, 0.55, 0), (1.0, 1.0, 1.0), "skin-finish", "blade", "macro", 1.0,
                  ["edge bevel highlight", "engraved pattern swirl"]),
         _cs2node("grip", "Grip", "curve-sweep", (0, -0.55, 0), (1.0, 1.0, 1.0), "skin-finish", "grip", "macro", 0.9,
@@ -736,26 +733,139 @@ def make_cs2_component_tree(item_family: str = "knife", subtype: str | None = No
         _cs2node("pommel", "Pommel", "sphere", (0, -0.95, 0), (0.2, 0.2, 0.2), "substrate", "pommel", "meso", 0.6),
         _cs2node("bolster", "Bolster", "box", (0, 0.02, 0), (0.2, 0.18, 0.26), "substrate", "bolster", "meso", 0.6),
     ]
+
+
+def _pistol_parts() -> list:
+    return [
+        _cs2node("slide", "Slide", "extrude", (0, 0.3, 0), (1.0, 0.5, 1.0), "skin-finish", "slide", "macro", 1.0,
+                 ["ejection port", "rear/front sight"]),
+        _cs2node("frame", "Frame", "extrude", (0, -0.1, 0), (0.9, 0.6, 0.9), "skin-finish", "frame", "macro", 0.9,
+                 ["trigger guard loop", "grip panel texture"]),
+        _cs2node("barrel", "Barrel", "lathe", (0.3, 0.3, 0), (0.15, 0.5, 0.15), "substrate", "barrel", "meso", 0.7),
+        _cs2node("magazine", "Magazine", "box", (0, -0.9, 0), (0.2, 0.5, 0.15), "substrate", "magazine", "meso", 0.6),
+        _cs2node("trigger", "Trigger", "box", (0.05, -0.15, 0), (0.06, 0.15, 0.06), "substrate", "trigger", "meso", 0.5),
+    ]
+
+
+def _sniper_parts() -> list:
+    return [
+        _cs2node("barrel", "Barrel", "lathe", (-0.8, 0, 0), (0.08, 1.4, 0.08), "substrate", "barrel", "macro", 0.9),
+        _cs2node("receiver", "Receiver", "box", (0.2, -0.05, 0), (0.5, 0.2, 0.15), "skin-finish", "receiver", "macro", 1.0,
+                 ["ejection port"]),
+        _cs2node("scope", "Riflescope", "lathe", (0.5, 0.2, 0), (0.06, 0.8, 0.06), "substrate", "scope", "meso", 0.7,
+                 ["objective/ocular bell", "turret cap"]),
+        _cs2node("stock", "Stock", "extrude", (1.2, -0.1, 0), (0.5, 0.45, 0.15), "skin-finish", "stock", "macro", 0.9,
+                 ["thumbhole or grip cutout"]),
+        _cs2node("magazine", "Magazine", "box", (0.55, -0.25, 0), (0.12, 0.25, 0.13), "substrate", "magazine", "meso", 0.6),
+    ]
+
+
+def _rifle_parts() -> list:
+    return [
+        _cs2node("barrel", "Barrel", "lathe", (-0.7, 0.1, 0), (0.06, 1.1, 0.06), "substrate", "barrel", "macro", 0.9),
+        _cs2node("receiver", "Receiver", "box", (0.1, 0.05, 0), (0.45, 0.18, 0.14), "skin-finish", "receiver", "macro", 1.0,
+                 ["ejection port"]),
+        _cs2node("handguard", "Handguard", "extrude", (-0.35, 0.08, 0), (0.35, 0.13, 0.13), "skin-finish", "handguard", "meso", 0.7),
+        _cs2node("stock", "Stock", "extrude", (0.9, 0.0, 0), (0.4, 0.2, 0.13), "skin-finish", "stock", "macro", 0.8),
+        _cs2node("pistol-grip", "Pistol grip", "curve-sweep", (0.35, -0.3, 0), (0.12, 0.3, 0.12), "substrate", "pistol-grip", "meso", 0.6),
+        _cs2node("magazine", "Magazine", "box", (0.15, -0.35, 0), (0.12, 0.4, 0.13), "substrate", "magazine", "meso", 0.6),
+    ]
+
+
+def _smg_parts() -> list:
+    return [
+        _cs2node("barrel", "Barrel", "lathe", (-0.5, 0.05, 0), (0.05, 0.6, 0.05), "substrate", "barrel", "macro", 0.8),
+        _cs2node("receiver", "Receiver", "box", (0.05, 0.0, 0), (0.4, 0.16, 0.13), "skin-finish", "receiver", "macro", 1.0),
+        _cs2node("magazine", "Magazine (or top-mount / drum -- verify against reference)", "box",
+                 (0.0, -0.35, 0), (0.1, 0.4, 0.12), "substrate", "magazine", "meso", 0.7),
+        _cs2node("stock", "Stock (fixed / folding / absent -- verify against reference)", "extrude",
+                 (0.55, 0.0, 0), (0.3, 0.15, 0.1), "skin-finish", "stock", "meso", 0.6),
+        _cs2node("pistol-grip", "Pistol grip", "curve-sweep", (0.15, -0.28, 0), (0.1, 0.25, 0.1), "substrate", "pistol-grip", "meso", 0.5),
+    ]
+
+
+def _heavy_parts() -> list:
+    return [
+        _cs2node("barrel", "Barrel", "lathe", (-0.8, 0.05, 0), (0.07, 1.2, 0.07), "substrate", "barrel", "macro", 0.9),
+        _cs2node("receiver", "Receiver", "box", (0.1, 0.0, 0), (0.5, 0.2, 0.16), "skin-finish", "receiver", "macro", 1.0),
+        _cs2node("handguard", "Handguard / pump-slide (verify against reference)", "extrude",
+                 (-0.35, 0.0, 0), (0.35, 0.15, 0.14), "skin-finish", "handguard", "meso", 0.7),
+        _cs2node("feed", "Magazine / ammo box / belt feed (verify against reference)", "box",
+                 (0.2, -0.35, 0), (0.15, 0.4, 0.15), "substrate", "feed", "meso", 0.6),
+        _cs2node("stock", "Stock", "extrude", (0.9, 0.0, 0), (0.4, 0.2, 0.14), "skin-finish", "stock", "macro", 0.7),
+    ]
+
+
+def _glove_parts() -> list:
+    return [
+        _cs2node("cuff", "Cuff / wrist strap", "extrude", (0, -0.7, 0), (0.5, 0.35, 0.35), "skin-finish", "cuff", "macro", 0.8,
+                 ["wrist strap / buckle"]),
+        _cs2node("back-of-hand", "Back of hand panel", "extrude", (0, 0.0, 0), (0.5, 0.55, 0.3), "skin-finish", "back-of-hand", "macro", 1.0,
+                 ["knuckle plate or padding"]),
+        _cs2node("fingers", "Finger segments", "curve-sweep", (0, 0.6, 0), (0.45, 0.35, 0.25), "skin-finish", "fingers", "meso", 0.8,
+                 ["finger/thumb segmentation"]),
+        _cs2node("palm", "Palm", "extrude", (0, 0.05, -0.15), (0.45, 0.5, 0.15), "substrate", "palm", "meso", 0.6,
+                 ["palm grip texture"]),
+    ]
+
+
+_CS2_FAMILY_PARTS = {
+    "knife": _knife_parts,
+    "pistol": _pistol_parts,
+    "sniper": _sniper_parts,
+    "rifle": _rifle_parts,
+    "smg": _smg_parts,
+    "heavy": _heavy_parts,
+    "glove": _glove_parts,
+}
+
+
+def make_cs2_component_tree(item_family: str = "knife", subtype: str | None = None) -> list:
+    # get_family_adapter is the single source of truth for family/subtype support (shared with
+    # forge/stage1_intake/cs2_manifest.py's intake gate) -- raises ValueError with a clear
+    # unsupported-family/unsupported-subtype message for anything not registered there.
+    get_family_adapter(item_family, subtype)
+    # Root is an organizing group only: use the invisible 'hidden' material (opacity 0) exactly
+    # like the character template, so the generator's per-component mesh for root never renders as
+    # a stray box over the weapon -- no generic generator change needed.
+    root = _cnode("root", "Weapon (root)", "box", None, (0, 0, 0), (1, 1, 1),
+                  material="hidden", role="body", level="macro", importance=1.0, anim_role="root")
+    parts = _CS2_FAMILY_PARTS[item_family]()
     return [root, *parts]
 
 
-def make_cs2_feature_targets() -> list:
+# Per-family (primaryPaintedPart, secondaryPart) used to seed feature-target componentRefs
+# below without hardcoding blade/guard for every family. Pick the two parts from each family's
+# _*_parts() builder that best carry the finish and a secondary structural read.
+_CS2_FAMILY_PRIMARY_PARTS = {
+    "knife": ("blade", "grip", "guard"),
+    "pistol": ("slide", "frame", "frame"),
+    "sniper": ("stock", "receiver", "receiver"),
+    "rifle": ("receiver", "stock", "handguard"),
+    "smg": ("receiver", "stock", "receiver"),
+    "heavy": ("receiver", "stock", "handguard"),
+    "glove": ("back-of-hand", "cuff", "fingers"),
+}
+
+
+def make_cs2_feature_targets(item_family: str = "knife") -> list:
+    primary, secondary, tertiary = _CS2_FAMILY_PRIMARY_PARTS.get(item_family, ("blade", "grip", "guard"))
     return [
         {"id": "cs2-silhouette", "name": "Weapon silhouette and proportions", "tier": "critical",
          "passIds": ["blockout"], "minimumScore": 0.8, "mustPass": True,
-         "componentRefs": ["root", "blade", "grip"], "evidenceRefs": ["full-object"]},
+         "componentRefs": ["root", primary, secondary], "evidenceRefs": ["full-object"]},
         {"id": "cs2-finish-style-read", "name": "Finish style reads correctly", "tier": "critical",
          "passIds": ["material-pass"], "minimumScore": 0.75, "mustPass": True,
-         "componentRefs": ["blade"], "evidenceRefs": ["full-object"]},
+         "componentRefs": [primary], "evidenceRefs": ["full-object"]},
         {"id": "cs2-metal-response", "name": "Metal / anodized environment response", "tier": "critical",
          "passIds": ["lighting-pass"], "minimumScore": 0.75, "mustPass": True,
-         "componentRefs": ["blade", "guard"], "evidenceRefs": ["full-object"]},
+         "componentRefs": [primary, tertiary], "evidenceRefs": ["full-object"]},
         {"id": "cs2-pattern-placement", "name": "Pattern placement (approximated)", "tier": "important",
          "passIds": ["material-pass"], "minimumScore": 0.65, "mustPass": False,
-         "componentRefs": ["blade"], "evidenceRefs": ["full-object"]},
+         "componentRefs": [primary], "evidenceRefs": ["full-object"]},
         {"id": "cs2-wear-read", "name": "Wear / float reads plausibly", "tier": "important",
          "passIds": ["surface-pass"], "minimumScore": 0.65, "mustPass": False,
-         "componentRefs": ["blade", "grip"], "evidenceRefs": ["full-object"]},
+         "componentRefs": [primary, secondary], "evidenceRefs": ["full-object"]},
     ]
 
 
@@ -785,7 +895,7 @@ def apply_cs2_template(
     profile = CS2_FINISH_PROFILES[resolved_style]
     spec["componentTree"] = make_cs2_component_tree(item_family, subtype)
     spec["materials"] = [_cs2_finish_material(resolved_style, float_value, paint_seed), _cs2_substrate_material(), _cs2_hidden_material()]
-    spec["featureReviewTargets"] = make_cs2_feature_targets()
+    spec["featureReviewTargets"] = make_cs2_feature_targets(item_family)
     # top-level signal for the pre-render environment gate (mirrors the material value)
     spec["envMapIntensity"] = profile["env"]
     spec["cs2Finish"] = {"finishStyle": resolved_style, "viewDependent": profile["viewDependent"],
@@ -799,12 +909,17 @@ def apply_cs2_template(
         unknowns = pre.setdefault("unknownsToResolveBeforeImplementation", [])
         unknowns.extend(conflict for conflict in conflicts if conflict not in unknowns)
     oc = pre.setdefault("objectClass", {})
-    oc["primaryType"] = "weapon-skin"
+    oc["primaryType"] = "glove-skin" if item_family == "glove" else "weapon-skin"
     oc["primaryDomain"] = "object"
-    oc["formLanguage"] = ["hard-surface", "bladed"]
-    oc["structureKind"] = ["blade", "grip", "guard"]
+    oc["formLanguage"] = (
+        ["soft-goods", "wrapped-hand"] if item_family == "glove" else ["hard-surface", "bladed" if item_family == "knife" else "mechanical"]
+    )
+    oc["structureKind"] = [node["id"] for node in _CS2_FAMILY_PARTS.get(item_family, _knife_parts)()]
     oc["motionPotential"] = ["static", "inspect-orbit"]
-    oc["materialFamilies"] = ["metal", "anodized-coat" if profile["viewDependent"] else "painted-coat"]
+    oc["materialFamilies"] = (
+        ["leather", "synthetic-wrap"] if item_family == "glove"
+        else ["metal", "anodized-coat" if profile["viewDependent"] else "painted-coat"]
+    )
     oc["cs2"] = True
     complexity = pre.setdefault("complexity", {})
     complexity["tier"] = "ultra-complex"
@@ -1585,6 +1700,12 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--float", dest="cs2_float", type=float,
                         help="CS2 item float (0.0 Factory New .. 1.0 Battle-Scarred); approximated from the image if omitted")
     parser.add_argument("--paint-seed", type=int, help="CS2 paint seed; deterministic default placement if omitted")
+    parser.add_argument("--family", choices=sorted(_CS2_FAMILY_PARTS),
+                        help="CS2 item family (knife/pistol/sniper/rifle/smg/heavy/glove); required for a non-knife "
+                             "family when --manifest is not given, or the family silently defaults to 'knife'. "
+                             "Overrides --manifest's itemFamily if both are given and disagree (a warning is printed).")
+    parser.add_argument("--subtype", help="CS2 subtype within --family (e.g. 'ak-47', 'sport'); validated against "
+                                          "forge/stage2_spec/cs2_adapters.py")
     parser.add_argument("--no-environment", action="store_true",
                         help="Mark the code-generated default environment as unavailable (testing/last-resort only) "
                              "-- validate_sculpt_spec.py blocks view-dependent finishes when set")
@@ -1599,9 +1720,19 @@ def main(argv: list[str]) -> int:
             parser.error("CS2 intake manifest must be a JSON object")
         if manifest.get("state") != "proceed":
             parser.error(f"CS2 intake is not ready for spec authoring: {manifest.get('state', 'unknown')}")
-        if manifest.get("itemFamily") != "knife":
-            parser.error("CS2 spec authoring currently supports only the knife family")
-    spec = make_spec(args.target_name, args.image, assessment)
+        manifest_family = manifest.get("itemFamily")
+        if manifest_family not in _CS2_FAMILY_PARTS:
+            parser.error(f"CS2 spec authoring has no adapter for family {manifest_family!r} "
+                         f"(supported: {', '.join(sorted(_CS2_FAMILY_PARTS))})")
+        if args.family and args.family != manifest_family:
+            print(f"warning: --family {args.family!r} overrides manifest itemFamily {manifest_family!r}", file=sys.stderr)
+    # NOTE: origin/main's pre-existing call here passed args.image (a list, from the --image
+    # append action) directly to make_spec(target_name, image: str | None, ...) -- a type
+    # mismatch predating this change, unrelated to CS2 family support. Left as the corrected
+    # single-image extraction rather than reintroducing that mismatch; flagged separately,
+    # not silently folded into this PR's intent.
+    primary_image = args.image[0] if args.image else None
+    spec = make_spec(args.target_name, primary_image, assessment)
     domain = None
     cs2_marker = False
     if isinstance(assessment, dict):
@@ -1615,6 +1746,19 @@ def main(argv: list[str]) -> int:
             oc = assessment.get("preSpecAssessment", {}).get("objectClass", {})
             if isinstance(oc, dict) and oc.get("finishStyle") in CS2_FINISH_PROFILES:
                 finish_style = oc["finishStyle"]
+        if args.family:
+            resolved_family = args.family
+        elif manifest is not None:
+            resolved_family = str(manifest.get("itemFamily", "knife"))
+        else:
+            resolved_family = "knife"
+            print("warning: no --manifest or --family given; defaulting itemFamily to 'knife'. "
+                  "Pass --family explicitly for a non-knife CS2 item.", file=sys.stderr)
+        resolved_subtype = args.subtype or (str(manifest["subtype"]) if manifest and manifest.get("subtype") else None)
+        try:
+            get_family_adapter(resolved_family, resolved_subtype)
+        except ValueError as exc:
+            parser.error(str(exc))
         apply_cs2_template(
             spec, finish_style,
             skin_name=args.skin_name,
@@ -1623,8 +1767,8 @@ def main(argv: list[str]) -> int:
             float_value=args.cs2_float,
             paint_seed=args.paint_seed,
             environment_available=not args.no_environment,
-            item_family=str(manifest.get("itemFamily", "knife")) if manifest else "knife",
-            subtype=str(manifest["subtype"]) if manifest and manifest.get("subtype") else None,
+            item_family=resolved_family,
+            subtype=resolved_subtype,
         )
         if manifest:
             apply_cs2_manifest_evidence(spec, manifest)

--- a/forge/tests/test_cs2_foundation.py
+++ b/forge/tests/test_cs2_foundation.py
@@ -88,10 +88,21 @@ class TextureFoundationTests(unittest.TestCase):
 
 
 class AdapterAndReviewTests(unittest.TestCase):
-    def test_only_knife_adapter_is_registered(self) -> None:
+    def test_registered_family_adapters(self) -> None:
         self.assertEqual(get_family_adapter("knife", "karambit").family, "knife")
+        self.assertEqual(get_family_adapter("pistol", "glock-18").family, "pistol")
+        # AWP is a Sniper Rifle in CS2's own Market taxonomy, not a (semi-auto) Rifle -- it
+        # moved to its own 'sniper' family once non-sniper rifles were registered, so an
+        # AK-47 request can't collide with the AWP-specific adapter.
+        self.assertEqual(get_family_adapter("sniper", "awp").family, "sniper")
+        self.assertEqual(get_family_adapter("rifle", "ak-47").family, "rifle")
+        self.assertEqual(get_family_adapter("smg", "mp9").family, "smg")
+        self.assertEqual(get_family_adapter("heavy", "xm1014").family, "heavy")
+        self.assertEqual(get_family_adapter("glove", "sport").family, "glove")
         with self.assertRaises(ValueError):
-            get_family_adapter("rifle", "ak47")
+            get_family_adapter("rifle", "ak47")  # unsupported-subtype: no hyphen -> not registered
+        with self.assertRaises(ValueError):
+            get_family_adapter("equipment", "zeus-x27")  # unsupported-family: no adapter at all
 
     def test_review_scene_is_versioned_and_thresholds_are_frozen(self) -> None:
         scene = build_review_scene("fixture-sha256")

--- a/forge/tests/test_cs2_manifest.py
+++ b/forge/tests/test_cs2_manifest.py
@@ -57,13 +57,104 @@ class Cs2ManifestTests(unittest.TestCase):
             self.assertTrue(validate_manifest(manifest))
 
     def test_unsupported_family_never_receives_knife_adapter(self) -> None:
+        # "equipment" (Zeus x27, C4, defuse kit, Kevlar) has its own real CS2 skins but no
+        # geometry adapter yet -- distinct from an unrecognized/junk classification.
+        with tempfile.TemporaryDirectory() as directory:
+            reference = Path(directory) / "equipment.png"
+            write_png(reference)
+            classification = build_classification_record("equipment", "zeus-x27", 0.99, ["view:front:subject"])
+            manifest = build_manifest(reference, classification)
+            self.assertEqual(manifest["state"], "unsupported-family")
+            self.assertNotIn("componentAdapter", manifest)
+
+    def test_unlisted_rifle_subtype_is_unsupported_subtype_not_family(self) -> None:
+        # "rifle" is a supported family (AK-47 etc. have an adapter) but "ak47" (no hyphen,
+        # not the registered "ak-47") has no fixture -- that must surface as
+        # unsupported-subtype, distinct from an unknown family entirely.
         with tempfile.TemporaryDirectory() as directory:
             reference = Path(directory) / "rifle.png"
             write_png(reference)
             classification = build_classification_record("rifle", "ak47", 0.99, ["view:front:subject"])
             manifest = build_manifest(reference, classification)
-            self.assertEqual(manifest["state"], "unsupported-family")
+            self.assertEqual(manifest["state"], "unsupported-subtype")
             self.assertNotIn("componentAdapter", manifest)
+
+    def test_classified_sniper_awp_proceeds_with_sniper_adapter(self) -> None:
+        # AWP is a Sniper Rifle in CS2's own Market taxonomy, not a (semi-auto) Rifle -- see
+        # cs2_adapters.py's _SNIPER/_RIFLE split.
+        with tempfile.TemporaryDirectory() as directory:
+            reference = Path(directory) / "awp.png"
+            write_png(reference)
+            classification = build_classification_record(
+                "sniper", "awp", 0.9, ["view:front:subject"], provider="offline-fixture"
+            )
+            manifest = build_manifest(reference, classification)
+            self.assertEqual(manifest["state"], "proceed")
+            self.assertEqual(manifest["itemFamily"], "sniper")
+            self.assertEqual(manifest["componentAdapter"], "cs2-sniper-v1")
+            self.assertTrue(validate_manifest(manifest))
+
+    def test_classified_rifle_ak47_proceeds_with_rifle_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            reference = Path(directory) / "ak47.png"
+            write_png(reference)
+            classification = build_classification_record(
+                "rifle", "ak-47", 0.9, ["view:front:subject"], provider="offline-fixture"
+            )
+            manifest = build_manifest(reference, classification)
+            self.assertEqual(manifest["state"], "proceed")
+            self.assertEqual(manifest["componentAdapter"], "cs2-rifle-v1")
+            self.assertTrue(validate_manifest(manifest))
+
+    def test_classified_smg_mp9_proceeds_with_smg_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            reference = Path(directory) / "mp9.png"
+            write_png(reference)
+            classification = build_classification_record(
+                "smg", "mp9", 0.9, ["view:front:subject"], provider="offline-fixture"
+            )
+            manifest = build_manifest(reference, classification)
+            self.assertEqual(manifest["state"], "proceed")
+            self.assertEqual(manifest["componentAdapter"], "cs2-smg-v1")
+            self.assertTrue(validate_manifest(manifest))
+
+    def test_classified_heavy_xm1014_proceeds_with_heavy_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            reference = Path(directory) / "xm1014.png"
+            write_png(reference)
+            classification = build_classification_record(
+                "heavy", "xm1014", 0.9, ["view:front:subject"], provider="offline-fixture"
+            )
+            manifest = build_manifest(reference, classification)
+            self.assertEqual(manifest["state"], "proceed")
+            self.assertEqual(manifest["componentAdapter"], "cs2-heavy-v1")
+            self.assertTrue(validate_manifest(manifest))
+
+    def test_classified_glove_sport_proceeds_with_glove_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            reference = Path(directory) / "sport.png"
+            write_png(reference)
+            classification = build_classification_record(
+                "glove", "sport", 0.9, ["view:front:subject"], provider="offline-fixture"
+            )
+            manifest = build_manifest(reference, classification)
+            self.assertEqual(manifest["state"], "proceed")
+            self.assertEqual(manifest["componentAdapter"], "cs2-glove-v1")
+            self.assertTrue(validate_manifest(manifest))
+
+    def test_classified_pistol_glock18_proceeds_with_pistol_adapter(self) -> None:
+        # Regression: the pistol adapter existed in cs2_adapters.py but SUPPORTED_FAMILIES
+        # never included "pistol", so a Glock-18 classification could never reach `proceed`.
+        with tempfile.TemporaryDirectory() as directory:
+            reference = Path(directory) / "glock.png"
+            write_png(reference)
+            classification = build_classification_record(
+                "pistol", "glock-18", 0.9, ["view:front:subject"], provider="offline-fixture"
+            )
+            manifest = build_manifest(reference, classification)
+            self.assertEqual(manifest["state"], "proceed")
+            self.assertEqual(manifest["componentAdapter"], "cs2-pistol-v1")
+            self.assertTrue(validate_manifest(manifest))
 
     def test_manifest_write_is_atomic_and_round_trips(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/forge/tests/test_pipeline.py
+++ b/forge/tests/test_pipeline.py
@@ -810,6 +810,62 @@ class PipelineTest(unittest.TestCase):
         self.assertNotEqual(r.returncode, 0)
         self.assertIn("environment", r.stdout.lower())
 
+    def test_cs2_family_aware_scaffold_per_family(self):
+        # Each family gets its own topology-appropriate placeholder component tree, not the
+        # knife-shaped default (root/blade/grip/guard/pommel/bolster) that new_sculpt_spec.py
+        # used to hand back for every non-knife family before the CS2 taxonomy was generalized.
+        cases = {
+            "pistol": ("usp-s", {"slide", "frame", "barrel", "magazine", "trigger"}),
+            "sniper": ("awp", {"barrel", "receiver", "scope", "stock", "magazine"}),
+            "rifle": ("ak-47", {"barrel", "receiver", "handguard", "stock", "pistol-grip", "magazine"}),
+            "smg": ("mp9", {"barrel", "receiver", "magazine", "stock", "pistol-grip"}),
+            "heavy": ("xm1014", {"barrel", "receiver", "handguard", "feed", "stock"}),
+            "glove": ("sport", {"cuff", "back-of-hand", "fingers", "palm"}),
+        }
+        for family, (subtype, expected_ids) in cases.items():
+            with self.subTest(family=family):
+                spec = self.dir / f"{family}-spec.json"
+                r = run("stage2_spec/new_sculpt_spec.py", f"{family} test", "--cs2",
+                        "--family", family, "--subtype", subtype, "--out", spec, "--force")
+                self.assertEqual(r.returncode, 0, r.stderr)
+                payload = json.loads(spec.read_text())
+                ids = {c["id"] for c in payload["componentTree"]} - {"root"}
+                self.assertEqual(ids, expected_ids)
+                # every family's scaffold must itself be a valid, non-knife-shaped spec
+                v = run("stage2_spec/validate_sculpt_spec.py", spec)
+                self.assertEqual(v.returncode, 0, v.stdout + v.stderr)
+
+    def test_cs2_no_family_or_manifest_warns_and_defaults_to_knife(self):
+        r = run("stage2_spec/new_sculpt_spec.py", "Mystery Item", "--cs2", "--out", self.spec)
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("defaulting itemfamily to 'knife'", r.stderr.lower())
+        spec = json.loads(self.spec.read_text())
+        self.assertEqual({c["id"] for c in spec["componentTree"]} - {"root"},
+                         {"blade", "grip", "guard", "pommel", "bolster"})
+
+    def test_cs2_invalid_family_subtype_is_a_clean_cli_error(self):
+        r = run("stage2_spec/new_sculpt_spec.py", "Bad Item", "--cs2",
+                "--family", "rifle", "--subtype", "not-a-real-gun", "--out", self.spec)
+        self.assertNotEqual(r.returncode, 0)
+        self.assertIn("unsupported-subtype", r.stderr.lower())
+
+    def test_cs2_family_flag_overrides_conflicting_manifest_with_warning(self):
+        manifest = self.dir / "cs2-intake.json"
+        run("stage1_intake/cs2_manifest.py", self.ref, "--out", manifest)
+        # patch the manifest to a proceed state for a family other than the one we'll pass
+        payload = json.loads(manifest.read_text())
+        payload["state"] = "proceed"
+        payload["itemFamily"] = "knife"
+        manifest.write_text(json.dumps(payload))
+        r = run("stage2_spec/new_sculpt_spec.py", "Override Item", "--cs2",
+                "--manifest", manifest, "--family", "smg", "--subtype", "mp9",
+                "--out", self.spec, "--force")
+        self.assertEqual(r.returncode, 0, r.stderr)
+        self.assertIn("overrides manifest itemfamily", r.stderr.lower())
+        spec = json.loads(self.spec.read_text())
+        self.assertEqual({c["id"] for c in spec["componentTree"]} - {"root"},
+                         {"barrel", "receiver", "magazine", "stock", "pistol-grip"})
+
     def test_fetch_cs2_metadata_resolves_and_flags_ambiguity(self):
         index = self.dir / "skins.json"
         index.write_text(json.dumps([

--- a/grimoire/intake/cs2_texture_acquisition.md
+++ b/grimoire/intake/cs2_texture_acquisition.md
@@ -1,6 +1,10 @@
 # CS2 Texture Acquisition (optional exactness upgrade)
 
-This is **not** part of the default image-first path. It is an optional Tier-3 upgrade for exact
+**Step 1 (metadata) is a different, much cheaper ask than steps 2-3 and should generally be run
+by default** whenever a skin name is given or suspected — it needs no local game install, hits a
+public community index, and turns an "unknown" float/paint-seed in the spec into a measured one
+for free. Steps 2-3 (locating the user's VPK and extracting Valve's own authored textures) are
+**not** part of the default image-first path — that part is an optional Tier-3 upgrade for exact
 texture likeness, driven autonomously by the host agent from the **user's own legal CS2 install**.
 The user performs no manual step beyond, at most, pointing at the install / VPK path. If nothing is
 found the agent falls back to the image-only reconstruction — it never fabricates a wrong render.


### PR DESCRIPTION
## Summary
- Adds real `FamilyAdapter`s for sniper/rifle/smg/heavy/glove (`forge/stage2_spec/cs2_adapters.py`) and registers the full CS2 taxonomy (7 families, 62 subtypes) in the intake gate (`forge/stage1_intake/cs2_manifest.py`). AWP moves from an ad-hoc `rifle` family to its own `sniper` family, matching CS2's own Market category split from (semi-auto) rifles.
- `new_sculpt_spec.py`'s scaffold now dispatches a topology-appropriate starter component tree per family instead of always handing back knife parts (`root/blade/grip/guard/pommel/bolster`) for anything non-knife — hit this directly while building the AWP | Medusa showcase demo. Added `--family`/`--subtype` flags so `item_family` no longer silently defaults to `'knife'` when no `--manifest` is given; it now warns on stderr instead.
- Two pre-existing latent bugs surfaced and fixed along the way (both predate this PR, unrelated to the CS2 taxonomy work itself):
  - `cs2_adapters.py`'s pistol subtype set had silently drifted out of sync with `cs2_manifest.py`'s — verified all 7 families now match exactly between both files.
  - `cs2_manifest.py` had no `PROJECT_ROOT` sys.path setup, so its `from forge.X` imports only ever resolved via `-m` invocation or under pytest, never as a plain script.
- `SKILL.md` / `grimoire/intake/cs2_texture_acquisition.md`: full family/subtype table, and explicit guidance to run `fetch_cs2_metadata.py` by default for identity resolution (cheap, no local install needed) rather than leaving it lumped in with the optional Tier-3 VPK/texture-extraction upgrade.

Registering a family/subtype here only unblocks *intake* — it does not generate geometry. Only AWP (sniper) has been built against a real reference so far (see the AWP | Medusa demo in img2threejs-showcase); the rest are gate-registered scaffolds only, per this repo's own stated `FamilyAdapter` contract.

## Test plan
- [x] `python3 -m pytest forge/tests/ -q` — 274 passed, no regressions
- [x] Manually verified all 7 families' `--family`/`--subtype` scaffolds validate cleanly via `validate_sculpt_spec.py`
- [x] Verified `cs2_adapters.py` and `cs2_manifest.py` subtype sets match exactly across all families