### PR TITLE
feat: add reference-motion reconstruction skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Gates      Run --strict-quality, and do not advance a pass until the side-by-sid
 
 Useful additions depending on the subject:
 
+- **A video or image-sequence reference** — `Measure the exact interval at native resolution and
+  frame rate first. Separate camera, geometry, material, reflection, and overlay motion with the
+  reconstruct-reference-motion companion skill before editing the model.`
 - **A specific person or character** — `Maximize likeness: fit the parametric template to the landmarks, de-light and camera-match the reference, then project it. Tell me which regions are inferred.`
 - **An animal or creature** — `This is a creature, not a humanoid — use the quadruped body plan and the body-unit proportion system.`
 - **A saturated anodized or candy finish** — `The coat is candy-coat, not gem-metal. Keep the hue; do not let the environment steal it.`

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,6 +31,11 @@ The user attaches/points to an object image and wants a procedural Three.js mode
 reconstruction/animation/destruction plan, a sculpt spec, or code. Also for material studies,
 action-ready props, game objects, botanical/mechanical parts, and stylized reconstructions.
 
+For a video or image-sequence reference, or any request to mirror motion, reflections, or morphing
+frame by frame, MUST read `skills/reconstruct-reference-motion/SKILL.md` before image analysis and
+validate its motion manifest before implementation. That companion adds temporal evidence; it does
+not bypass this skill's state, build-pass, or visual-review gates.
+
 ## Core Promise
 
 Sculpt from a photo, in order — never one-shot a mesh:

--- a/forge/tests/test_reference_motion_skill.py
+++ b/forge/tests/test_reference_motion_skill.py
@@ -1,0 +1,155 @@
+"""Contracts for the reconstruct-reference-motion companion skill."""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL_ROOT = ROOT / "skills" / "reconstruct-reference-motion"
+VALIDATOR_PATH = SKILL_ROOT / "scripts" / "validate_motion_manifest.py"
+EXAMPLE_PATH = SKILL_ROOT / "references" / "example-motion-manifest.json"
+SCHEMA_PATH = SKILL_ROOT / "references" / "reference-motion-manifest.schema.json"
+
+
+def load_validator():
+    spec = importlib.util.spec_from_file_location("validate_motion_manifest", VALIDATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("could not load motion-manifest validator")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+VALIDATOR = load_validator()
+
+
+class ReferenceMotionSkillTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.example = json.loads(EXAMPLE_PATH.read_text(encoding="utf-8"))
+
+    def error_codes(self, manifest: dict) -> set[str]:
+        return {error["code"] for error in VALIDATOR.validate_manifest(manifest)}
+
+    def test_example_manifest_is_valid(self) -> None:
+        self.assertEqual(VALIDATOR.validate_manifest(self.example), [])
+
+        result = subprocess.run(
+            [sys.executable, str(VALIDATOR_PATH), str(EXAMPLE_PATH), "--json"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertTrue(payload["valid"])
+        self.assertEqual(payload["preImplementationDecision"], "ready-for-implementation")
+        self.assertEqual(payload["rootReviewDecision"], "refine-spec")
+
+    def test_every_frame_request_rejects_sampled_analysis(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["source"]["analysisCoverage"] = "sampled"
+        manifest["source"]["samplingRule"] = "every tenth frame"
+        self.assertIn("COVERAGE", self.error_codes(manifest))
+
+    def test_frame_source_points_use_original_frame_bounds(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["frames"][0]["observed"]["features"][0]["sourcePoints"] = [[641, 12]]
+        self.assertIn("BOUNDS", self.error_codes(manifest))
+
+    def test_non_equivalent_features_must_be_proxy_metrics(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["comparison"]["classification"] = "like-for-like"
+        self.assertIn("FEATURE_IDENTITY", self.error_codes(manifest))
+
+    def test_first_implementation_can_start_before_a_render_exists(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["comparison"] = {"status": "not-run"}
+        manifest["rootReviewDecision"] = {"status": "not-run"}
+        self.assertEqual(VALIDATOR.validate_manifest(manifest), [])
+
+    def test_not_run_phase_rejects_stale_comparison_and_review_fields(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["comparison"] = {"status": "not-run", "metrics": []}
+        manifest["rootReviewDecision"] = {"status": "not-run", "action": "continue"}
+        codes = self.error_codes(manifest)
+        self.assertIn("STALE_COMPARISON", codes)
+        self.assertIn("STALE_REVIEW", codes)
+
+    def test_comparison_and_root_review_phase_must_match(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["rootReviewDecision"] = {"status": "not-run"}
+        self.assertIn("PHASE_MISMATCH", self.error_codes(manifest))
+
+    def test_stable_bootstrap_frame_must_lie_in_stable_interval(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["source"]["bootstrapReferenceFrame"]["selectionRule"] = "stable-hold-midpoint"
+        manifest["source"]["bootstrapReferenceFrame"]["timestampSeconds"] = 1.0
+        self.assertIn("BOOTSTRAP_SELECTION", self.error_codes(manifest))
+
+    def test_interval_bootstrap_frame_uses_nearest_midpoint_with_earlier_tie(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["frames"] = [manifest["frames"][0], manifest["frames"][2]]
+        manifest["source"]["frameCount"] = 2
+        manifest["source"]["bootstrapReferenceFrame"]["timestampSeconds"] = 1.0666666667
+        self.assertIn("BOOTSTRAP_SELECTION", self.error_codes(manifest))
+
+        manifest["source"]["bootstrapReferenceFrame"]["timestampSeconds"] = 1.0
+        self.assertNotIn("BOOTSTRAP_SELECTION", self.error_codes(manifest))
+
+    def test_completed_root_review_requires_prior_implementation_readiness(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["preImplementationDecision"]["action"] = "stop"
+        self.assertIn("PHASE_MISMATCH", self.error_codes(manifest))
+
+    def test_completed_comparison_must_be_synchronized_and_camera_matched(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["comparison"]["synchronizedTimes"] = False
+        manifest["comparison"]["cameraMatched"] = False
+        self.assertIn("COMPARISON_ALIGNMENT", self.error_codes(manifest))
+
+    def test_single_view_high_confidence_requires_calibration(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        inferred = manifest["frames"][0]["inferred"]["properties"][0]
+        inferred["confidence"] = 0.9
+        self.assertIn("SINGLE_VIEW_CONFIDENCE", self.error_codes(manifest))
+
+        inferred["calibrationEvidence"] = ["known chrome-ball calibration target"]
+        self.assertNotIn("SINGLE_VIEW_CONFIDENCE", self.error_codes(manifest))
+
+    def test_ready_decision_requires_stable_interval_and_visual_evidence(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["intervals"][0]["classification"] = "transition"
+        del manifest["evidence"]["annotatedKeyframes"]
+        codes = self.error_codes(manifest)
+        self.assertIn("READINESS", codes)
+
+    def test_timestamps_must_be_strictly_increasing(self) -> None:
+        manifest = copy.deepcopy(self.example)
+        manifest["frames"][1]["timestampSeconds"] = manifest["frames"][0]["timestampSeconds"]
+        self.assertIn("ORDER", self.error_codes(manifest))
+
+    def test_skill_and_schema_are_reachable_and_machine_readable(self) -> None:
+        skill_text = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+        companion_text = (SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")
+        scripts_text = (ROOT / "grimoire" / "scripts.md").read_text(encoding="utf-8")
+        relative_skill = "skills/reconstruct-reference-motion/SKILL.md"
+        relative_validator = "skills/reconstruct-reference-motion/scripts/validate_motion_manifest.py"
+        self.assertIn(relative_skill, skill_text)
+        self.assertIn(relative_validator, scripts_text)
+        self.assertTrue(companion_text.startswith("---\nname: reconstruct-reference-motion\ndescription: "))
+        self.assertEqual(companion_text.count("\n---\n"), 1)
+        frontmatter = companion_text.split("\n---\n", 1)[0]
+        self.assertNotIn("TODO", companion_text)
+        self.assertNotIn("metadata:", frontmatter)
+        self.assertEqual(json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))["title"], "Reference motion manifest")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoire/scripts.md
+++ b/grimoire/scripts.md
@@ -43,6 +43,15 @@ material/PBR evidence decision. A non-applicable conditional gate must be skippe
 `stage1_intake/probe_image.py <image>` — image type, dimensions, aspect ratio, obvious technical
 issues. Metadata only; not a substitute for visual inspection.
 
+## reconstruct-reference-motion manifest gate
+
+`skills/reconstruct-reference-motion/scripts/validate_motion_manifest.py <manifest.json> [--json]`
+validates the companion video/image-sequence measurement hand-off. It blocks sampled analysis from
+passing an every-frame request, out-of-frame source coordinates, mixed-up feature equivalence,
+single-view overconfidence without calibration, unsynchronized comparisons, and implementation
+readiness without stable-interval and annotated-frame evidence. It packages evidence only; agent
+vision must still inspect the annotated frames and source motion.
+
 ## stage2_spec/new_pre_spec_assessment.py
 `stage2_spec/new_pre_spec_assessment.py "Name" [--image IMG] [--complexity simple|moderate|complex|ultra-complex] --out assessment.json [--force]`
 Emits a pre-spec assessment + `qualityContract` skeleton. Refine `--complexity` after looking at

--- a/skills/reconstruct-reference-motion/SKILL.md
+++ b/skills/reconstruct-reference-motion/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: reconstruct-reference-motion
+description: Measure and reproduce motion from a video or image sequence before implementing it in procedural Three.js. Use when a user asks to mirror an animation frame by frame, reconstruct camera/object/light motion, match moving reflections or caustics, compare a live Three.js animation with a reference video, or fix a 3D object that reads as a flat animated texture.
+---
+
+# Reconstruct Reference Motion
+
+Use this companion skill with the root `img2threejs` skill. Add temporal evidence to the existing
+intake, build, and review gates; do not bypass them.
+
+## Non-negotiable rule
+
+Measure before editing the model or shader. Keep these systems separate throughout the solve:
+
+1. camera/framing motion;
+2. object geometry and pose;
+3. material response;
+4. direct light and environment reflections;
+5. UI, labels, arcs, dots, and other overlays.
+
+A moving highlight is not proof that the mesh moves. A stable silhouette is not proof that the
+camera is static. A texture atlas containing baked light is not a substitute for dynamic specular
+response when the reference shows independent light motion.
+
+## Required reading and artifacts
+
+Read [references/measurement-contract.md](references/measurement-contract.md) completely before
+analyzing frames. Use
+[references/reference-motion-manifest.schema.json](references/reference-motion-manifest.schema.json)
+as the machine-readable hand-off. Start from
+[references/example-motion-manifest.json](references/example-motion-manifest.json) when useful.
+
+Produce, at minimum:
+
+- a source probe with dimensions, frame rate, duration, color metadata, and source hash;
+- a contact sheet confirming the exact interval and all semantic transitions;
+- a `reference-motion-manifest.json` that separates observed values from inferred properties;
+- annotated keyframes with source-coordinate overlays;
+- a synchronized reference-versus-render comparison when a render exists, otherwise an explicit
+  `not-run` comparison state;
+- one explicit `preImplementationDecision`: `ready-for-implementation`, `refine-analysis`,
+  `request-input`, or `stop`;
+- a separate `rootReviewDecision`, initially `not-run` and completed after a live render exists.
+
+## Workflow
+
+### 1. Resume the parent pipeline
+
+If `.img2threejs/state.json` does not exist, perform only the minimal source probe needed to extract
+one representative frame at native resolution. Use the requested interval's temporal midpoint,
+rounded to the nearest native frame with ties resolved earlier. If a minimal contact sheet shows
+that frame is transitional, occluded, or does not identify the subject, use the midpoint of the
+first stable or hold interval instead. Use a manual semantic keyframe only when neither rule works,
+and record why in `source.bootstrapReferenceFrame`. Then initialize the parent state from that
+source frame:
+
+```bash
+python3 forge/state.py init \
+  --state .img2threejs/state.json \
+  --reference <representative-source-frame> \
+  --profile <generic|cs2|character>
+```
+
+Do not initialize from the current render, generated atlas, or comparison image unless it is itself
+the user's authoritative reference. Then run the root state gate before substantive analysis:
+
+```bash
+python3 forge/next.py --state .img2threejs/state.json
+```
+
+If it reports a hard stop, stop. Record the validated motion manifest as intake evidence; chat
+history is not evidence.
+
+### 2. Lock the source and interval
+
+Download or copy the exact source locally, hash it, and probe it. Decode the selected interval at
+the original dimensions and native frame rate. Do not resize, smooth, interpolate, or silently skip
+frames. If performance requires sampling, label the result `sampled` and do not claim frame-complete
+analysis.
+
+Verify semantic endpoints from the pixels. Do not trust a spoken label such as “90 to 60” until the
+frames show those values. Preserve absolute source coordinates even when an ROI is used for focused
+measurement.
+
+### 3. Segment independent motion systems
+
+Create one system record per independently moving or shaded element. Typical systems are:
+
+- silhouette or projected boundary;
+- camera/gauge center and apparent scale;
+- object rotation/deformation;
+- point highlight or caustic;
+- broad environment strip/rim;
+- fixed overlay arcs, ticks, dots, numerals, and labels.
+
+Do not merge two systems because they share a color. Do not track a dot sequence as animation unless
+the frames show its position or visibility changing.
+
+### 4. Record observed image evidence
+
+For every decoded frame, record timestamps and feature measurements in source-pixel coordinates.
+Store local ROI coordinates only as a secondary convenience. Include confidence, fit residuals, and
+feature identity. Work in linear color for luminance or lighting calculations and record the transfer
+function used.
+
+Keep dense maps as external evidence files referenced by hash; do not inflate the JSON with one row
+per pixel.
+
+### 5. Infer conditional 3D quantities
+
+Only infer camera pose, depth, normals, light direction, roughness, or falloff after observed values
+exist. Put assumptions and confidence beside every inferred property. A single view of reflective or
+transmissive material is non-unique; cap confidence unless calibration, known geometry, or multiple
+views resolve the ambiguity.
+
+When using a spherical specular approximation with view vector `V` and observed surface normal `N`,
+record the convention and equation explicitly, for example:
+
+```text
+L = normalize(2 * dot(N, V) * N - V)
+```
+
+Treat this as a reconstruction target, not recovered ground truth.
+
+### 6. Remove camera motion before interpreting surface motion
+
+Register the silhouette or another stable geometric feature first. Report both raw feature motion
+and camera-compensated motion. Use normalized object coordinates when apparent scale changes.
+
+Classify intervals such as `transition`, `stable`, `morph`, and `hold`. Report stable-state metrics
+separately when an entrance transition would distort velocity or direction estimates.
+
+### 7. Validate the manifest
+
+Run:
+
+```bash
+python3 skills/reconstruct-reference-motion/scripts/validate_motion_manifest.py \
+  reference-motion-manifest.json --json
+```
+
+Fix every error. Structural validity does not grant implementation readiness; the pre-implementation
+manifest decision must also be `ready-for-implementation`. A first implementation may begin with
+`comparison.status: not-run` and `rootReviewDecision.status: not-run`; neither object may retain
+fields from a completed comparison. Update both to `complete` after capturing the live render.
+
+### 8. Choose the correct Three.js representation
+
+- Use geometry/camera transforms for silhouette, pose, or parallax changes.
+- Use independent lights, environment maps, normals, roughness, transmission, or a custom physical
+  shader for view-dependent reflection motion.
+- Use texture atlases for genuinely baked, view-independent appearance only.
+- Keep UI overlays in their own geometry or render layer and bind them to the same measured path.
+
+If a reference feature has no equivalent in the current render, mark the comparison as `proxy`.
+Never publish its angular or pixel error as a like-for-like metric.
+
+### 9. Reconstruct one system at a time
+
+Implement in this order unless evidence requires another dependency order:
+
+1. camera and projected boundary;
+2. rigid pose or deformation;
+3. material and environment response;
+4. direct highlight/caustic motion;
+5. overlays and labels.
+
+After each system, capture the same timestamps from the live Three.js route and compare them against
+the source. Do not tune several systems at once; that makes causality unreadable.
+
+### 10. Review temporal fidelity
+
+Compare synchronized frames using the same crop, coordinate convention, camera, and feature identity.
+Report boundary residual, camera-registered feature-path error, angular-path error where justified,
+luminance/softness curves, phase error, flicker, and hold stability. Inspect the video as motion; a
+good still frame cannot pass a temporal gate.
+
+After a render exists, update the comparison to `complete`, record exactly one action under
+`rootReviewDecision`, validate again, and return that root img2threejs review action:
+
+- `continue` only when the temporal contract and the normal img2threejs pass gates both pass;
+- `refine-spec` when tracking, registration, feature identity, or the temporal contract is wrong;
+- `refine-code` when the measurement contract is sound but the renderer differs;
+- `request-input` when the source or interval cannot support the requested inference;
+- `stop` when the requested one-to-one result is not feasible under the stated constraints.
+
+Preserve the pre-implementation decision as phase history. Before rendering, a bad track maps to
+`refine-analysis`; after rendering, discovering that the track or feature identity was wrong maps
+to `refine-spec`. The later root review does not overwrite the earlier analysis decision.
+
+## Hard stops
+
+Stop rather than implement when any of these is true:
+
+- the exact source or interval is unavailable;
+- frames were skipped or resampled but the user requested frame-complete analysis;
+- observed and inferred fields are mixed;
+- camera motion has not been separated from the tracked surface feature;
+- a current render lacks a feature equivalent but its completed comparison is labelled exact;
+- single-view inverse-lighting output is presented without assumptions and confidence;
+- the parent img2threejs state gate is blocked.
+
+## Reporting
+
+State what was measured, what was inferred, the coordinate spaces, the stable interval, confidence,
+unresolved ambiguity, pre-implementation decision, and post-render root review when applicable.
+Name what still differs. Never say “matched one-to-one” from visual impression alone.

--- a/skills/reconstruct-reference-motion/references/example-motion-manifest.json
+++ b/skills/reconstruct-reference-motion/references/example-motion-manifest.json
@@ -1,0 +1,237 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "kind": "video",
+    "sourceHashSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "width": 640,
+    "height": 480,
+    "fps": 30.0,
+    "frameCount": 3,
+    "intervalSeconds": [1.0, 1.0666666667],
+    "decodePolicy": "original-resolution-no-resample",
+    "requestedCoverage": "every-frame",
+    "analysisCoverage": "every-frame",
+    "bootstrapReferenceFrame": {
+      "timestampSeconds": 1.0333333333,
+      "selectionRule": "interval-midpoint",
+      "reason": "Nearest native frame to the requested interval midpoint."
+    },
+    "viewCount": 1,
+    "colorSpace": "sRGB",
+    "transferFunction": "sRGB EOTF to linear-light RGB",
+    "measurementRoi": {
+      "x": 160,
+      "y": 40,
+      "width": 320,
+      "height": 320
+    }
+  },
+  "systems": [
+    {
+      "id": "camera-registration",
+      "class": "camera",
+      "observedFeature": "projected boundary center and scale"
+    },
+    {
+      "id": "orb-boundary",
+      "class": "silhouette",
+      "observedFeature": "ellipse boundary"
+    },
+    {
+      "id": "cyan-key",
+      "class": "lighting",
+      "observedFeature": "cyan highlight centroid"
+    },
+    {
+      "id": "silver-rim",
+      "class": "lighting",
+      "observedFeature": "broad neutral environment strip"
+    },
+    {
+      "id": "bottom-dots",
+      "class": "overlay",
+      "observedFeature": "fixed dotted arc"
+    }
+  ],
+  "frames": [
+    {
+      "index": 0,
+      "timestampSeconds": 1.0,
+      "observed": {
+        "features": [
+          {
+            "systemId": "camera-registration",
+            "featureId": "ellipse-center",
+            "sourcePoints": [[320.0, 210.0]],
+            "confidence": 0.96,
+            "fitResidualPx": 0.9,
+            "measurements": { "radiusX": 148.0, "radiusY": 158.0 }
+          },
+          {
+            "systemId": "orb-boundary",
+            "featureId": "cardinal-contour-points",
+            "sourcePoints": [[172.0, 210.0], [320.0, 52.0], [468.0, 210.0], [320.0, 368.0]],
+            "confidence": 0.94,
+            "fitResidualPx": 0.9
+          },
+          {
+            "systemId": "cyan-key",
+            "featureId": "highlight-centroid",
+            "sourcePoints": [[316.0, 91.0]],
+            "confidence": 0.91,
+            "measurements": { "linearLuminance": 0.48, "softnessRadiusPx": 2.1 }
+          }
+        ]
+      },
+      "inferred": {
+        "properties": [
+          {
+            "systemId": "cyan-key",
+            "property": "light-direction-camera",
+            "value": [-0.08, 0.71, 0.70],
+            "units": "unit-vector",
+            "confidence": 0.35,
+            "assumptions": ["unit sphere", "orthographic view vector", "mirror-like point highlight"]
+          }
+        ]
+      }
+    },
+    {
+      "index": 1,
+      "timestampSeconds": 1.0333333333,
+      "observed": {
+        "features": [
+          {
+            "systemId": "camera-registration",
+            "featureId": "ellipse-center",
+            "sourcePoints": [[319.0, 210.0]],
+            "confidence": 0.96,
+            "fitResidualPx": 0.8,
+            "measurements": { "radiusX": 148.0, "radiusY": 158.0 }
+          },
+          {
+            "systemId": "orb-boundary",
+            "featureId": "cardinal-contour-points",
+            "sourcePoints": [[171.0, 210.0], [319.0, 52.0], [467.0, 210.0], [319.0, 368.0]],
+            "confidence": 0.94,
+            "fitResidualPx": 0.8
+          },
+          {
+            "systemId": "cyan-key",
+            "featureId": "highlight-centroid",
+            "sourcePoints": [[313.0, 91.0]],
+            "confidence": 0.92,
+            "measurements": { "linearLuminance": 0.51, "softnessRadiusPx": 2.0 }
+          }
+        ]
+      },
+      "inferred": {
+        "properties": [
+          {
+            "systemId": "cyan-key",
+            "property": "light-direction-camera",
+            "value": [-0.11, 0.70, 0.70],
+            "units": "unit-vector",
+            "confidence": 0.36,
+            "assumptions": ["unit sphere", "orthographic view vector", "mirror-like point highlight"]
+          }
+        ]
+      }
+    },
+    {
+      "index": 2,
+      "timestampSeconds": 1.0666666667,
+      "observed": {
+        "features": [
+          {
+            "systemId": "camera-registration",
+            "featureId": "ellipse-center",
+            "sourcePoints": [[318.0, 210.0]],
+            "confidence": 0.96,
+            "fitResidualPx": 0.8,
+            "measurements": { "radiusX": 148.0, "radiusY": 158.0 }
+          },
+          {
+            "systemId": "orb-boundary",
+            "featureId": "cardinal-contour-points",
+            "sourcePoints": [[170.0, 210.0], [318.0, 52.0], [466.0, 210.0], [318.0, 368.0]],
+            "confidence": 0.94,
+            "fitResidualPx": 0.8
+          },
+          {
+            "systemId": "cyan-key",
+            "featureId": "highlight-centroid",
+            "sourcePoints": [[310.0, 91.0]],
+            "confidence": 0.92,
+            "measurements": { "linearLuminance": 0.53, "softnessRadiusPx": 1.9 }
+          }
+        ]
+      },
+      "inferred": {
+        "properties": [
+          {
+            "systemId": "cyan-key",
+            "property": "light-direction-camera",
+            "value": [-0.14, 0.70, 0.70],
+            "units": "unit-vector",
+            "confidence": 0.36,
+            "assumptions": ["unit sphere", "orthographic view vector", "mirror-like point highlight"]
+          }
+        ]
+      }
+    }
+  ],
+  "intervals": [
+    {
+      "id": "stable-glass",
+      "classification": "stable",
+      "startSeconds": 1.0,
+      "endSeconds": 1.0666666667,
+      "notes": "Boundary remains stable while the cyan key moves left."
+    }
+  ],
+  "comparison": {
+    "status": "complete",
+    "referenceFeatureId": "cyan-key:highlight-centroid",
+    "renderFeatureId": "orb-material:broad-upper-highlight",
+    "featureEquivalent": false,
+    "classification": "proxy",
+    "synchronizedTimes": true,
+    "cameraMatched": true,
+    "metrics": [
+      { "name": "direction-angular-rmse", "value": 88.4, "units": "degrees" }
+    ],
+    "metricInterpretation": "Structural direction mismatch proxy; the render lacks an isolated cyan point-key equivalent."
+  },
+  "evidence": {
+    "contactSheet": {
+      "path": "evidence/contact-sheet.png",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    "annotatedKeyframes": {
+      "path": "evidence/annotated-keyframes.png",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  },
+  "preImplementationDecision": {
+    "action": "ready-for-implementation",
+    "reasons": [
+      "Every requested source frame was measured at original resolution.",
+      "Camera and cyan-key motion are separated in source coordinates."
+    ],
+    "unresolvedAmbiguities": [
+      "Single-view rough-glass inverse lighting is non-unique.",
+      "The current render has no like-for-like cyan point-key feature."
+    ]
+  },
+  "rootReviewDecision": {
+    "status": "complete",
+    "action": "refine-spec",
+    "reasons": [
+      "The current render lacks an equivalent isolated cyan point-key feature, so the temporal target must be corrected before code tuning."
+    ],
+    "unresolvedAmbiguities": [
+      "Single-view rough-glass inverse lighting remains non-unique."
+    ]
+  }
+}

--- a/skills/reconstruct-reference-motion/references/measurement-contract.md
+++ b/skills/reconstruct-reference-motion/references/measurement-contract.md
@@ -1,0 +1,182 @@
+# Reference Motion Measurement Contract
+
+## Contents
+
+1. Evidence boundary
+2. Coordinate and frame contract
+3. Motion-system decomposition
+4. Observed and inferred records
+5. Camera registration
+6. Reflection and lighting inference
+7. Comparison contract
+8. Acceptance gate
+
+## 1. Evidence boundary
+
+Treat the decoded source pixels as the visual authority. Preserve the exact local source and its
+SHA-256 hash. Record probe output separately from interpretation.
+
+An every-frame claim requires all frames in the selected interval at native frame rate. A sampled
+analysis must identify its sampling rule and may guide exploration, but it cannot pass an explicit
+frame-complete request.
+
+Do not commit private or copyrighted source media to a public repository. Store paths and hashes in
+local evidence. Use synthetic fixtures in tests.
+
+## 2. Coordinate and frame contract
+
+Use `source-pixels` as the primary 2D coordinate space:
+
+- origin: upper-left of the original decoded frame;
+- x: right-positive;
+- y: down-positive;
+- bounds: `0 <= x < width`, `0 <= y < height`.
+
+An ROI may accelerate analysis, but preserve its `(x, y, width, height)` in source coordinates and
+emit absolute source points. Never report ROI-local positions as full-frame coordinates.
+
+Keep timestamps in seconds from the source timeline, not from the start of an extracted clip. Keep
+frame indexes monotonic. Record native width, height, frame rate, frame count, color space, transfer
+function, and any tone mapping detected or assumed.
+
+Choose the parent-pipeline bootstrap frame deterministically. Default to the temporal midpoint of
+the requested interval, rounded to the nearest native frame with ties resolved toward the earlier
+frame. If a minimal contact sheet shows that frame is transitional, occluded, or does not identify
+the subject, use the midpoint of the first stable or hold interval with the same tie rule. Use
+`manual-semantic-keyframe` only when neither midpoint is representative. Record the timestamp,
+selection rule, and reason under `source.bootstrapReferenceFrame`. The frame must come from the
+authoritative source, never from a generated atlas, current render, or comparison composite.
+
+For lighting calculations, convert encoded RGB to linear RGB first. Name the exact transfer
+function. Preserve encoded observations separately when they are needed for render comparison.
+
+## 3. Motion-system decomposition
+
+Create a separate system whenever two features can move or change independently:
+
+| Class | Examples | Primary evidence |
+| --- | --- | --- |
+| `camera` | framing, projected center, apparent scale | stable landmarks, boundary fit |
+| `geometry` | silhouette, rigid rotation, morph | contour, landmarks, depth cues |
+| `material` | roughness, transmission, albedo response | highlight width, chroma, refraction |
+| `lighting` | point caustic, rim strip, environment reflection | centroid, orientation, luminance |
+| `overlay` | ticks, labels, dots, arcs | exact path, visibility, attachment |
+| `silhouette` | projected boundary when treated independently | contour samples and residual |
+
+Color does not establish system identity. A cyan rim segment and cyan specular point remain separate
+when their paths, attachment, or timing differ.
+
+## 4. Observed and inferred records
+
+Put directly measured image evidence under `observed.features[]`:
+
+- `systemId` and `featureId`;
+- `sourcePoints` in full-frame pixels;
+- `confidence`;
+- optional `fitResidualPx`;
+- optional measured values such as linear luminance, softness radius, orientation, ellipse axes,
+  visibility, or contour samples.
+
+Put model-dependent quantities under `inferred.properties[]`:
+
+- `systemId` and property name;
+- value and units;
+- confidence;
+- explicit assumptions;
+- optional calibration evidence.
+
+Depth, surface normals, light direction, camera pose, roughness, and falloff are inferred unless a
+calibrated sensor or known scene makes them observed. Dark material is not automatically shadow;
+bright material is not automatically emission.
+
+For a single uncalibrated view, confidence above `0.65` requires named calibration evidence. This is
+an honesty ceiling, not a statement that all values below it are correct.
+
+## 5. Camera registration
+
+Track a stable geometric feature before interpreting surface motion. Report:
+
+1. raw feature displacement in source pixels;
+2. camera or projected-boundary displacement;
+3. camera-translation-removed displacement;
+4. scale- and rotation-normalized displacement when projected size or orientation changes.
+
+For an ellipse-like projected circular feature, keep center, radii, orientation, fit residual, and
+sample count per frame. An ellipse axis ratio can support apparent tilt under weak perspective, but
+only as an inference with that assumption recorded.
+
+Separate entrance transitions from stable motion. Compute stable-interval velocity and direction
+without allowing the initial registration jump to dominate the result.
+
+## 6. Reflection and lighting inference
+
+A highlight path can constrain a conditional lighting target when geometry and camera conventions
+are stated. For a unit sphere with view vector `V` and observed surface normal `N`, a mirror-like
+direction estimate may use:
+
+```text
+L = normalize(2 * dot(N, V) * N - V)
+```
+
+This is non-unique for rough, transmissive, layered, or environment-lit materials. Track point keys,
+broad environment strips, and internal/refraction features separately. Record highlight centroid,
+linear luminance, softness, orientation, and confidence before inferring a light vector.
+
+Do not reconstruct reflection motion by stretching the silhouette unless the contour measurements
+show real deformation. Do not bake a moving highlight into albedo when the source shows it responding
+independently to view or light.
+
+## 7. Comparison contract
+
+Use `comparison.status: not-run` before the first render exists. It must contain only that status.
+This is valid for a `preImplementationDecision.action` of `ready-for-implementation`; it is not
+evidence that temporal fidelity passes. Set `rootReviewDecision.status: not-run` at the same phase,
+also without stale action fields. After a live render is captured, replace both with
+`status: complete` and their required fields.
+
+Synchronize source and render timestamps. Match camera, crop, coordinate convention, and feature
+identity before calculating error.
+
+Set `featureEquivalent: true` only when both sides measure the same physical/visual feature. Then use
+`classification: like-for-like`. If the render lacks an equivalent and a broad highlight is compared
+with a point caustic, use `classification: proxy` and explain the limitation in
+`metricInterpretation`.
+
+Useful temporal metrics include:
+
+- boundary residual in pixels;
+- camera-registered path RMSE;
+- direction angular RMSE when the inference model is shared;
+- luminance and softness-curve error;
+- phase/timing error;
+- hold-state drift and flicker;
+- radius/path residual for attached arcs, lines, and dots.
+
+Never let a good still-frame score override a failed motion path.
+
+The two decisions serve different gates and both remain in the manifest:
+
+- `preImplementationDecision` records whether source analysis authorizes a first implementation;
+- `rootReviewDecision` records the root img2threejs action after synchronized render comparison.
+
+A tracking or registration defect is `refine-analysis` before the first render and `refine-spec`
+when discovered during post-render review. The post-render record does not supersede or rewrite the
+pre-implementation record.
+
+## 8. Acceptance gate
+
+`ready-for-implementation` requires:
+
+- the exact source and interval are identified;
+- requested frame coverage is satisfied;
+- every frame is decoded at original resolution without resampling;
+- camera motion is recorded, even when measured as static;
+- observed and inferred values are separate;
+- inferred properties contain assumptions and confidence;
+- at least one stable or explicitly justified target interval exists;
+- when a current render exists, its comparison is synchronized, camera-matched, and proxy metrics
+  are labelled as proxies;
+- unresolved ambiguity is listed.
+
+The manifest validator checks structural evidence. Agent vision must still inspect annotated frames
+and the source video. A valid manifest with the wrong tracked feature is still wrong.

--- a/skills/reconstruct-reference-motion/references/reference-motion-manifest.schema.json
+++ b/skills/reconstruct-reference-motion/references/reference-motion-manifest.schema.json
@@ -1,0 +1,296 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://img2threejs.dev/schemas/reference-motion-manifest.v1.json",
+  "title": "Reference motion manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "source",
+    "systems",
+    "frames",
+    "intervals",
+    "comparison",
+    "evidence",
+    "preImplementationDecision",
+    "rootReviewDecision"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "sourceHashSha256",
+        "width",
+        "height",
+        "fps",
+        "frameCount",
+        "intervalSeconds",
+        "decodePolicy",
+        "requestedCoverage",
+        "analysisCoverage",
+        "bootstrapReferenceFrame",
+        "viewCount",
+        "colorSpace",
+        "transferFunction"
+      ],
+      "properties": {
+        "kind": { "enum": ["video", "image-sequence"] },
+        "sourceHashSha256": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" },
+        "width": { "type": "integer", "minimum": 1 },
+        "height": { "type": "integer", "minimum": 1 },
+        "fps": { "type": "number", "exclusiveMinimum": 0 },
+        "frameCount": { "type": "integer", "minimum": 2 },
+        "intervalSeconds": {
+          "type": "array",
+          "prefixItems": [{ "type": "number" }, { "type": "number" }],
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "decodePolicy": { "const": "original-resolution-no-resample" },
+        "requestedCoverage": { "enum": ["every-frame", "sampled-allowed"] },
+        "analysisCoverage": { "enum": ["every-frame", "sampled"] },
+        "samplingRule": { "type": "string", "minLength": 1 },
+        "bootstrapReferenceFrame": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["timestampSeconds", "selectionRule", "reason"],
+          "properties": {
+            "timestampSeconds": { "type": "number" },
+            "selectionRule": {
+              "enum": ["interval-midpoint", "stable-hold-midpoint", "manual-semantic-keyframe"]
+            },
+            "reason": { "type": "string", "minLength": 1 }
+          }
+        },
+        "viewCount": { "type": "integer", "minimum": 1 },
+        "colorSpace": { "type": "string", "minLength": 1 },
+        "transferFunction": { "type": "string", "minLength": 1 },
+        "measurementRoi": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["x", "y", "width", "height"],
+          "properties": {
+            "x": { "type": "integer", "minimum": 0 },
+            "y": { "type": "integer", "minimum": 0 },
+            "width": { "type": "integer", "minimum": 1 },
+            "height": { "type": "integer", "minimum": 1 }
+          }
+        }
+      }
+    },
+    "systems": {
+      "type": "array",
+      "minItems": 2,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "class", "observedFeature"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "class": { "enum": ["camera", "geometry", "material", "lighting", "overlay", "silhouette", "other"] },
+          "observedFeature": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "frames": {
+      "type": "array",
+      "minItems": 2,
+      "items": { "$ref": "#/$defs/frame" }
+    },
+    "intervals": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "classification", "startSeconds", "endSeconds"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "classification": { "enum": ["transition", "stable", "morph", "hold", "other"] },
+          "startSeconds": { "type": "number" },
+          "endSeconds": { "type": "number" },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "comparison": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["not-run", "complete"] },
+        "referenceFeatureId": { "type": "string", "minLength": 1 },
+        "renderFeatureId": { "type": "string", "minLength": 1 },
+        "featureEquivalent": { "type": "boolean" },
+        "classification": { "enum": ["like-for-like", "proxy"] },
+        "synchronizedTimes": { "type": "boolean" },
+        "cameraMatched": { "type": "boolean" },
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "value", "units"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "value": { "type": "number" },
+              "units": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "metricInterpretation": { "type": "string", "minLength": 1 }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "not-run" } },
+            "required": ["status"]
+          },
+          "then": { "maxProperties": 1 }
+        },
+        {
+          "if": {
+            "properties": { "status": { "const": "complete" } },
+            "required": ["status"]
+          },
+          "then": {
+            "required": [
+              "referenceFeatureId",
+              "renderFeatureId",
+              "featureEquivalent",
+              "classification",
+              "synchronizedTimes",
+              "cameraMatched",
+              "metrics",
+              "metricInterpretation"
+            ]
+          }
+        }
+      ]
+    },
+    "evidence": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "$ref": "#/$defs/evidenceFile" }
+    },
+    "preImplementationDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["action", "reasons", "unresolvedAmbiguities"],
+      "properties": {
+        "action": { "enum": ["ready-for-implementation", "refine-analysis", "request-input", "stop"] },
+        "reasons": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "unresolvedAmbiguities": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "rootReviewDecision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "enum": ["not-run", "complete"] },
+        "action": { "enum": ["continue", "refine-spec", "refine-code", "request-input", "stop"] },
+        "reasons": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } },
+        "unresolvedAmbiguities": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "not-run" } },
+            "required": ["status"]
+          },
+          "then": { "maxProperties": 1 }
+        },
+        {
+          "if": {
+            "properties": { "status": { "const": "complete" } },
+            "required": ["status"]
+          },
+          "then": { "required": ["action", "reasons", "unresolvedAmbiguities"] }
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "frame": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["index", "timestampSeconds", "observed", "inferred"],
+      "properties": {
+        "index": { "type": "integer", "minimum": 0 },
+        "timestampSeconds": { "type": "number" },
+        "observed": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["features"],
+          "properties": {
+            "features": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/observedFeature" }
+            }
+          }
+        },
+        "inferred": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["properties"],
+          "properties": {
+            "properties": {
+              "type": "array",
+              "items": { "$ref": "#/$defs/inferredProperty" }
+            }
+          }
+        }
+      }
+    },
+    "observedFeature": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["systemId", "featureId", "sourcePoints", "confidence"],
+      "properties": {
+        "systemId": { "type": "string" },
+        "featureId": { "type": "string", "minLength": 1 },
+        "sourcePoints": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "array",
+            "prefixItems": [{ "type": "number" }, { "type": "number" }],
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "fitResidualPx": { "type": "number", "minimum": 0 },
+        "measurements": { "type": "object" }
+      }
+    },
+    "inferredProperty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["systemId", "property", "value", "units", "confidence", "assumptions"],
+      "properties": {
+        "systemId": { "type": "string" },
+        "property": { "type": "string", "minLength": 1 },
+        "value": {},
+        "units": { "type": "string", "minLength": 1 },
+        "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+        "assumptions": { "type": "array", "items": { "type": "string", "minLength": 1 } },
+        "calibrationEvidence": { "type": "array", "items": { "type": "string", "minLength": 1 } }
+      }
+    },
+    "evidenceFile": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "type": "string", "minLength": 1 },
+        "sha256": { "type": "string", "pattern": "^[a-fA-F0-9]{64}$" }
+      }
+    }
+  }
+}

--- a/skills/reconstruct-reference-motion/scripts/validate_motion_manifest.py
+++ b/skills/reconstruct-reference-motion/scripts/validate_motion_manifest.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Validate a reference-motion manifest without third-party dependencies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SHA256 = re.compile(r"^[0-9a-fA-F]{64}$")
+SYSTEM_CLASSES = {"camera", "geometry", "material", "lighting", "overlay", "silhouette", "other"}
+INTERVAL_CLASSES = {"transition", "stable", "morph", "hold", "other"}
+DECISIONS = {"ready-for-implementation", "refine-analysis", "request-input", "stop"}
+ROOT_REVIEW_ACTIONS = {"continue", "refine-spec", "refine-code", "request-input", "stop"}
+TOP_LEVEL_KEYS = {
+    "schemaVersion",
+    "source",
+    "systems",
+    "frames",
+    "intervals",
+    "comparison",
+    "evidence",
+    "preImplementationDecision",
+    "rootReviewDecision",
+}
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(float(value))
+
+
+def _confidence(value: Any) -> bool:
+    return _is_number(value) and 0.0 <= float(value) <= 1.0
+
+
+def validate_manifest(document: Any) -> list[dict[str, str]]:
+    errors: list[dict[str, str]] = []
+
+    def add(path: str, code: str, message: str) -> None:
+        errors.append({"path": path, "code": code, "message": message})
+
+    if not isinstance(document, dict):
+        add("$", "TYPE", "manifest must be a JSON object")
+        return errors
+
+    missing = sorted(TOP_LEVEL_KEYS - set(document))
+    unknown = sorted(set(document) - TOP_LEVEL_KEYS)
+    for key in missing:
+        add("$", "REQUIRED", f"missing top-level field: {key}")
+    for key in unknown:
+        add(f"$.{key}", "UNKNOWN_FIELD", "unknown top-level field")
+    if missing:
+        return errors
+
+    if document.get("schemaVersion") != 1:
+        add("$.schemaVersion", "SCHEMA_VERSION", "schemaVersion must equal 1")
+
+    source = document.get("source")
+    if not isinstance(source, dict):
+        add("$.source", "TYPE", "source must be an object")
+        return errors
+
+    required_source = {
+        "kind",
+        "sourceHashSha256",
+        "width",
+        "height",
+        "fps",
+        "frameCount",
+        "intervalSeconds",
+        "decodePolicy",
+        "requestedCoverage",
+        "analysisCoverage",
+        "bootstrapReferenceFrame",
+        "viewCount",
+        "colorSpace",
+        "transferFunction",
+    }
+    for key in sorted(required_source - set(source)):
+        add("$.source", "REQUIRED", f"missing source field: {key}")
+
+    width = source.get("width")
+    height = source.get("height")
+    frame_count = source.get("frameCount")
+    view_count = source.get("viewCount")
+    if source.get("kind") not in {"video", "image-sequence"}:
+        add("$.source.kind", "ENUM", "kind must be video or image-sequence")
+    if not isinstance(source.get("sourceHashSha256"), str) or not SHA256.fullmatch(source["sourceHashSha256"]):
+        add("$.source.sourceHashSha256", "HASH", "source hash must be 64 hexadecimal characters")
+    for key, value, minimum in (
+        ("width", width, 1),
+        ("height", height, 1),
+        ("frameCount", frame_count, 2),
+        ("viewCount", view_count, 1),
+    ):
+        if not isinstance(value, int) or isinstance(value, bool) or value < minimum:
+            add(f"$.source.{key}", "RANGE", f"{key} must be an integer >= {minimum}")
+    if not _is_number(source.get("fps")) or float(source.get("fps", 0.0)) <= 0.0:
+        add("$.source.fps", "RANGE", "fps must be a finite number > 0")
+
+    interval = source.get("intervalSeconds")
+    interval_start = interval_end = None
+    if (
+        not isinstance(interval, list)
+        or len(interval) != 2
+        or not all(_is_number(value) for value in interval)
+        or float(interval[0]) >= float(interval[1])
+    ):
+        add("$.source.intervalSeconds", "INTERVAL", "intervalSeconds must be [start, end] with start < end")
+    else:
+        interval_start, interval_end = map(float, interval)
+
+    if source.get("decodePolicy") != "original-resolution-no-resample":
+        add("$.source.decodePolicy", "DECODE_POLICY", "decodePolicy must be original-resolution-no-resample")
+    requested_coverage = source.get("requestedCoverage")
+    analysis_coverage = source.get("analysisCoverage")
+    if requested_coverage not in {"every-frame", "sampled-allowed"}:
+        add("$.source.requestedCoverage", "ENUM", "requestedCoverage must be every-frame or sampled-allowed")
+    if analysis_coverage not in {"every-frame", "sampled"}:
+        add("$.source.analysisCoverage", "ENUM", "analysisCoverage must be every-frame or sampled")
+    if requested_coverage == "every-frame" and analysis_coverage != "every-frame":
+        add("$.source.analysisCoverage", "COVERAGE", "an every-frame request cannot be satisfied by sampled analysis")
+    if analysis_coverage == "sampled" and not isinstance(source.get("samplingRule"), str):
+        add("$.source.samplingRule", "REQUIRED", "sampled analysis requires a samplingRule")
+    for key in ("colorSpace", "transferFunction"):
+        if not isinstance(source.get(key), str) or not source[key].strip():
+            add(f"$.source.{key}", "REQUIRED", f"{key} must be a non-empty string")
+
+    bootstrap = source.get("bootstrapReferenceFrame")
+    bootstrap_time = None
+    bootstrap_rule = None
+    if not isinstance(bootstrap, dict):
+        add("$.source.bootstrapReferenceFrame", "TYPE", "bootstrapReferenceFrame must be an object")
+    else:
+        bootstrap_time = bootstrap.get("timestampSeconds")
+        bootstrap_rule = bootstrap.get("selectionRule")
+        if not _is_number(bootstrap_time):
+            add("$.source.bootstrapReferenceFrame.timestampSeconds", "TYPE", "timestampSeconds must be finite")
+        elif interval_start is not None and not (interval_start - 1e-6 <= float(bootstrap_time) <= interval_end + 1e-6):
+            add("$.source.bootstrapReferenceFrame.timestampSeconds", "BOUNDS", "bootstrap frame is outside source interval")
+        if bootstrap_rule not in {"interval-midpoint", "stable-hold-midpoint", "manual-semantic-keyframe"}:
+            add("$.source.bootstrapReferenceFrame.selectionRule", "ENUM", "unknown bootstrap frame selection rule")
+        if not isinstance(bootstrap.get("reason"), str) or not bootstrap["reason"].strip():
+            add("$.source.bootstrapReferenceFrame.reason", "REQUIRED", "bootstrap frame selection requires a reason")
+
+    roi = source.get("measurementRoi")
+    if roi is not None:
+        if not isinstance(roi, dict):
+            add("$.source.measurementRoi", "TYPE", "measurementRoi must be an object")
+        else:
+            values = [roi.get(key) for key in ("x", "y", "width", "height")]
+            if not all(isinstance(value, int) and not isinstance(value, bool) for value in values):
+                add("$.source.measurementRoi", "TYPE", "ROI x, y, width, and height must be integers")
+            elif values[0] < 0 or values[1] < 0 or values[2] < 1 or values[3] < 1:
+                add("$.source.measurementRoi", "RANGE", "ROI must have non-negative origin and positive size")
+            elif isinstance(width, int) and isinstance(height, int) and (
+                values[0] + values[2] > width or values[1] + values[3] > height
+            ):
+                add("$.source.measurementRoi", "BOUNDS", "ROI extends outside the source frame")
+
+    systems = document.get("systems")
+    system_ids: set[str] = set()
+    has_camera_system = False
+    if not isinstance(systems, list) or len(systems) < 2:
+        add("$.systems", "COUNT", "systems must contain at least two independently tracked systems")
+    else:
+        for index, system in enumerate(systems):
+            path = f"$.systems[{index}]"
+            if not isinstance(system, dict):
+                add(path, "TYPE", "system must be an object")
+                continue
+            system_id = system.get("id")
+            if not isinstance(system_id, str) or not re.fullmatch(r"[a-z0-9][a-z0-9-]*", system_id):
+                add(f"{path}.id", "ID", "system id must use lower-case letters, digits, and hyphens")
+            elif system_id in system_ids:
+                add(f"{path}.id", "DUPLICATE", f"duplicate system id: {system_id}")
+            else:
+                system_ids.add(system_id)
+            system_class = system.get("class")
+            if system_class not in SYSTEM_CLASSES:
+                add(f"{path}.class", "ENUM", "unknown system class")
+            has_camera_system = has_camera_system or system_class == "camera"
+            if not isinstance(system.get("observedFeature"), str) or not system["observedFeature"].strip():
+                add(f"{path}.observedFeature", "REQUIRED", "observedFeature must be a non-empty string")
+    if systems and not has_camera_system:
+        add("$.systems", "CAMERA_SYSTEM", "record camera motion as its own system, even when static")
+
+    frames = document.get("frames")
+    if not isinstance(frames, list) or len(frames) < 2:
+        add("$.frames", "COUNT", "frames must contain at least two measured frames")
+        frames = []
+    if analysis_coverage == "every-frame" and isinstance(frame_count, int) and len(frames) != frame_count:
+        add("$.frames", "COVERAGE", "every-frame analysis requires len(frames) == source.frameCount")
+
+    frame_timestamps: list[float] = []
+    previous_index: int | None = None
+    previous_time: float | None = None
+    for frame_position, frame in enumerate(frames):
+        path = f"$.frames[{frame_position}]"
+        if not isinstance(frame, dict):
+            add(path, "TYPE", "frame must be an object")
+            continue
+        index = frame.get("index")
+        timestamp = frame.get("timestampSeconds")
+        if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+            add(f"{path}.index", "RANGE", "frame index must be an integer >= 0")
+        elif previous_index is not None and index <= previous_index:
+            add(f"{path}.index", "ORDER", "frame indexes must be strictly increasing")
+        else:
+            previous_index = index
+        if not _is_number(timestamp):
+            add(f"{path}.timestampSeconds", "TYPE", "timestamp must be a finite number")
+        else:
+            timestamp = float(timestamp)
+            if previous_time is not None and timestamp <= previous_time:
+                add(f"{path}.timestampSeconds", "ORDER", "timestamps must be strictly increasing")
+            previous_time = timestamp
+            frame_timestamps.append(timestamp)
+            if interval_start is not None and (timestamp < interval_start - 1e-6 or timestamp > interval_end + 1e-6):
+                add(f"{path}.timestampSeconds", "BOUNDS", "timestamp is outside source.intervalSeconds")
+
+        observed = frame.get("observed")
+        features = observed.get("features") if isinstance(observed, dict) else None
+        if not isinstance(features, list) or not features:
+            add(f"{path}.observed.features", "COUNT", "each frame requires at least one observed feature")
+            features = []
+        for feature_position, feature in enumerate(features):
+            feature_path = f"{path}.observed.features[{feature_position}]"
+            if not isinstance(feature, dict):
+                add(feature_path, "TYPE", "observed feature must be an object")
+                continue
+            if feature.get("systemId") not in system_ids:
+                add(f"{feature_path}.systemId", "REFERENCE", "observed feature references an unknown system")
+            if not isinstance(feature.get("featureId"), str) or not feature["featureId"].strip():
+                add(f"{feature_path}.featureId", "REQUIRED", "featureId must be a non-empty string")
+            if not _confidence(feature.get("confidence")):
+                add(f"{feature_path}.confidence", "RANGE", "confidence must be between 0 and 1")
+            residual = feature.get("fitResidualPx")
+            if residual is not None and (not _is_number(residual) or float(residual) < 0.0):
+                add(f"{feature_path}.fitResidualPx", "RANGE", "fitResidualPx must be a finite number >= 0")
+            points = feature.get("sourcePoints")
+            if not isinstance(points, list) or not points:
+                add(f"{feature_path}.sourcePoints", "COUNT", "sourcePoints must contain at least one point")
+            else:
+                for point_position, point in enumerate(points):
+                    point_path = f"{feature_path}.sourcePoints[{point_position}]"
+                    if not isinstance(point, list) or len(point) != 2 or not all(_is_number(value) for value in point):
+                        add(point_path, "TYPE", "source point must be [x, y] finite numbers")
+                    elif isinstance(width, int) and isinstance(height, int) and not (
+                        0.0 <= float(point[0]) < width and 0.0 <= float(point[1]) < height
+                    ):
+                        add(point_path, "BOUNDS", "source point lies outside the original frame")
+
+        inferred = frame.get("inferred")
+        properties = inferred.get("properties") if isinstance(inferred, dict) else None
+        if not isinstance(properties, list):
+            add(f"{path}.inferred.properties", "TYPE", "inferred.properties must be a list")
+            properties = []
+        for property_position, inferred_property in enumerate(properties):
+            property_path = f"{path}.inferred.properties[{property_position}]"
+            if not isinstance(inferred_property, dict):
+                add(property_path, "TYPE", "inferred property must be an object")
+                continue
+            if inferred_property.get("systemId") not in system_ids:
+                add(f"{property_path}.systemId", "REFERENCE", "inferred property references an unknown system")
+            for key in ("property", "units"):
+                if not isinstance(inferred_property.get(key), str) or not inferred_property[key].strip():
+                    add(f"{property_path}.{key}", "REQUIRED", f"{key} must be a non-empty string")
+            if "value" not in inferred_property:
+                add(f"{property_path}.value", "REQUIRED", "inferred property requires a value")
+            confidence_value = inferred_property.get("confidence")
+            if not _confidence(confidence_value):
+                add(f"{property_path}.confidence", "RANGE", "confidence must be between 0 and 1")
+            assumptions = inferred_property.get("assumptions")
+            calibration = inferred_property.get("calibrationEvidence", [])
+            if not isinstance(assumptions, list) or not all(isinstance(item, str) and item.strip() for item in assumptions):
+                add(f"{property_path}.assumptions", "TYPE", "assumptions must be a list of non-empty strings")
+                assumptions = []
+            if not assumptions and not calibration:
+                add(f"{property_path}.assumptions", "INFERENCE_EVIDENCE", "inference requires assumptions or calibration evidence")
+            if (
+                view_count == 1
+                and _confidence(confidence_value)
+                and float(confidence_value) > 0.65
+                and (not isinstance(calibration, list) or not calibration)
+            ):
+                add(
+                    f"{property_path}.confidence",
+                    "SINGLE_VIEW_CONFIDENCE",
+                    "single-view inference above 0.65 requires calibrationEvidence",
+                )
+
+    intervals = document.get("intervals")
+    has_stable_interval = False
+    stable_intervals: list[tuple[float, float]] = []
+    if not isinstance(intervals, list) or not intervals:
+        add("$.intervals", "COUNT", "at least one classified interval is required")
+        intervals = []
+    for interval_position, item in enumerate(intervals):
+        path = f"$.intervals[{interval_position}]"
+        if not isinstance(item, dict):
+            add(path, "TYPE", "interval must be an object")
+            continue
+        classification = item.get("classification")
+        if classification not in INTERVAL_CLASSES:
+            add(f"{path}.classification", "ENUM", "unknown interval classification")
+        has_stable_interval = has_stable_interval or classification in {"stable", "hold"}
+        start = item.get("startSeconds")
+        end = item.get("endSeconds")
+        if not _is_number(start) or not _is_number(end) or float(start) >= float(end):
+            add(path, "INTERVAL", "interval requires finite startSeconds < endSeconds")
+        elif interval_start is not None and (float(start) < interval_start - 1e-6 or float(end) > interval_end + 1e-6):
+            add(path, "BOUNDS", "classified interval lies outside source interval")
+        elif classification in {"stable", "hold"}:
+            stable_intervals.append((float(start), float(end)))
+
+    if _is_number(bootstrap_time) and frame_timestamps:
+        midpoint_candidates = frame_timestamps
+        midpoint_target = None
+        if bootstrap_rule == "interval-midpoint" and interval_start is not None:
+            midpoint_target = (interval_start + interval_end) / 2.0
+        elif bootstrap_rule == "stable-hold-midpoint" and stable_intervals:
+            first_stable = min(stable_intervals, key=lambda bounds: (bounds[0], bounds[1]))
+            midpoint_candidates = [
+                timestamp
+                for timestamp in frame_timestamps
+                if first_stable[0] - 1e-6 <= timestamp <= first_stable[1] + 1e-6
+            ]
+            midpoint_target = (first_stable[0] + first_stable[1]) / 2.0
+        elif bootstrap_rule == "stable-hold-midpoint":
+            add(
+                "$.source.bootstrapReferenceFrame.timestampSeconds",
+                "BOOTSTRAP_SELECTION",
+                "stable-hold-midpoint requires a stable or hold interval with a measured frame",
+            )
+
+        if bootstrap_rule == "manual-semantic-keyframe":
+            nearest_recorded = min(frame_timestamps, key=lambda timestamp: abs(timestamp - float(bootstrap_time)))
+            if abs(float(bootstrap_time) - nearest_recorded) > 1e-6:
+                add(
+                    "$.source.bootstrapReferenceFrame.timestampSeconds",
+                    "BOOTSTRAP_SELECTION",
+                    "manual semantic keyframe must match a measured native-frame timestamp",
+                )
+        elif midpoint_target is not None and midpoint_candidates:
+            expected_time = min(midpoint_candidates, key=lambda timestamp: (abs(timestamp - midpoint_target), timestamp))
+            if abs(float(bootstrap_time) - expected_time) > 1e-6:
+                add(
+                    "$.source.bootstrapReferenceFrame.timestampSeconds",
+                    "BOOTSTRAP_SELECTION",
+                    f"{bootstrap_rule} requires timestamp {expected_time:g}, the nearest measured frame to the midpoint",
+                )
+
+    comparison = document.get("comparison")
+    if not isinstance(comparison, dict):
+        add("$.comparison", "TYPE", "comparison must be an object")
+        comparison = {}
+    comparison_status = comparison.get("status")
+    if comparison_status not in {"not-run", "complete"}:
+        add("$.comparison.status", "ENUM", "comparison status must be not-run or complete")
+    if comparison_status == "not-run" and set(comparison) != {"status"}:
+        add("$.comparison", "STALE_COMPARISON", "not-run comparison must contain only status")
+    if comparison_status == "complete":
+        equivalent = comparison.get("featureEquivalent")
+        classification = comparison.get("classification")
+        if not isinstance(equivalent, bool):
+            add("$.comparison.featureEquivalent", "TYPE", "featureEquivalent must be boolean")
+        elif equivalent and classification != "like-for-like":
+            add("$.comparison.classification", "FEATURE_IDENTITY", "equivalent features require like-for-like classification")
+        elif not equivalent and classification != "proxy":
+            add("$.comparison.classification", "FEATURE_IDENTITY", "non-equivalent features must be classified as proxy")
+        for key in ("referenceFeatureId", "renderFeatureId", "metricInterpretation"):
+            if not isinstance(comparison.get(key), str) or not comparison[key].strip():
+                add(f"$.comparison.{key}", "REQUIRED", f"{key} must be a non-empty string")
+        for key in ("synchronizedTimes", "cameraMatched"):
+            if not isinstance(comparison.get(key), bool):
+                add(f"$.comparison.{key}", "TYPE", f"{key} must be boolean")
+            elif comparison[key] is not True:
+                add(f"$.comparison.{key}", "COMPARISON_ALIGNMENT", f"completed comparison requires {key}=true")
+        metrics = comparison.get("metrics")
+        if not isinstance(metrics, list):
+            add("$.comparison.metrics", "TYPE", "metrics must be a list")
+        else:
+            for metric_position, metric in enumerate(metrics):
+                path = f"$.comparison.metrics[{metric_position}]"
+                if not isinstance(metric, dict):
+                    add(path, "TYPE", "metric must be an object")
+                    continue
+                if not isinstance(metric.get("name"), str) or not metric["name"].strip():
+                    add(f"{path}.name", "REQUIRED", "metric name must be non-empty")
+                if not _is_number(metric.get("value")):
+                    add(f"{path}.value", "TYPE", "metric value must be finite")
+                if not isinstance(metric.get("units"), str) or not metric["units"].strip():
+                    add(f"{path}.units", "REQUIRED", "metric units must be non-empty")
+
+    evidence = document.get("evidence")
+    if not isinstance(evidence, dict) or not evidence:
+        add("$.evidence", "COUNT", "evidence must contain at least one artifact")
+        evidence = {}
+    for name, artifact in evidence.items():
+        path = f"$.evidence.{name}"
+        if not isinstance(artifact, dict):
+            add(path, "TYPE", "evidence artifact must be an object")
+            continue
+        if not isinstance(artifact.get("path"), str) or not artifact["path"].strip():
+            add(f"{path}.path", "REQUIRED", "evidence path must be non-empty")
+        if not isinstance(artifact.get("sha256"), str) or not SHA256.fullmatch(artifact["sha256"]):
+            add(f"{path}.sha256", "HASH", "evidence hash must be 64 hexadecimal characters")
+
+    decision = document.get("preImplementationDecision")
+    if not isinstance(decision, dict):
+        add("$.preImplementationDecision", "TYPE", "preImplementationDecision must be an object")
+        decision = {}
+    action = decision.get("action")
+    if action not in DECISIONS:
+        add("$.preImplementationDecision.action", "ENUM", "unknown pre-implementation decision")
+    reasons = decision.get("reasons")
+    if not isinstance(reasons, list) or not reasons or not all(isinstance(item, str) and item.strip() for item in reasons):
+        add("$.preImplementationDecision.reasons", "COUNT", "preImplementationDecision requires at least one non-empty reason")
+    ambiguities = decision.get("unresolvedAmbiguities")
+    if not isinstance(ambiguities, list) or not all(isinstance(item, str) and item.strip() for item in ambiguities):
+        add("$.preImplementationDecision.unresolvedAmbiguities", "TYPE", "unresolvedAmbiguities must be a list of non-empty strings")
+    if action == "ready-for-implementation":
+        if not has_stable_interval:
+            add("$.intervals", "READINESS", "implementation readiness requires a stable or hold interval")
+        for evidence_name in ("contactSheet", "annotatedKeyframes"):
+            if evidence_name not in evidence:
+                add("$.evidence", "READINESS", f"implementation readiness requires {evidence_name} evidence")
+
+    root_review = document.get("rootReviewDecision")
+    if not isinstance(root_review, dict):
+        add("$.rootReviewDecision", "TYPE", "rootReviewDecision must be an object")
+        root_review = {}
+    root_status = root_review.get("status")
+    if root_status not in {"not-run", "complete"}:
+        add("$.rootReviewDecision.status", "ENUM", "root review status must be not-run or complete")
+    if root_status == "not-run" and set(root_review) != {"status"}:
+        add("$.rootReviewDecision", "STALE_REVIEW", "not-run root review must contain only status")
+    if root_status == "complete":
+        root_action = root_review.get("action")
+        if root_action not in ROOT_REVIEW_ACTIONS:
+            add("$.rootReviewDecision.action", "ENUM", "unknown root img2threejs review action")
+        root_reasons = root_review.get("reasons")
+        if not isinstance(root_reasons, list) or not root_reasons or not all(
+            isinstance(item, str) and item.strip() for item in root_reasons
+        ):
+            add("$.rootReviewDecision.reasons", "COUNT", "completed root review requires at least one non-empty reason")
+        root_ambiguities = root_review.get("unresolvedAmbiguities")
+        if not isinstance(root_ambiguities, list) or not all(
+            isinstance(item, str) and item.strip() for item in root_ambiguities
+        ):
+            add("$.rootReviewDecision.unresolvedAmbiguities", "TYPE", "unresolvedAmbiguities must be a list of non-empty strings")
+    if comparison_status == "not-run" and root_status != "not-run":
+        add("$.rootReviewDecision.status", "PHASE_MISMATCH", "root review must be not-run before comparison")
+    if comparison_status == "complete" and root_status != "complete":
+        add("$.rootReviewDecision.status", "PHASE_MISMATCH", "completed comparison requires completed root review")
+    if root_status == "complete" and action != "ready-for-implementation":
+        add(
+            "$.rootReviewDecision.status",
+            "PHASE_MISMATCH",
+            "a completed post-render review requires a prior ready-for-implementation decision",
+        )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args(argv)
+
+    try:
+        document = json.loads(args.manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        result = {"valid": False, "errorType": "input-error", "message": str(exc)}
+        if args.as_json:
+            print(json.dumps(result, indent=2))
+        else:
+            print(f"INPUT ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    errors = validate_manifest(document)
+    action = document.get("preImplementationDecision", {}).get("action") if isinstance(document, dict) else None
+    root_action = document.get("rootReviewDecision", {}).get("action") if isinstance(document, dict) else None
+    result = {
+        "valid": not errors,
+        "schemaVersion": document.get("schemaVersion") if isinstance(document, dict) else None,
+        "frameCount": len(document.get("frames", [])) if isinstance(document, dict) and isinstance(document.get("frames"), list) else 0,
+        "systemCount": len(document.get("systems", [])) if isinstance(document, dict) and isinstance(document.get("systems"), list) else 0,
+        "preImplementationDecision": action,
+        "rootReviewDecision": root_action,
+        "errors": errors,
+    }
+    if args.as_json:
+        print(json.dumps(result, indent=2, allow_nan=False))
+    elif errors:
+        print(f"INVALID ({len(errors)} errors)")
+        for error in errors:
+            print(f"- {error['path']} [{error['code']}]: {error['message']}")
+    else:
+        print(
+            f"VALID: {result['frameCount']} frames, {result['systemCount']} systems, "
+            f"preImplementationDecision={action}, rootReviewDecision={root_action or 'not-run'}"
+        )
+    return 0 if not errors else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a standalone reference-motion companion skill for video and image-sequence reconstruction.
It closes the temporal-evidence gap between static reference intake and procedural Three.js
implementation: agents must measure and separate camera, geometry, material, lighting/reflection,
and overlay motion before editing a model or shader.

Refs #80

## Changes

- Add `skills/reconstruct-reference-motion/` with a progressive workflow and measurement contract.
- Add a versioned JSON manifest schema, synthetic example, and pure Python 3.10+ validator.
- Fail closed on sampled coverage for every-frame requests, invalid source coordinates, stale
  comparison state, proxy metrics presented as exact, single-view overconfidence, unsynchronized
  comparison, nondeterministic bootstrap-frame selection, and incompatible pre/post decisions.
- Route video and frame-by-frame requests from the root skill and document the validator.
- Add focused regression tests without source media, CV dependencies, or changes to existing object
  spec schemas.

## Validation

- [x] `python3 forge/tests/test_pipeline.py -q` — 62 passed.
- [x] `python3 -m unittest forge.tests.test_reference_motion_skill -v` — 15 passed.
- [x] `python3 -m unittest discover -s forge/tests -p 'test_*.py'` — 688 passed, 25 existing skips.
- [x] JSON parsing plus Draft 2020-12 schema validation of the synthetic example.
- [x] Independent forward test on a raw video/atlas scenario — approved after verifying native
  source-frame bootstrap, midpoint tie-breaking, stale-state rejection, and phase compatibility.
- [x] Render or comparison-sheet review — not applicable; this is an additive analysis/gating skill
  and includes no renderer or visual asset changes.

## Contributor checklist

- [x] This PR keeps the code-only procedural reconstruction contract; it does not silently download meshes or art packs.
- [x] Existing object specs remain valid; this adds a standalone temporal manifest.
- [x] I added tests for the new gate, schema, and decision phases.
- [x] I updated the root skill and script documentation. No roadmap item changes status.
