### PR TITLE
tier1: pixel-evidence fallback for small hue-distinct parts in per_part_color_delta

### DIFF
--- a/forge/stage4_review/diagnose_render.py
+++ b/forge/stage4_review/diagnose_render.py
@@ -134,10 +134,25 @@ def bilateral_symmetry_error(mask: list[bool], size: int = MASK_GRID_SIZE) -> fl
     return mismatches / total if total else 0.0
 
 
+PIXEL_EVIDENCE_DELTA_E = 15.0
+PIXEL_EVIDENCE_MIN_FRACTION = 0.0025
+
+
 def per_part_color_delta(recipes: list[dict[str, Any]], render_path: Path) -> dict[str, Any]:
     """Compares each component's colorMaterialRecipe against the render's overall
     dominant Lab-space color clusters (see module docstring for the per-component-
-    region scope limitation). Returns per-recipe delta-E and a pass/fail summary."""
+    region scope limitation). Returns per-recipe delta-E and a pass/fail summary.
+
+    Small-part fallback: the k-means palette seeds its centroids from luminance
+    quantiles, so a hue-distinct part covering little area (a teal arc, a logo, a
+    gem) can never win a centroid against a dominant material at similar
+    luminance — the cluster comparison then reports a large delta even though the
+    recipe's color is plainly present in the render. Per Risk R7 this check only
+    needs to catch gross mismatches, so a recipe also passes when at least
+    PIXEL_EVIDENCE_MIN_FRACTION of foreground pixels sit within
+    PIXEL_EVIDENCE_DELTA_E of it: direct pixel evidence, reported per component
+    as pixelEvidenceFraction, with clusterDeltaE preserving the raw cluster
+    distance for the record."""
     if not recipes:
         return {"checked": 0, "maxDeltaE": 0.0, "perComponent": []}
     width, height, pixels, _warnings = load_image(render_path)
@@ -156,7 +171,17 @@ def per_part_color_delta(recipes: list[dict[str, Any]], render_path: Path) -> di
             continue
         expected_lab = srgb_to_lab((r, g, b))
         best_delta = min((lab_distance(expected_lab, c["center"]) for c in clusters), default=999.0)
-        results.append({"componentId": recipe.get("componentId"), "deltaE": round(best_delta, 2)})
+        entry: dict[str, Any] = {"componentId": recipe.get("componentId"), "clusterDeltaE": round(best_delta, 2)}
+        if best_delta > COLOR_DELTA_E_THRESHOLD and foreground_lab:
+            supporting = sum(
+                1 for sample in foreground_lab if lab_distance(expected_lab, sample) <= PIXEL_EVIDENCE_DELTA_E
+            )
+            fraction = supporting / len(foreground_lab)
+            entry["pixelEvidenceFraction"] = round(fraction, 5)
+            if fraction >= PIXEL_EVIDENCE_MIN_FRACTION:
+                best_delta = PIXEL_EVIDENCE_DELTA_E
+        entry["deltaE"] = round(best_delta, 2)
+        results.append(entry)
     max_delta = max((entry["deltaE"] for entry in results), default=0.0)
     return {"checked": len(results), "maxDeltaE": round(max_delta, 2), "perComponent": results}
 

--- a/forge/tests/test_tier1_diagnostics.py
+++ b/forge/tests/test_tier1_diagnostics.py
@@ -12,9 +12,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "stage4_review"))
 
 from diagnose_render import (  # noqa: E402
+    PIXEL_EVIDENCE_DELTA_E,
     bbox_of,
     bilateral_symmetry_error,
     color_is_gated,
+    per_part_color_delta,
     proportion_delta,
     silhouette_iou,
 )
@@ -107,3 +109,59 @@ class BboxOfTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class SmallPartPixelEvidenceTest(unittest.TestCase):
+    """A hue-distinct small part must pass via direct pixel evidence even when
+    the luminance-seeded k-means palette gives every centroid to the dominant
+    material (the false-positive this fallback exists for)."""
+
+    def _write_png(self, path, width, height, painter):
+        sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "stage1_intake"))
+        from extract_pbr_evidence import write_png_rgb
+        rgb = bytearray()
+        for y in range(height):
+            for x in range(width):
+                rgb.extend(painter(x, y))
+        write_png_rgb(path, width, height, bytes(rgb))
+
+    def test_small_teal_region_passes_by_pixel_evidence(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            render = Path(tmp) / "render.png"
+            # Five warm luminance bands absorb all five k-means seeds (the
+            # luminance-quantile init); a ~1.6% teal patch then cannot win a
+            # centroid and must pass through the pixel-evidence fallback.
+            golds = [(120, 90, 30), (160, 120, 45), (200, 155, 60), (225, 185, 90), (245, 215, 130)]
+            def painter(x, y):
+                if 8 <= x < 56 and 8 <= y < 56:
+                    if 30 <= x < 36 and 30 <= y < 36:
+                        return (46, 127, 110)   # teal part
+                    return golds[min(4, (y - 8) // 10)]
+                return (16, 16, 16)             # background
+            self._write_png(render, 64, 64, painter)
+            recipes = [
+                {"componentId": f"gold-{i}", "dominantAlbedo": f"rgba({g[0]}, {g[1]}, {g[2]}, 1)"}
+                for i, g in enumerate(golds)
+            ] + [{"componentId": "teal-arc", "dominantAlbedo": "rgba(46, 127, 110, 1)"}]
+            report = per_part_color_delta(recipes, render)
+            by_id = {e["componentId"]: e for e in report["perComponent"]}
+            teal = by_id["teal-arc"]
+            self.assertGreater(teal["clusterDeltaE"], 20.0)   # the false-positive this guards
+            self.assertIn("pixelEvidenceFraction", teal)
+            self.assertGreater(teal["pixelEvidenceFraction"], 0.001)
+            self.assertLessEqual(teal["deltaE"], PIXEL_EVIDENCE_DELTA_E)
+            self.assertLessEqual(report["maxDeltaE"], 20.0)
+
+    def test_absent_color_still_fails(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            render = Path(tmp) / "render.png"
+            def painter(x, y):
+                if 8 <= x < 56 and 8 <= y < 56:
+                    return (200, 155, 60)
+                return (16, 16, 16)
+            self._write_png(render, 64, 64, painter)
+            recipes = [{"componentId": "ghost", "dominantAlbedo": "rgba(46, 127, 210, 1)"}]
+            report = per_part_color_delta(recipes, render)
+            self.assertGreater(report["maxDeltaE"], 20.0)


### PR DESCRIPTION
Refs #76. Contribution intent: #77.

## Behavior change

`per_part_color_delta` gains a direct pixel-evidence fallback for the false-reject class described in #76: `lab_kmeans_palette` seeds centroids from luminance quantiles, so a small hue-distinct part (teal arc on a gold coin, a logo, a gem) can never win a global cluster and the gated check fails from `material-pass` onward regardless of the recipe value.

With this change, when a recipe's nearest-cluster distance exceeds `COLOR_DELTA_E_THRESHOLD`, the check counts foreground pixels within `PIXEL_EVIDENCE_DELTA_E` (15) of the recipe color. At or above `PIXEL_EVIDENCE_MIN_FRACTION` (0.25% of foreground) the recipe is supported by direct pixel evidence and scores at the fallback delta. The record stays honest: per-component output now carries `clusterDeltaE` (raw cluster distance, unchanged semantics) and `pixelEvidenceFraction`; a recipe color absent from the render still fails.

Scope intentionally excluded (per #77): no change to `lab_kmeans_palette` (shared with intake), no Divine Eye changes (#18's territory), no schema or threshold changes elsewhere. `deltaE`/`maxDeltaE` keep their meaning, so existing tier1 consumers and specs are unaffected.

## How verified

- New `SmallPartPixelEvidenceTest` in `forge/tests/test_tier1_diagnostics.py`:
  - five warm luminance bands absorb all five k-means seeds; a 1.6% teal patch asserts `clusterDeltaE > 20` (reproduces the bug on main), carries `pixelEvidenceFraction`, and passes via the fallback;
  - an absent color still fails (`maxDeltaE > 20`).
- Full suite from skill root: `python3 -m unittest discover -s forge/tests -p 'test_*.py'` -> 675 tests OK, 25 skipped (showcase TypeScript gates without `IMG2THREEJS_SHOWCASE_ROOT`, as documented).
- Real reconstruction (Casascius coin, 14 components, gold-dominant): tier1 material-pass goes from `max per-part color delta-E 57.85` hard fail to pass, with the three small parts (teal arc, cyan guilloche, violet glitter patch) reporting pixel fractions 0.003-0.016; their colors are visibly present in the render. Silhouette gates unaffected (IoU 0.986, scale delta 0.0 before and after).

Authored with Claude Code (AI-assisted; commit carries co-author trailer). Happy to adjust thresholds or naming per triage.
