### PR TITLE
fix: preserve full framing in comparison sheets

### DIFF
--- a/forge/stage4_review/make_comparison_sheet.py
+++ b/forge/stage4_review/make_comparison_sheet.py
@@ -155,24 +155,33 @@ def composite_over_checker(pixel: tuple[int, int, int, int], x: int, y: int) -> 
     )
 
 
-def resize_cover(
+def resize_contain(
     width: int,
     height: int,
     pixels: list[tuple[int, int, int, int]],
     target_w: int,
     target_h: int,
 ) -> list[tuple[int, int, int]]:
-    scale = max(target_w / width, target_h / height)
+    """Fit the full silhouette inside the panel without cropping acceptance evidence."""
+    scale = min(target_w / width, target_h / height)
     scaled_w = max(1, round(width * scale))
     scaled_h = max(1, round(height * scale))
-    offset_x = max(0, (scaled_w - target_w) // 2)
-    offset_y = max(0, (scaled_h - target_h) // 2)
-    output: list[tuple[int, int, int]] = []
-    for y in range(target_h):
-        source_y = min(height - 1, max(0, int((y + offset_y) / scale)))
-        for x in range(target_w):
-            source_x = min(width - 1, max(0, int((x + offset_x) / scale)))
-            output.append(composite_over_checker(pixels[source_y * width + source_x], x, y))
+    offset_x = (target_w - scaled_w) // 2
+    offset_y = (target_h - scaled_h) // 2
+    output = [
+        ((238, 238, 238) if ((x // 12 + y // 12) % 2 == 0) else (210, 210, 210))
+        for y in range(target_h)
+        for x in range(target_w)
+    ]
+    for y in range(scaled_h):
+        source_y = 0 if scaled_h == 1 else round(y * (height - 1) / (scaled_h - 1))
+        target_y = y + offset_y
+        for x in range(scaled_w):
+            source_x = 0 if scaled_w == 1 else round(x * (width - 1) / (scaled_w - 1))
+            target_x = x + offset_x
+            output[target_y * target_w + target_x] = composite_over_checker(
+                pixels[source_y * width + source_x], target_x, target_y
+            )
     return output
 
 
@@ -232,8 +241,8 @@ def create_sheet(
     fill_rect(canvas, canvas_w, gutter * 2 + panel_w, gutter, panel_w, header_h, (40, 45, 48))
     fill_rect(canvas, canvas_w, gutter, gutter + header_h, panel_w, panel_h, (230, 230, 230))
     fill_rect(canvas, canvas_w, gutter * 2 + panel_w, gutter + header_h, panel_w, panel_h, (230, 230, 230))
-    ref_panel = resize_cover(ref_w, ref_h, ref_pixels, panel_w, panel_h)
-    ren_panel = resize_cover(ren_w, ren_h, ren_pixels, panel_w, panel_h)
+    ref_panel = resize_contain(ref_w, ref_h, ref_pixels, panel_w, panel_h)
+    ren_panel = resize_contain(ren_w, ren_h, ren_pixels, panel_w, panel_h)
     blit(canvas, canvas_w, ref_panel, panel_w, gutter, gutter + header_h)
     blit(canvas, canvas_w, ren_panel, panel_w, gutter * 2 + panel_w, gutter + header_h)
     fill_rect(canvas, canvas_w, panel_w + gutter + gutter // 2, gutter, max(2, gutter // 5), canvas_h - gutter * 2, (170, 146, 92))

--- a/forge/tests/test_pipeline.py
+++ b/forge/tests/test_pipeline.py
@@ -9,6 +9,7 @@ Run: python3 forge/tests/test_pipeline.py   (from skill root)
   or: python3 -m unittest discover -s forge/tests
 """
 import json
+import runpy
 import struct
 import subprocess
 import sys
@@ -543,6 +544,21 @@ class PipelineTest(unittest.TestCase):
                 "--render", self.render, "--out", cmp, "--json")
         self.assertEqual(r.returncode, 0, r.stderr)
         self.assertTrue(cmp.exists() and cmp.stat().st_size > 0)
+
+    def test_comparison_sheet_preserves_wide_image_endpoints(self):
+        resize_contain = runpy.run_path(
+            str(SCRIPTS / "stage4_review" / "make_comparison_sheet.py")
+        )["resize_contain"]
+        pixels = [
+            (255, 0, 0, 255),
+            (0, 255, 0, 255),
+            (0, 255, 0, 255),
+            (0, 0, 255, 255),
+        ]
+        panel = resize_contain(4, 1, pixels, 4, 4)
+        self.assertEqual(panel[4], (255, 0, 0))
+        self.assertEqual(panel[7], (0, 0, 255))
+        self.assertEqual(panel[0], (238, 238, 238))
 
     def test_append_review_gate_and_record(self):
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)


### PR DESCRIPTION
## What changed

- Fit reference and render images inside comparison panels without cropping.
- Center letterboxed images over the existing checkerboard treatment.
- Add a regression test proving both endpoints of an extreme-aspect-ratio image remain visible.

## Why

`make_comparison_sheet.py` used cover-style scaling (`max(...)`), so any source whose aspect ratio differed from the square review panel was cropped. For long objects this can remove the silhouette endpoints that the acceptance sheet is supposed to expose.

I reproduced this while reviewing a wide sword reconstruction: the old sheet showed only a magnified strip of the reference blade, while the patched sheet retained the pommel, guard, and tip alongside the complete render. This affects review evidence only; scoring and image decoding are unchanged.

## Root cause

The resize scale was chosen to fill both panel dimensions. The larger scale necessarily overflowed one axis, and the sampling offsets intentionally discarded that overflow.

The new contain-style scale uses the smaller ratio, centers the result, and maps the first and last destination samples to the source endpoints.

## Verification

- `python -m unittest forge.tests.test_pipeline.PipelineTest.test_comparison_sheet_preserves_wide_image_endpoints forge.tests.test_pipeline.PipelineTest.test_comparison_sheet_packages_without_scoring` — 2 passed.
- `PYTHONUTF8=1 python -m unittest discover -s forge/tests` — 261 passed; 3 pre-existing Windows-only setup errors require symlink privilege (`WinError 1314`). The changed comparison-sheet tests pass, and CI runs on Ubuntu.
- `git diff --check` — passed.

Refs #72
