### PR TITLE
Add a reproducible procedural data-refinery MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,9 @@ docs/research/
 # session, never inputs to a build, and they carry multi-megabyte PNGs. Tuning ships with the
 # stable release, not with a beta of the scripts.
 work/
+
+# Henry local MVP private inputs and captures
+examples/**/node_modules/
+examples/**/dist/
+examples/henry-data-refinery/private/
+examples/henry-data-refinery/artifacts/

--- a/examples/henry-data-refinery/README.md
+++ b/examples/henry-data-refinery/README.md
@@ -1,0 +1,45 @@
+# Data Refinery procedural MVP
+
+A locally runnable Three.js visual approximation of an embodied-AI data-refinery illustration. It is a presentation model, not an engineering-accurate plant, process simulation, or source of dimensions.
+
+## Private input identity
+
+- Label: `embodied-ai-data-refinery`
+- SHA-256: `d0c4da693c43891d9934072eef079a1aa7391d58fc0771f5369e1985d90c3ce0`
+
+Only the label and digest are committed. The reference image and all browser captures remain in ignored local paths.
+
+## Run locally
+
+Use Node.js 20.19 or newer, then run one command from this directory:
+
+```bash
+./scripts/demo-local.sh
+```
+
+Drag to orbit, use the wheel or trackpad to zoom, right-drag to pan, and use `重置视角` to restore camera `(9, 7, 11)` with target `(0, 2, 0)`.
+
+## Modeled systems
+
+- Transparent central chamber with deterministic particle motion and pulse
+- Three secondary tanks and a procedural metallic pipe network
+- Layered refinery base and front processor coils
+- Three incoming particle streams
+- Three color-coded output platforms with synthetic columns or cylinders
+
+All geometry, materials, and motion are generated in code. No meshes, textures, or art packs are downloaded by the app.
+
+## Test and capture
+
+```bash
+npm test
+npm run build
+npx vite preview --host 127.0.0.1 --port 4173
+npm run smoke
+```
+
+The smoke script uses `http://127.0.0.1:4173` by default. Override a busy port with `MVP_URL=http://127.0.0.1:4174 npm run smoke`. It checks the canvas, reset control, visible limitation label, zero page errors, and produces one fixed plus two orbit screenshots under the ignored `artifacts/` directory.
+
+## Limitations
+
+This reconstruction is based on one image. Occluded and rear geometry, depth, scale, and connectivity are inferred rather than observed. The left-side photo/robot panels, the fourth purple terrain panel, dense micro-particle effects, exact factory topology, physical fluid behavior, dimensions, tolerances, and bill of materials are unsupported. See `docs/acceptance.md` for measured structural, browser, privacy, and visual-comparison evidence.

--- a/examples/henry-data-refinery/README.md
+++ b/examples/henry-data-refinery/README.md
@@ -38,7 +38,7 @@ npx vite preview --host 127.0.0.1 --port 4173
 npm run smoke
 ```
 
-The smoke script uses `http://127.0.0.1:4173` by default. Override a busy port with `MVP_URL=http://127.0.0.1:4174 npm run smoke`. It checks the canvas, reset control, visible limitation label, zero page errors, and produces one fixed plus two orbit screenshots under the ignored `artifacts/` directory.
+The smoke script uses `http://127.0.0.1:4173` by default. Override a busy port with `MVP_URL=http://127.0.0.1:4174 npm run smoke`. It checks the canvas, reset control, visible limitation label, zero page errors, and produces one fixed plus two orbit screenshots under the ignored `artifacts/` directory. Capture URLs pin only the procedural animation to 1.25 seconds for reproducible pixels; orbit and reset controls stay active, while ordinary browser sessions continue using live elapsed time.
 
 ## Limitations
 

--- a/examples/henry-data-refinery/docs/acceptance.md
+++ b/examples/henry-data-refinery/docs/acceptance.md
@@ -1,0 +1,87 @@
+# Data Refinery MVP acceptance
+
+Date: 2026-08-07
+Branch: `henry/mvp-20260807`
+
+## Outcome
+
+The scoped local MVP passes structural, build, interaction, screenshot, multi-angle, and privacy checks. It is accepted only as a procedural visual approximation; it is not an engineering model, and deterministic full-image fidelity diagnostics reject it as a close pixel-level reconstruction of the complete source illustration.
+
+## Input identity
+
+- Label: `embodied-ai-data-refinery`
+- SHA-256: `d0c4da693c43891d9934072eef079a1aa7391d58fc0771f5369e1985d90c3ce0`
+- Private fixture: byte-identical copy, 2,208,431 bytes, mode `0600`
+
+No source location is committed. The reference, private manifest, screenshots, and comparison sheet remain outside tracked Git content.
+
+## Implemented systems
+
+| System | Measured evidence |
+| --- | --- |
+| Model contract | Root is `DataRefinery`; `CoreChamber`, `PipeNetwork`, `InputStream`, and `OutputPlatforms` exist. |
+| Useful bounds | Unit test verifies width > 4, height > 3, and depth > 3. |
+| Core chamber | Procedural glass vessel, metal rims, inner pulse, and 90 deterministic points. |
+| Secondary equipment | Three tanks, five curved pipe runs, layered base, processor housing, and coils. |
+| Data flow | Three input curves with 45 elapsed-time-driven particles. |
+| Outputs | Three transparent platforms with deterministic synthetic features and shimmer. |
+| Viewer | WebGL canvas, orbit, zoom, pan, resize, and reset to camera `(9, 7, 11)` / target `(0, 2, 0)`. |
+| Limitation disclosure | `视觉近似，非工程模型` is visible and asserted by the browser smoke. |
+
+## Acceptance runs
+
+| Gate | Result |
+| --- | --- |
+| Upstream baseline | PASS — 673 `unittest` tests, 25 skipped. |
+| Model tests | PASS — 2 Vitest tests. The motion test proves equal elapsed time reproduces the same particle position and a different time moves it. |
+| Production build | PASS — TypeScript strict no-emit check and Vite production build. Vite reports a non-blocking 529 kB Three.js bundle-size warning. |
+| Browser smoke | PASS — canvas, reset, and limitation label visible; reset clicked; zero `pageerror` events. |
+| Captures | PASS — fixed 286,454 bytes; left orbit 203,438 bytes; right orbit 214,042 bytes; each 1536 × 1024 and visually read back. |
+| Multi-angle geometry | PASS — no degenerate view; orbit silhouette ratios 0.852 and 0.608, both above the 0.15 collapse threshold. |
+| Source integrity | PASS — source digest remained equal to the recorded SHA-256 after all work. |
+| Tracking privacy | PASS — no tracked `private`, `reference.png`, or `artifacts` path; no committed private absolute source path. |
+
+Port `4173` was already occupied by an unrelated local service during validation, so the documented `MVP_URL` interface was exercised against the preview on `http://127.0.0.1:4174`.
+
+## Visual comparison evidence
+
+A local side-by-side sheet was generated and inspected with the source on the left and the fixed render on the right. The procedural scene preserves the main visual grammar—central refinery, flowing inputs, blue/green/cyan outputs, pale technical background—but intentionally omits source-only photographic panels, the fourth purple terrain panel, dense particle volume, and much of the fine pipework.
+
+Semantic inspection scores are heuristic 0–1 judgments from that same sheet, not physical measurements:
+
+| Feature | Score | Review |
+| --- | ---: | --- |
+| Central chamber | 0.76 | Clear transparent chamber, cap/rim, blue tint, and particles; source is denser and more luminous. |
+| Secondary tanks | 0.69 | Multiple metallic vessels are legible; count, proportions, and rear tower detail are simplified. |
+| Pipe network | 0.62 | Curved metallic connectivity reads correctly; source has substantially greater routing density. |
+| Input stream | 0.48 | Direction and discrete particles are present; source has wider, layered ribbons and more volume. |
+| Output platforms | 0.61 | Three color-coded floating panels are clear; source has denser feature clouds plus an unsupported fourth panel. |
+| Overall scoped approximation | 0.63 | Suitable for an interactive MVP; not close enough for full-image fidelity acceptance. |
+
+Deterministic pixel/feature diagnostics were also retained rather than overruled:
+
+- `diagnose_render.py`: REJECT, exit 1 — silhouette IoU 0.3587, aspect-ratio delta 0.1597, scale delta 0.1473, bilateral-symmetry error 0.3743.
+- `divine_eye.py`: REJECT, exit 1 — fidelity 0.4043 against target 0.85; pHash 0.5938, SSIM 0.2352, edge overlap 0.4173, tonal parity 0.7139, objectness 0.6436.
+- These failures are expected for the intentionally scoped procedural scene versus the complete multi-panel 2D composition. They prohibit any claim of close visual reproduction; they do not invalidate the tested local interaction MVP.
+
+## Commands
+
+```bash
+python3 -m unittest discover -s forge/tests -p 'test_*.py'
+cd examples/henry-data-refinery
+npm test
+npm run build
+npx vite preview --host 127.0.0.1 --port 4173
+MVP_URL=http://127.0.0.1:4174 npm run smoke
+```
+
+Privacy checks from the repository root:
+
+```bash
+git status --short
+git ls-files | rg 'private|reference\.png|artifacts' && exit 1 || true
+```
+
+## One-image limitation and unsupported claims
+
+Only one view was available, so rear faces, hidden connections, true depth, and physical scale cannot be recovered from evidence. The app does not claim engineering topology, process correctness, flow simulation, exact dimensions, manufacturability, materials accuracy, performance capacity, or bill-of-material completeness. Orbit views demonstrate that the authored scene is genuinely three-dimensional; they do not validate unseen geometry against the source.

--- a/examples/henry-data-refinery/docs/acceptance.md
+++ b/examples/henry-data-refinery/docs/acceptance.md
@@ -1,6 +1,6 @@
 # Data Refinery MVP acceptance
 
-Date: 2026-08-07
+Date: 2026-08-08
 Branch: `henry/mvp-20260807`
 
 ## Outcome
@@ -33,15 +33,25 @@ No source location is committed. The reference, private manifest, screenshots, a
 | Gate | Result |
 | --- | --- |
 | Upstream baseline | PASS — 673 `unittest` tests, 25 skipped. |
-| Model tests | PASS — 2 Vitest tests. The motion test proves equal elapsed time reproduces the same particle position and a different time moves it. |
+| Model tests | PASS — 4 Vitest tests across 2 files. Motion remains elapsed-time-driven in normal use, while capture mode pins repeated frames to the requested time and rejects invalid overrides. |
 | Production build | PASS — TypeScript strict no-emit check and Vite production build. Vite reports a non-blocking 529 kB Three.js bundle-size warning. |
-| Browser smoke | PASS — canvas, reset, and limitation label visible; reset clicked; zero `pageerror` events. |
-| Captures | PASS — fixed 286,454 bytes; left orbit 203,438 bytes; right orbit 214,042 bytes; each 1536 × 1024 and visually read back. |
-| Multi-angle geometry | PASS — no degenerate view; orbit silhouette ratios 0.852 and 0.608, both above the 0.15 collapse threshold. |
+| Browser smoke | PASS — two consecutive runs at animation time 1.25 seconds; canvas, reset, and limitation label visible; reset clicked; orbit exercised in both directions; zero `pageerror` events. |
+| Captures | PASS — all three PNGs are 1536 × 1024 and had byte-identical SHA-256 values across both runs. |
+| Multi-angle geometry | PASS — no degenerate view; orbit silhouette ratios 0.851 and 0.607, both above the 0.15 collapse threshold. |
 | Source integrity | PASS — source digest remained equal to the recorded SHA-256 after all work. |
 | Tracking privacy | PASS — no tracked `private`, `reference.png`, or `artifacts` path; no committed private absolute source path. |
 
 Port `4173` was already occupied by an unrelated local service during validation, so the documented `MVP_URL` interface was exercised against the preview on `http://127.0.0.1:4174`.
+
+### Deterministic capture reproduction
+
+Only smoke capture mode pins procedural animation to 1.25 seconds. The ordinary viewer still uses live elapsed time, and the smoke continues to click reset and drive OrbitControls before taking the orbit views.
+
+| Capture | Dimensions | Run 1 SHA-256 | Run 2 SHA-256 |
+| --- | --- | --- | --- |
+| `refinery.png` | 1536 × 1024 | `13fc0471b9405b4440b8c9a14622d1d32a2462ef42eea35c70ca405e3af0e2b1` | `13fc0471b9405b4440b8c9a14622d1d32a2462ef42eea35c70ca405e3af0e2b1` |
+| `refinery-orbit-left.png` | 1536 × 1024 | `690bb225141ca99d8c9e8fee74f073da47af9e9b233f07c2420e3e58f156388e` | `690bb225141ca99d8c9e8fee74f073da47af9e9b233f07c2420e3e58f156388e` |
+| `refinery-orbit-right.png` | 1536 × 1024 | `1815c5f3435c4dfd6d07ee88112687da6db3c676df72f9541758afc11ba66850` | `1815c5f3435c4dfd6d07ee88112687da6db3c676df72f9541758afc11ba66850` |
 
 ## Visual comparison evidence
 
@@ -60,8 +70,8 @@ Semantic inspection scores are heuristic 0–1 judgments from that same sheet, n
 
 Deterministic pixel/feature diagnostics were also retained rather than overruled:
 
-- `diagnose_render.py`: REJECT, exit 1 — silhouette IoU 0.3587, aspect-ratio delta 0.1597, scale delta 0.1473, bilateral-symmetry error 0.3743.
-- `divine_eye.py`: REJECT, exit 1 — fidelity 0.4043 against target 0.85; pHash 0.5938, SSIM 0.2352, edge overlap 0.4173, tonal parity 0.7139, objectness 0.6436.
+- `diagnose_render.py`: REJECT, exit 1 — silhouette IoU 0.3597, aspect-ratio delta 0.1597, scale delta 0.1473, bilateral-symmetry error 0.3734.
+- `divine_eye.py`: REJECT, exit 1 — fidelity 0.4059 against target 0.85; pHash 0.6250, SSIM 0.2336, edge overlap 0.4158, tonal parity 0.7070, objectness 0.6399.
 - These failures are expected for the intentionally scoped procedural scene versus the complete multi-panel 2D composition. They prohibit any claim of close visual reproduction; they do not invalidate the tested local interaction MVP.
 
 ## Commands
@@ -73,6 +83,9 @@ npm test
 npm run build
 npx vite preview --host 127.0.0.1 --port 4173
 MVP_URL=http://127.0.0.1:4174 npm run smoke
+shasum -a 256 artifacts/refinery.png artifacts/refinery-orbit-left.png artifacts/refinery-orbit-right.png
+MVP_URL=http://127.0.0.1:4174 npm run smoke
+shasum -a 256 artifacts/refinery.png artifacts/refinery-orbit-left.png artifacts/refinery-orbit-right.png
 ```
 
 Privacy checks from the repository root:

--- a/examples/henry-data-refinery/index.html
+++ b/examples/henry-data-refinery/index.html
@@ -6,6 +6,20 @@
     <title>Data Refinery · Visual Approximation</title>
   </head>
   <body>
-    <div id="app"></div>
+    <div id="app" aria-label="Interactive data refinery model"></div>
+    <header class="hud">
+      <div>
+        <p class="eyebrow">Embodied AI · Data Refinery</p>
+        <h1>数据炼化工厂</h1>
+        <p class="disclaimer">视觉近似，非工程模型</p>
+      </div>
+      <button type="button" data-testid="reset-camera">重置视角</button>
+    </header>
+    <aside class="controls-hint" aria-label="Interaction help">
+      <span>拖动旋转</span>
+      <span>滚轮缩放</span>
+      <span>右键平移</span>
+    </aside>
+    <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/examples/henry-data-refinery/index.html
+++ b/examples/henry-data-refinery/index.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Data Refinery · Visual Approximation</title>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/examples/henry-data-refinery/package-lock.json
+++ b/examples/henry-data-refinery/package-lock.json
@@ -1,0 +1,1800 @@
+{
+  "name": "henry-data-refinery",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "henry-data-refinery",
+      "version": "0.1.0",
+      "dependencies": {
+        "three": "^0.180.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.55.0",
+        "@types/three": "^0.180.0",
+        "typescript": "^5.9.2",
+        "vite": "^7.1.3",
+        "vitest": "^3.2.4"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/examples/henry-data-refinery/package.json
+++ b/examples/henry-data-refinery/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "henry-data-refinery",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 127.0.0.1",
+    "build": "tsc --noEmit && vite build",
+    "test": "vitest run",
+    "smoke": "node scripts/smoke.mjs"
+  },
+  "dependencies": {
+    "three": "^0.180.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0",
+    "@types/three": "^0.180.0",
+    "typescript": "^5.9.2",
+    "vite": "^7.1.3",
+    "vitest": "^3.2.4"
+  }
+}

--- a/examples/henry-data-refinery/scripts/demo-local.sh
+++ b/examples/henry-data-refinery/scripts/demo-local.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+npm install
+npm run dev

--- a/examples/henry-data-refinery/scripts/smoke.mjs
+++ b/examples/henry-data-refinery/scripts/smoke.mjs
@@ -1,0 +1,70 @@
+import {mkdir, stat} from 'node:fs/promises';
+import {fileURLToPath} from 'node:url';
+import {chromium, expect} from '@playwright/test';
+
+const url = process.env.MVP_URL ?? 'http://127.0.0.1:4173';
+const artifactDirectory = fileURLToPath(new URL('../artifacts/', import.meta.url));
+const fixedCapture = fileURLToPath(new URL('../artifacts/refinery.png', import.meta.url));
+const leftCapture = fileURLToPath(new URL('../artifacts/refinery-orbit-left.png', import.meta.url));
+const rightCapture = fileURLToPath(new URL('../artifacts/refinery-orbit-right.png', import.meta.url));
+
+await mkdir(artifactDirectory, {recursive: true});
+
+const browser = await chromium.launch({headless: true});
+const page = await browser.newPage({viewport: {width: 1536, height: 1024}, deviceScaleFactor: 1});
+const pageErrors = [];
+page.on('pageerror', (error) => pageErrors.push(error));
+
+async function waitForPaint() {
+  await page.evaluate(() => new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  }));
+}
+
+async function orbit(deltaX) {
+  const canvasBounds = await page.locator('canvas').boundingBox();
+  if (!canvasBounds) {
+    throw new Error('Canvas bounds are unavailable.');
+  }
+  const startX = canvasBounds.x + canvasBounds.width * 0.55;
+  const startY = canvasBounds.y + canvasBounds.height * 0.55;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + deltaX, startY - 35, {steps: 14});
+  await page.mouse.up();
+  await waitForPaint();
+}
+
+try {
+  await page.goto(url, {waitUntil: 'networkidle'});
+  const canvas = page.locator('canvas');
+  const reset = page.locator('[data-testid="reset-camera"]');
+  await expect(canvas).toBeVisible();
+  await expect(reset).toBeVisible();
+  await expect(page.getByText('视觉近似，非工程模型')).toBeVisible();
+
+  await reset.click();
+  await waitForPaint();
+  await page.screenshot({path: fixedCapture, fullPage: true});
+
+  await orbit(-210);
+  await page.screenshot({path: leftCapture, fullPage: true});
+
+  await reset.click();
+  await orbit(210);
+  await page.screenshot({path: rightCapture, fullPage: true});
+
+  if (pageErrors.length > 0) {
+    throw new Error(`Page errors: ${pageErrors.map((error) => error.message).join(' | ')}`);
+  }
+
+  for (const capture of [fixedCapture, leftCapture, rightCapture]) {
+    const captureStat = await stat(capture);
+    if (captureStat.size === 0) {
+      throw new Error(`Empty screenshot: ${capture}`);
+    }
+  }
+  process.stdout.write('Smoke passed: canvas, reset, label, zero page errors, and 3 non-empty captures.\n');
+} finally {
+  await browser.close();
+}

--- a/examples/henry-data-refinery/scripts/smoke.mjs
+++ b/examples/henry-data-refinery/scripts/smoke.mjs
@@ -2,7 +2,8 @@ import {mkdir, stat} from 'node:fs/promises';
 import {fileURLToPath} from 'node:url';
 import {chromium, expect} from '@playwright/test';
 
-const url = process.env.MVP_URL ?? 'http://127.0.0.1:4173';
+const url = new URL(process.env.MVP_URL ?? 'http://127.0.0.1:4173');
+url.searchParams.set('captureTime', '1.25');
 const artifactDirectory = fileURLToPath(new URL('../artifacts/', import.meta.url));
 const fixedCapture = fileURLToPath(new URL('../artifacts/refinery.png', import.meta.url));
 const leftCapture = fileURLToPath(new URL('../artifacts/refinery-orbit-left.png', import.meta.url));
@@ -36,7 +37,7 @@ async function orbit(deltaX) {
 }
 
 try {
-  await page.goto(url, {waitUntil: 'networkidle'});
+  await page.goto(url.href, {waitUntil: 'networkidle'});
   const canvas = page.locator('canvas');
   const reset = page.locator('[data-testid="reset-camera"]');
   await expect(canvas).toBeVisible();
@@ -64,7 +65,7 @@ try {
       throw new Error(`Empty screenshot: ${capture}`);
     }
   }
-  process.stdout.write('Smoke passed: canvas, reset, label, zero page errors, and 3 non-empty captures.\n');
+  process.stdout.write('Smoke passed at deterministic animation time 1.25s: canvas, reset, label, zero page errors, and 3 non-empty captures.\n');
 } finally {
   await browser.close();
 }

--- a/examples/henry-data-refinery/src/animationTime.ts
+++ b/examples/henry-data-refinery/src/animationTime.ts
@@ -1,0 +1,14 @@
+export function resolveAnimationTime(
+  elapsedSeconds: number,
+  query: URLSearchParams,
+): number {
+  const requestedTime = query.get('captureTime');
+  if (requestedTime === null || requestedTime.trim() === '') {
+    return elapsedSeconds;
+  }
+
+  const captureTime = Number(requestedTime);
+  return Number.isFinite(captureTime) && captureTime >= 0
+    ? captureTime
+    : elapsedSeconds;
+}

--- a/examples/henry-data-refinery/src/createDataRefineryModel.ts
+++ b/examples/henry-data-refinery/src/createDataRefineryModel.ts
@@ -261,6 +261,11 @@ export function createDataRefineryModel(): THREE.Group {
 
   const inputStream = new THREE.Group();
   inputStream.name = 'InputStream';
+  const inputParticles: Array<{
+    mesh: THREE.Mesh;
+    path: THREE.CatmullRomCurve3;
+    offset: number;
+  }> = [];
   const inputPaths = [
     new THREE.CatmullRomCurve3([
       new THREE.Vector3(-6.5, 3.7, -0.6),
@@ -303,6 +308,11 @@ export function createDataRefineryModel(): THREE.Group {
       particle.userData.pathIndex = pathIndex;
       particle.userData.offset = particleIndex / 15;
       inputStream.add(particle);
+      inputParticles.push({
+        mesh: particle,
+        path,
+        offset: particleIndex / 15,
+      });
     }
   }
   root.add(inputStream);
@@ -313,6 +323,34 @@ export function createDataRefineryModel(): THREE.Group {
   outputs.add(makePlatform(2.15, 0x45aa75, 1));
   outputs.add(makePlatform(0.15, 0x2ac7cf, 2));
   root.add(outputs);
+
+  const platformSlabs = outputs.children.map((platform, index) => {
+    return platform.getObjectByName(`PlatformSlab${index + 1}`) as THREE.Mesh<
+      THREE.BoxGeometry,
+      THREE.MeshPhysicalMaterial
+    >;
+  });
+
+  root.userData.tick = (elapsedSeconds: number): void => {
+    for (const particle of inputParticles) {
+      const progress = (particle.offset + elapsedSeconds * 0.16) % 1;
+      particle.mesh.position.copy(particle.path.getPoint(progress));
+      const sparkle = 0.72 + Math.sin((progress + particle.offset) * Math.PI * 2) * 0.2;
+      particle.mesh.scale.setScalar(sparkle);
+    }
+
+    const pulse = (Math.sin(elapsedSeconds * 2.4) + 1) / 2;
+    chamberGlow.scale.set(1 + pulse * 0.035, 1 + pulse * 0.02, 1 + pulse * 0.035);
+    const glowMaterial = chamberGlow.material as THREE.MeshStandardMaterial;
+    glowMaterial.emissiveIntensity = 1.05 + pulse * 0.65;
+    coreParticles.rotation.y = elapsedSeconds * 0.22;
+
+    for (let index = 0; index < platformSlabs.length; index += 1) {
+      const shimmer = (Math.sin(elapsedSeconds * 1.7 + index * 1.15) + 1) / 2;
+      platformSlabs[index].material.opacity = 0.34 + shimmer * 0.12;
+      platformSlabs[index].material.emissiveIntensity = 0.05 + shimmer * 0.14;
+    }
+  };
 
   return root;
 }

--- a/examples/henry-data-refinery/src/createDataRefineryModel.ts
+++ b/examples/henry-data-refinery/src/createDataRefineryModel.ts
@@ -168,10 +168,12 @@ export function createDataRefineryModel(): THREE.Group {
       transmission: 0.45,
       roughness: 0.08,
       metalness: 0.05,
+      depthWrite: false,
       side: THREE.DoubleSide,
     }),
   );
   chamberGlass.name = 'ChamberGlass';
+  chamberGlass.renderOrder = 2;
   chamberGlass.position.set(0, 2.05, 0);
   core.add(chamberGlass);
 
@@ -184,9 +186,11 @@ export function createDataRefineryModel(): THREE.Group {
       transparent: true,
       opacity: 0.38,
       roughness: 0.24,
+      depthWrite: false,
     }),
   );
   chamberGlow.name = 'ChamberPulse';
+  chamberGlow.renderOrder = 1;
   chamberGlow.position.set(0, 1.82, 0);
   core.add(chamberGlow);
 
@@ -218,9 +222,12 @@ export function createDataRefineryModel(): THREE.Group {
       transparent: true,
       opacity: 0.9,
       sizeAttenuation: true,
+      depthTest: true,
+      depthWrite: false,
     }),
   );
   coreParticles.name = 'CoreParticles';
+  coreParticles.renderOrder = 3;
   core.add(coreParticles);
 
   addTank(core, new THREE.Vector3(2.0, 1.8, -0.35), 0.66, 2.45);

--- a/examples/henry-data-refinery/src/createDataRefineryModel.ts
+++ b/examples/henry-data-refinery/src/createDataRefineryModel.ts
@@ -1,0 +1,318 @@
+import * as THREE from 'three';
+
+const metal = new THREE.MeshStandardMaterial({
+  color: 0x9aa8b8,
+  metalness: 0.82,
+  roughness: 0.24,
+});
+const darkMetal = new THREE.MeshStandardMaterial({
+  color: 0x3d4c61,
+  metalness: 0.78,
+  roughness: 0.3,
+});
+const cobalt = new THREE.MeshStandardMaterial({
+  color: 0x236de8,
+  emissive: 0x0b3f9a,
+  emissiveIntensity: 0.55,
+  metalness: 0.15,
+  roughness: 0.28,
+});
+const cyan = new THREE.MeshStandardMaterial({
+  color: 0x37e2e4,
+  emissive: 0x0f8f9d,
+  emissiveIntensity: 0.8,
+  roughness: 0.24,
+});
+
+function makePipe(points: THREE.Vector3[], radius = 0.12): THREE.Mesh {
+  const curve = new THREE.CatmullRomCurve3(points);
+  const pipe = new THREE.Mesh(
+    new THREE.TubeGeometry(curve, 32, radius, 10, false),
+    metal,
+  );
+  pipe.castShadow = true;
+  pipe.receiveShadow = true;
+  return pipe;
+}
+
+function addTank(
+  parent: THREE.Group,
+  position: THREE.Vector3,
+  radius: number,
+  height: number,
+): void {
+  const tank = new THREE.Group();
+  tank.position.copy(position);
+
+  const body = new THREE.Mesh(
+    new THREE.CylinderGeometry(radius, radius, height, 28),
+    metal,
+  );
+  body.castShadow = true;
+  body.receiveShadow = true;
+  tank.add(body);
+
+  const cap = new THREE.Mesh(
+    new THREE.SphereGeometry(radius, 28, 12, 0, Math.PI * 2, 0, Math.PI / 2),
+    metal,
+  );
+  cap.position.y = height / 2;
+  cap.castShadow = true;
+  tank.add(cap);
+
+  for (const y of [-height * 0.28, height * 0.28]) {
+    const band = new THREE.Mesh(
+      new THREE.TorusGeometry(radius * 1.015, 0.045, 8, 32),
+      darkMetal,
+    );
+    band.rotation.x = Math.PI / 2;
+    band.position.y = y;
+    tank.add(band);
+  }
+  parent.add(tank);
+}
+
+function makePlatform(
+  y: number,
+  accent: number,
+  index: number,
+): THREE.Group {
+  const platform = new THREE.Group();
+  platform.name = `OutputPlatform${index + 1}`;
+  platform.position.set(5.1, y, 0.5);
+
+  const slab = new THREE.Mesh(
+    new THREE.BoxGeometry(3.6, 0.14, 2.5),
+    new THREE.MeshPhysicalMaterial({
+      color: accent,
+      emissive: accent,
+      emissiveIntensity: 0.08,
+      transparent: true,
+      opacity: 0.42,
+      metalness: 0.1,
+      roughness: 0.18,
+      transmission: 0.18,
+    }),
+  );
+  slab.name = `PlatformSlab${index + 1}`;
+  slab.receiveShadow = true;
+  platform.add(slab);
+
+  const edge = new THREE.LineSegments(
+    new THREE.EdgesGeometry(slab.geometry),
+    new THREE.LineBasicMaterial({color: accent, transparent: true, opacity: 0.9}),
+  );
+  edge.name = `PlatformEdge${index + 1}`;
+  platform.add(edge);
+
+  const featureMaterial = new THREE.MeshStandardMaterial({
+    color: accent,
+    emissive: accent,
+    emissiveIntensity: 0.15,
+    metalness: 0.2,
+    roughness: 0.32,
+  });
+  for (let column = 0; column < 8; column += 1) {
+    const height = 0.24 + ((column * 7 + index * 3) % 6) * 0.13;
+    const geometry = index === 2
+      ? new THREE.CylinderGeometry(0.18, 0.18, height, 16)
+      : new THREE.BoxGeometry(0.35, height, 0.35);
+    const feature = new THREE.Mesh(geometry, featureMaterial);
+    feature.position.set(
+      -1.2 + (column % 4) * 0.78,
+      0.07 + height / 2,
+      -0.72 + Math.floor(column / 4) * 1.25,
+    );
+    feature.castShadow = true;
+    platform.add(feature);
+  }
+
+  return platform;
+}
+
+export function createDataRefineryModel(): THREE.Group {
+  const root = new THREE.Group();
+  root.name = 'DataRefinery';
+
+  const foundation = new THREE.Group();
+  foundation.name = 'Foundation';
+  const lowerBase = new THREE.Mesh(
+    new THREE.CylinderGeometry(3.25, 3.25, 0.28, 8),
+    darkMetal,
+  );
+  lowerBase.scale.z = 0.78;
+  lowerBase.position.y = 0.05;
+  lowerBase.receiveShadow = true;
+  lowerBase.castShadow = true;
+  foundation.add(lowerBase);
+
+  const upperBase = new THREE.Mesh(
+    new THREE.BoxGeometry(5.4, 0.24, 3.8),
+    metal,
+  );
+  upperBase.position.y = 0.28;
+  upperBase.receiveShadow = true;
+  upperBase.castShadow = true;
+  foundation.add(upperBase);
+  root.add(foundation);
+
+  const core = new THREE.Group();
+  core.name = 'CoreChamber';
+
+  const chamberGlass = new THREE.Mesh(
+    new THREE.CylinderGeometry(1.12, 1.12, 2.6, 36, 1, true),
+    new THREE.MeshPhysicalMaterial({
+      color: 0xb9e8ff,
+      transparent: true,
+      opacity: 0.28,
+      transmission: 0.45,
+      roughness: 0.08,
+      metalness: 0.05,
+      side: THREE.DoubleSide,
+    }),
+  );
+  chamberGlass.name = 'ChamberGlass';
+  chamberGlass.position.set(0, 2.05, 0);
+  core.add(chamberGlass);
+
+  const chamberGlow = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.93, 0.93, 1.95, 32),
+    new THREE.MeshStandardMaterial({
+      color: 0x1165c8,
+      emissive: 0x0e8bca,
+      emissiveIntensity: 1.35,
+      transparent: true,
+      opacity: 0.38,
+      roughness: 0.24,
+    }),
+  );
+  chamberGlow.name = 'ChamberPulse';
+  chamberGlow.position.set(0, 1.82, 0);
+  core.add(chamberGlow);
+
+  for (const y of [0.74, 3.36]) {
+    const rim = new THREE.Mesh(
+      new THREE.CylinderGeometry(1.32, 1.32, 0.28, 36),
+      metal,
+    );
+    rim.position.set(0, y, 0);
+    rim.castShadow = true;
+    core.add(rim);
+  }
+
+  const positions = new Float32Array(90 * 3);
+  for (let index = 0; index < 90; index += 1) {
+    const radius = 0.18 + ((index * 17) % 70) / 100;
+    const angle = index * 2.399963;
+    positions[index * 3] = Math.cos(angle) * radius;
+    positions[index * 3 + 1] = 0.9 + ((index * 29) % 205) / 100;
+    positions[index * 3 + 2] = Math.sin(angle) * radius;
+  }
+  const particleGeometry = new THREE.BufferGeometry();
+  particleGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+  const coreParticles = new THREE.Points(
+    particleGeometry,
+    new THREE.PointsMaterial({
+      color: 0x7fffff,
+      size: 0.075,
+      transparent: true,
+      opacity: 0.9,
+      sizeAttenuation: true,
+    }),
+  );
+  coreParticles.name = 'CoreParticles';
+  core.add(coreParticles);
+
+  addTank(core, new THREE.Vector3(2.0, 1.8, -0.35), 0.66, 2.45);
+  addTank(core, new THREE.Vector3(-1.85, 1.35, 0.72), 0.48, 1.55);
+  addTank(core, new THREE.Vector3(1.3, 2.75, -1.05), 0.48, 2.7);
+  root.add(core);
+
+  const pipes = new THREE.Group();
+  pipes.name = 'PipeNetwork';
+  const pipePaths = [
+    [new THREE.Vector3(-2.5, 0.55, 1.3), new THREE.Vector3(-2.0, 0.55, 1.3), new THREE.Vector3(-1.55, 1.0, 1.0), new THREE.Vector3(-1.2, 1.5, 0.7)],
+    [new THREE.Vector3(1.1, 0.62, 1.15), new THREE.Vector3(2.25, 0.62, 1.15), new THREE.Vector3(2.55, 1.05, 0.65), new THREE.Vector3(2.3, 1.6, 0.1)],
+    [new THREE.Vector3(-1.0, 3.3, -0.1), new THREE.Vector3(-1.3, 3.85, -0.2), new THREE.Vector3(-1.95, 3.85, -0.35), new THREE.Vector3(-2.0, 2.5, -0.35)],
+    [new THREE.Vector3(1.0, 3.2, 0.15), new THREE.Vector3(1.4, 3.65, 0.2), new THREE.Vector3(2.0, 3.55, 0.0), new THREE.Vector3(2.0, 2.9, -0.35)],
+    [new THREE.Vector3(-0.65, 0.7, -1.0), new THREE.Vector3(-0.3, 0.45, -1.55), new THREE.Vector3(0.85, 0.45, -1.55), new THREE.Vector3(1.45, 0.65, -1.1)],
+  ];
+  for (const path of pipePaths) {
+    pipes.add(makePipe(path));
+  }
+
+  const processor = new THREE.Mesh(
+    new THREE.BoxGeometry(1.65, 0.82, 1.0),
+    darkMetal,
+  );
+  processor.position.set(0, 0.85, 1.45);
+  processor.castShadow = true;
+  pipes.add(processor);
+  for (let offset = -0.6; offset <= 0.6; offset += 0.3) {
+    const coil = new THREE.Mesh(
+      new THREE.TorusGeometry(0.37, 0.055, 8, 24),
+      cobalt,
+    );
+    coil.rotation.y = Math.PI / 2;
+    coil.position.set(offset, 0.85, 1.96);
+    pipes.add(coil);
+  }
+  root.add(pipes);
+
+  const inputStream = new THREE.Group();
+  inputStream.name = 'InputStream';
+  const inputPaths = [
+    new THREE.CatmullRomCurve3([
+      new THREE.Vector3(-6.5, 3.7, -0.6),
+      new THREE.Vector3(-4.8, 3.45, -0.25),
+      new THREE.Vector3(-3.3, 2.6, 0.1),
+      new THREE.Vector3(-2.5, 1.7, 0.45),
+    ]),
+    new THREE.CatmullRomCurve3([
+      new THREE.Vector3(-6.2, 2.4, 0.7),
+      new THREE.Vector3(-4.6, 2.2, 0.9),
+      new THREE.Vector3(-3.5, 1.7, 1.0),
+      new THREE.Vector3(-2.7, 1.25, 0.9),
+    ]),
+    new THREE.CatmullRomCurve3([
+      new THREE.Vector3(-6.1, 1.15, -1.1),
+      new THREE.Vector3(-4.7, 1.05, -0.9),
+      new THREE.Vector3(-3.6, 0.95, -0.5),
+      new THREE.Vector3(-2.5, 0.9, -0.2),
+    ]),
+  ];
+  inputStream.userData.paths = inputPaths;
+  for (let pathIndex = 0; pathIndex < inputPaths.length; pathIndex += 1) {
+    const path = inputPaths[pathIndex];
+    const ribbon = new THREE.Mesh(
+      new THREE.TubeGeometry(path, 40, 0.018, 5, false),
+      new THREE.MeshBasicMaterial({
+        color: pathIndex === 2 ? 0x42d5cf : 0x6f98c4,
+        transparent: true,
+        opacity: 0.42,
+      }),
+    );
+    inputStream.add(ribbon);
+    for (let particleIndex = 0; particleIndex < 15; particleIndex += 1) {
+      const particle = new THREE.Mesh(
+        new THREE.BoxGeometry(0.08, 0.08, 0.08),
+        pathIndex === 2 ? cyan : cobalt,
+      );
+      particle.name = `InputParticle-${pathIndex}-${particleIndex}`;
+      particle.position.copy(path.getPoint(particleIndex / 15));
+      particle.userData.pathIndex = pathIndex;
+      particle.userData.offset = particleIndex / 15;
+      inputStream.add(particle);
+    }
+  }
+  root.add(inputStream);
+
+  const outputs = new THREE.Group();
+  outputs.name = 'OutputPlatforms';
+  outputs.add(makePlatform(4.15, 0x2f76e8, 0));
+  outputs.add(makePlatform(2.15, 0x45aa75, 1));
+  outputs.add(makePlatform(0.15, 0x2ac7cf, 2));
+  root.add(outputs);
+
+  return root;
+}

--- a/examples/henry-data-refinery/src/main.ts
+++ b/examples/henry-data-refinery/src/main.ts
@@ -1,0 +1,107 @@
+import * as THREE from 'three';
+import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
+import {createDataRefineryModel} from './createDataRefineryModel';
+import './styles.css';
+
+const app = document.querySelector<HTMLDivElement>('#app');
+const resetButton = document.querySelector<HTMLButtonElement>('[data-testid="reset-camera"]');
+
+if (!app || !resetButton) {
+  throw new Error('Data refinery viewer shell is incomplete.');
+}
+const viewport = app;
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0xf4f7fb);
+scene.fog = new THREE.FogExp2(0xf4f7fb, 0.018);
+
+const renderer = new THREE.WebGLRenderer({antialias: true, alpha: false});
+renderer.outputColorSpace = THREE.SRGBColorSpace;
+renderer.toneMapping = THREE.ACESFilmicToneMapping;
+renderer.toneMappingExposure = 1.12;
+renderer.shadowMap.enabled = true;
+renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+app.append(renderer.domElement);
+
+const camera = new THREE.PerspectiveCamera(40, 1, 0.1, 100);
+const defaultCameraPosition = new THREE.Vector3(9, 7, 11);
+const defaultTarget = new THREE.Vector3(0, 2, 0);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.enableDamping = true;
+controls.dampingFactor = 0.055;
+controls.minDistance = 7;
+controls.maxDistance = 30;
+controls.maxPolarAngle = Math.PI * 0.48;
+controls.target.copy(defaultTarget);
+
+function resetCamera(): void {
+  camera.position.copy(defaultCameraPosition);
+  controls.target.copy(defaultTarget);
+  controls.update();
+}
+
+resetCamera();
+resetButton.addEventListener('click', resetCamera);
+
+scene.add(new THREE.HemisphereLight(0xf4fbff, 0x27374b, 2.2));
+
+const keyLight = new THREE.DirectionalLight(0xffffff, 3.4);
+keyLight.position.set(-6, 12, 9);
+keyLight.castShadow = true;
+keyLight.shadow.mapSize.set(2048, 2048);
+keyLight.shadow.camera.left = -12;
+keyLight.shadow.camera.right = 12;
+keyLight.shadow.camera.top = 10;
+keyLight.shadow.camera.bottom = -8;
+scene.add(keyLight);
+
+const blueRim = new THREE.DirectionalLight(0x5ca8ff, 2.1);
+blueRim.position.set(8, 6, -8);
+scene.add(blueRim);
+
+const tealFill = new THREE.PointLight(0x38e1d3, 2.6, 12, 1.5);
+tealFill.position.set(-1.5, 3.2, 2.2);
+scene.add(tealFill);
+
+const ground = new THREE.Mesh(
+  new THREE.PlaneGeometry(34, 24),
+  new THREE.MeshStandardMaterial({color: 0xe6edf5, roughness: 0.82, metalness: 0.05}),
+);
+ground.name = 'Ground';
+ground.rotation.x = -Math.PI / 2;
+ground.position.y = -0.11;
+ground.receiveShadow = true;
+scene.add(ground);
+
+const grid = new THREE.GridHelper(28, 28, 0x8fadc8, 0xc9d7e5);
+grid.position.y = -0.1;
+const gridMaterials = Array.isArray(grid.material) ? grid.material : [grid.material];
+for (const material of gridMaterials) {
+  material.transparent = true;
+  material.opacity = 0.23;
+}
+scene.add(grid);
+
+const model = createDataRefineryModel();
+model.rotation.y = -0.06;
+scene.add(model);
+
+function resize(): void {
+  const width = viewport.clientWidth;
+  const height = viewport.clientHeight;
+  renderer.setSize(width, height, false);
+  camera.aspect = width / Math.max(height, 1);
+  camera.updateProjectionMatrix();
+}
+
+window.addEventListener('resize', resize);
+resize();
+
+const clock = new THREE.Clock();
+renderer.setAnimationLoop(() => {
+  model.userData.tick(clock.getElapsedTime());
+  controls.update();
+  renderer.render(scene, camera);
+});

--- a/examples/henry-data-refinery/src/main.ts
+++ b/examples/henry-data-refinery/src/main.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import {OrbitControls} from 'three/addons/controls/OrbitControls.js';
+import {resolveAnimationTime} from './animationTime';
 import {createDataRefineryModel} from './createDataRefineryModel';
 import './styles.css';
 
@@ -100,8 +101,9 @@ window.addEventListener('resize', resize);
 resize();
 
 const clock = new THREE.Clock();
+const animationQuery = new URLSearchParams(window.location.search);
 renderer.setAnimationLoop(() => {
-  model.userData.tick(clock.getElapsedTime());
+  model.userData.tick(resolveAnimationTime(clock.getElapsedTime(), animationQuery));
   controls.update();
   renderer.render(scene, camera);
 });

--- a/examples/henry-data-refinery/src/styles.css
+++ b/examples/henry-data-refinery/src/styles.css
@@ -1,0 +1,148 @@
+:root {
+  color: #172334;
+  background: #f4f7fb;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+body {
+  position: relative;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+}
+
+canvas:active {
+  cursor: grabbing;
+}
+
+.hud {
+  position: fixed;
+  top: 24px;
+  left: 24px;
+  right: 24px;
+  z-index: 2;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  pointer-events: none;
+}
+
+.hud > div {
+  max-width: 420px;
+  padding: 18px 20px;
+  border: 1px solid rgb(255 255 255 / 70%);
+  border-radius: 18px;
+  background: rgb(248 251 255 / 76%);
+  box-shadow: 0 18px 55px rgb(36 69 105 / 12%);
+  backdrop-filter: blur(18px);
+}
+
+.eyebrow,
+.disclaimer,
+h1 {
+  margin: 0;
+}
+
+.eyebrow {
+  color: #47739b;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin-top: 7px;
+  color: #152b43;
+  font-size: clamp(24px, 3vw, 38px);
+  line-height: 1.08;
+  letter-spacing: -0.035em;
+}
+
+.disclaimer {
+  margin-top: 10px;
+  color: #65798d;
+  font-size: 13px;
+}
+
+button {
+  padding: 11px 16px;
+  border: 1px solid rgb(28 84 135 / 18%);
+  border-radius: 999px;
+  color: #153450;
+  background: rgb(255 255 255 / 82%);
+  box-shadow: 0 10px 32px rgb(38 73 109 / 12%);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 650;
+  pointer-events: auto;
+  cursor: pointer;
+  backdrop-filter: blur(14px);
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  background: #fff;
+}
+
+button:focus-visible {
+  outline: 3px solid rgb(47 118 232 / 38%);
+  outline-offset: 3px;
+}
+
+.controls-hint {
+  position: fixed;
+  right: 24px;
+  bottom: 22px;
+  z-index: 2;
+  display: flex;
+  gap: 14px;
+  color: #6b7c8d;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  pointer-events: none;
+}
+
+.controls-hint span + span::before {
+  margin-right: 14px;
+  color: #b0bfcd;
+  content: "·";
+}
+
+@media (max-width: 640px) {
+  .hud {
+    top: 14px;
+    left: 14px;
+    right: 14px;
+  }
+
+  .hud > div {
+    padding: 14px 16px;
+  }
+
+  .controls-hint {
+    right: 14px;
+    bottom: 14px;
+  }
+}

--- a/examples/henry-data-refinery/tests/animationTime.test.ts
+++ b/examples/henry-data-refinery/tests/animationTime.test.ts
@@ -1,0 +1,16 @@
+import {describe, expect, it} from 'vitest';
+import {resolveAnimationTime} from '../src/animationTime';
+
+describe('resolveAnimationTime', () => {
+  it('pins every capture frame to the requested time', () => {
+    const query = new URLSearchParams('captureTime=1.25');
+    expect(resolveAnimationTime(0.1, query)).toBe(1.25);
+    expect(resolveAnimationTime(8.4, query)).toBe(1.25);
+  });
+
+  it('preserves live elapsed time without a valid capture override', () => {
+    expect(resolveAnimationTime(2.75, new URLSearchParams())).toBe(2.75);
+    expect(resolveAnimationTime(2.75, new URLSearchParams('captureTime=not-a-number'))).toBe(2.75);
+    expect(resolveAnimationTime(2.75, new URLSearchParams('captureTime=-1'))).toBe(2.75);
+  });
+});

--- a/examples/henry-data-refinery/tests/model.test.ts
+++ b/examples/henry-data-refinery/tests/model.test.ts
@@ -1,0 +1,18 @@
+import {Box3, Group, Vector3} from 'three';
+import {describe, expect, it} from 'vitest';
+import {createDataRefineryModel} from '../src/createDataRefineryModel';
+
+describe('createDataRefineryModel', () => {
+  it('has the required systems and useful bounds', () => {
+    const model = createDataRefineryModel();
+    expect(model).toBeInstanceOf(Group);
+    expect(model.name).toBe('DataRefinery');
+    for (const name of ['CoreChamber', 'PipeNetwork', 'InputStream', 'OutputPlatforms']) {
+      expect(model.getObjectByName(name), `${name} is missing`).toBeTruthy();
+    }
+    const size = new Box3().setFromObject(model).getSize(new Vector3());
+    expect(size.x).toBeGreaterThan(4);
+    expect(size.y).toBeGreaterThan(3);
+    expect(size.z).toBeGreaterThan(3);
+  });
+});

--- a/examples/henry-data-refinery/tests/model.test.ts
+++ b/examples/henry-data-refinery/tests/model.test.ts
@@ -15,4 +15,19 @@ describe('createDataRefineryModel', () => {
     expect(size.y).toBeGreaterThan(3);
     expect(size.z).toBeGreaterThan(3);
   });
+
+  it('moves the input stream deterministically from elapsed time', () => {
+    const model = createDataRefineryModel();
+    expect(model.userData.tick).toBeTypeOf('function');
+    model.userData.tick(1.25);
+    expect(model.getObjectByName('InputStream')).toBeTruthy();
+
+    const particle = model.getObjectByName('InputParticle-0-0');
+    expect(particle).toBeTruthy();
+    const firstPosition = particle!.position.clone();
+    model.userData.tick(1.25);
+    expect(particle!.position.equals(firstPosition)).toBe(true);
+    model.userData.tick(1.75);
+    expect(particle!.position.equals(firstPosition)).toBe(false);
+  });
 });

--- a/examples/henry-data-refinery/tsconfig.json
+++ b/examples/henry-data-refinery/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- add an isolated `examples/henry-data-refinery` Three.js MVP
- model a procedural data-refinery scene with orbit, zoom, pan, resize, and camera reset
- add deterministic browser captures while keeping normal animation elapsed-time driven
- document the evidence boundary and visual-fidelity limitations

## Why

This provides a concrete local example for evaluating the repository against a single-image, interactive 3D workflow. The implementation is intentionally a procedural approximation rather than an engineering or pixel-accurate reconstruction.

## Impact and scope

- upstream core behavior is unchanged
- private reference material and generated captures are excluded from Git
- capture mode pins animation time only for reproducible smoke evidence
- the acceptance report retains the failed high-fidelity diagnostic instead of overstating quality

## Validation

- 673 upstream unit tests passed; 25 skipped
- 4 Vitest tests passed
- TypeScript and Vite production build passed
- two browser-smoke runs produced identical SHA-256 values for all three 1536x1024 captures
- source-integrity and feature-history privacy checks passed
