### PR TITLE
Refs #85: Add state reset for resume and stale-complete detection

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -141,6 +141,19 @@ Mark a non-applicable step `skipped` only with `--reason`; silent omission is fo
 are derived from `reviewHistory` actions `refine-spec`/`refine-code`, not agent memory. Defaults are
 3 corrections per pass and 6 total.
 
+### State staleness detection
+
+If `forge/next.py --state` prints a WARNING about stale complete state, or if `state.json` shows
+`"status": "complete"` but work is continuing, reset before proceeding:
+
+```bash
+python3 forge/state.py reset --state .img2threejs/state.json --force
+```
+
+This resets the state to active and re-enters the pipeline from the last completed pass. Never
+trust a `"complete"` status from a previous session without verification — always run `next.py`
+first and obey its output.
+
 Profiles add mandatory gates rather than changing the core order: `cs2` requires classification,
 manifest, and a machine-readable CS2 review before AI review; `character` requires the character
 contracts and landmark evidence. Every profile records suitability, projection applicability, and

--- a/forge/_shared/workflow_state.py
+++ b/forge/_shared/workflow_state.py
@@ -379,6 +379,60 @@ def sync_from_spec(state: dict[str, Any], spec: dict[str, Any], current_pass: st
         recompute(state)
 
 
+def reset_for_resume(state: dict[str, Any]) -> None:
+    """Reset a completed or stopped state back to active for continued work.
+
+    When a new session resumes work on a previously-completed reconstruction,
+    the state file may still show status='complete'. This function resets it
+    so the agent can continue iterating without losing the evidence trail.
+
+    - 'complete' states: reset status to 'active', set currentPass back to
+      the last pass (so the agent re-enters the pass loop), and reset the
+      pass checklist for re-evaluation.
+    - 'stopped' states: reset status to 'active', clear stopReason, re-enter
+      from the stopped pass.
+    - 'active' states: no-op (already active).
+    """
+    current_status = state.get("status")
+    if current_status == "active":
+        return
+    if current_status not in {"complete", "stopped"}:
+        raise WorkflowStateError(f"cannot reset state with status={current_status!r}")
+    state["status"] = "active"
+    state["stopReason"] = ""
+    if state.get("currentPass") == "complete":
+        history = state.get("passHistory", [])
+        if history:
+            last_pass = history[-1].get("passId", "")
+            state["currentPass"] = last_pass
+        else:
+            state["currentPass"] = ""
+    if state.get("currentPass") and state["currentPass"] != "complete":
+        for entry in _entries(state, "pass"):
+            entry["status"] = "pending"
+            entry["evidence"] = []
+            entry["reason"] = ""
+        state["iterationAction"] = "resume"
+    recompute(state)
+
+
+def is_stale_complete(state: dict[str, Any]) -> bool:
+    """Return True if state shows 'complete' but may be stale.
+
+    A state is considered stale-complete when status is 'complete' but the
+    agent is being asked to continue work (detected by checking if there are
+    any pending final steps or if the currentPass is not 'complete').
+    """
+    if state.get("status") != "complete":
+        return False
+    # If currentPass is not 'complete', the pipeline didn't fully finish
+    if state.get("currentPass") != "complete":
+        return True
+    # If there are pending final steps, it's incomplete
+    final_pending = _pending(_entries(state, "final"))
+    return bool(final_pending)
+
+
 def status_payload(state: dict[str, Any]) -> dict[str, Any]:
     entry = next_entry(state)
     current_pass = str(state.get("currentPass") or "")
@@ -398,6 +452,7 @@ def status_payload(state: dict[str, Any]) -> dict[str, Any]:
         },
         "nextCommand": None if state["status"] != "active" or entry is None else _format_command(state, entry),
         "stopReason": state.get("stopReason") or None,
+        "staleComplete": is_stale_complete(state),
         "pending": [
             entry["id"]
             for entry in state["checklist"]

--- a/forge/next.py
+++ b/forge/next.py
@@ -12,6 +12,7 @@ from status_banner import emit_status
 from orchestrate_passes import current_pass, pass_acceptance, pass_order, completed_passes
 from workflow_state import (
     WorkflowStateError,
+    is_stale_complete,
     load_state,
     save_state,
     status_payload,
@@ -67,6 +68,13 @@ def main(argv: list[str]) -> int:
     if spec_path is None:
         if local_state is None:
             parser.error("spec is required unless --state points to an initialized pre-spec workflow")
+        if is_stale_complete(local_state):
+            print(
+                "WARNING: state.json shows 'complete' but pipeline is incomplete. "
+                "Run 'python3 forge/state.py reset --state .img2threejs/state.json --force' "
+                "to re-enter the pipeline before continuing.",
+                file=sys.stderr,
+            )
         payload = status_payload(local_state)
         emit_local_state(payload)
         return 3 if payload["status"] == "stopped" else 0
@@ -83,6 +91,13 @@ def main(argv: list[str]) -> int:
     current = current_pass(ids, completed)
 
     if local_state is not None:
+        if is_stale_complete(local_state):
+            print(
+                "WARNING: state.json shows 'complete' but pipeline is incomplete. "
+                "Run 'python3 forge/state.py reset --state .img2threejs/state.json --force' "
+                "to re-enter the pipeline before continuing.",
+                file=sys.stderr,
+            )
         sync_from_spec(local_state, spec, current)
         save_state(args.state, local_state)
         payload = status_payload(local_state)

--- a/forge/state.py
+++ b/forge/state.py
@@ -14,6 +14,7 @@ from workflow_state import (  # noqa: E402
     load_state,
     mark_steps,
     new_state,
+    reset_for_resume,
     save_state,
     status_payload,
 )
@@ -41,6 +42,10 @@ def build_parser() -> argparse.ArgumentParser:
     mark.add_argument("--status", choices=("done", "skipped", "pending"), default="done")
     mark.add_argument("--evidence", action="append", default=[])
     mark.add_argument("--reason", default="")
+
+    reset = commands.add_parser("reset")
+    reset.add_argument("--state", type=Path, default=Path(".img2threejs/state.json"))
+    reset.add_argument("--force", action="store_true", help="Reset without confirmation prompt")
 
     return parser
 
@@ -86,6 +91,22 @@ def main(argv: list[str]) -> int:
             print_status(state, as_json=args.json)
         elif args.command == "mark":
             mark_steps(state, args.step, status=args.status, evidence=args.evidence, reason=args.reason)
+            save_state(args.state, state)
+            print_status(state)
+        elif args.command == "reset":
+            previous_status = state.get("status")
+            if previous_status == "active":
+                print("state is already active; nothing to reset", file=sys.stderr)
+                return 0
+            if not args.force:
+                print(
+                    f"WARNING: resetting state from {previous_status!r} to active. "
+                    f"This will re-enter the pipeline from current pass. "
+                    f"Use --force to confirm.",
+                    file=sys.stderr,
+                )
+                return 2
+            reset_for_resume(state)
             save_state(args.state, state)
             print_status(state)
         return 3 if state.get("status") == "stopped" else 0

--- a/forge/tests/test_workflow_state.py
+++ b/forge/tests/test_workflow_state.py
@@ -13,8 +13,10 @@ sys.path.insert(0, str(ROOT / "forge" / "_shared"))
 
 from workflow_state import (  # noqa: E402
     WorkflowStateError,
+    is_stale_complete,
     mark_steps,
     new_state,
+    reset_for_resume,
     set_current_pass,
     status_payload,
     sync_from_spec,
@@ -300,6 +302,135 @@ class WorkflowStateTest(unittest.TestCase):
         self.assertIn("forge/stage4_review/diagnose_render.py", skill)
         self.assertIn("forge/stage4_review/diagnose_render_multi_angle.py", skill)
         self.assertIn("forge/stage4_review/check_part_coverage.py", skill)
+
+    def test_reset_for_resume_resets_complete_state(self):
+        state = new_state("reference.png", spec="spec.json")
+        setup_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "setup"]
+        pass_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "pass"]
+        final_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "final"]
+        mark_steps(state, setup_ids, status="done", evidence=["setup.json"])
+        set_current_pass(state, "blockout")
+        mark_steps(state, pass_ids, status="done", evidence=["blockout.json"])
+        set_current_pass(state, "complete")
+        mark_steps(state, final_ids, status="done", evidence=["final.json"])
+        self.assertEqual(state["status"], "complete")
+        reset_for_resume(state)
+        self.assertEqual(state["status"], "active")
+        self.assertNotEqual(state["currentStep"], "complete")
+
+    def test_reset_for_resume_resets_stopped_state(self):
+        state = new_state("reference.png", max_per_pass=2, max_total=6)
+        setup_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "setup"]
+        pass_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "pass"]
+        mark_steps(state, setup_ids, status="done", evidence=["setup.json"])
+        set_current_pass(state, "blockout")
+        mark_steps(state, pass_ids, status="done", evidence=["blockout.json"])
+        spec = {
+            "reviewHistory": [
+                {"passId": "blockout", "action": "refine-code"},
+                {"passId": "blockout", "action": "refine-spec"},
+            ]
+        }
+        sync_from_spec(state, spec, "blockout")
+        self.assertEqual(state["status"], "stopped")
+        reset_for_resume(state)
+        self.assertEqual(state["status"], "active")
+        self.assertEqual(state["stopReason"], "")
+
+    def test_reset_for_resume_is_noop_on_active(self):
+        state = new_state("reference.png")
+        self.assertEqual(state["status"], "active")
+        reset_for_resume(state)
+        self.assertEqual(state["status"], "active")
+
+    def test_is_stale_complete_returns_false_for_active(self):
+        state = new_state("reference.png")
+        self.assertFalse(is_stale_complete(state))
+
+    def test_is_stale_complete_returns_false_for_stopped(self):
+        state = new_state("reference.png", max_per_pass=1, max_total=1)
+        setup_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "setup"]
+        mark_steps(state, setup_ids, status="done", evidence=["setup.json"])
+        set_current_pass(state, "blockout")
+        spec = {"reviewHistory": [{"passId": "blockout", "action": "refine-code"}]}
+        sync_from_spec(state, spec, "blockout")
+        self.assertEqual(state["status"], "stopped")
+        self.assertFalse(is_stale_complete(state))
+
+    def test_is_stale_complete_returns_true_when_pass_not_complete(self):
+        state = new_state("reference.png", spec="spec.json")
+        setup_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "setup"]
+        mark_steps(state, setup_ids, status="done", evidence=["setup.json"])
+        set_current_pass(state, "blockout")
+        pass_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "pass"]
+        mark_steps(state, pass_ids, status="done", evidence=["blockout.json"])
+        # Manually set status to complete without updating currentPass
+        state["status"] = "complete"
+        state["currentStep"] = "complete"
+        self.assertTrue(is_stale_complete(state))
+
+    def test_status_payload_includes_stale_complete(self):
+        state = new_state("reference.png", spec="spec.json")
+        setup_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "setup"]
+        mark_steps(state, setup_ids, status="done", evidence=["setup.json"])
+        set_current_pass(state, "blockout")
+        pass_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "pass"]
+        mark_steps(state, pass_ids, status="done", evidence=["blockout.json"])
+        state["status"] = "complete"
+        state["currentStep"] = "complete"
+        payload = status_payload(state)
+        self.assertTrue(payload["staleComplete"])
+
+    def test_reset_cli_refuses_without_force(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_path = Path(directory) / "state.json"
+            state = new_state("reference.png")
+            state["status"] = "complete"
+            state["currentStep"] = "complete"
+            state_path.write_text(json.dumps(state), encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(ROOT / "forge" / "state.py"), "reset", "--state", str(state_path)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("WARNING", result.stderr)
+            self.assertIn("--force", result.stderr)
+
+    def test_reset_cli_with_force_resets_state(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_path = Path(directory) / "state.json"
+            state = new_state("reference.png")
+            state["status"] = "complete"
+            state["currentStep"] = "complete"
+            state_path.write_text(json.dumps(state), encoding="utf-8")
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "forge" / "state.py"),
+                    "reset",
+                    "--state",
+                    str(state_path),
+                    "--force",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("status=active", result.stdout)
+
+    def test_reset_cli_is_noop_on_active(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_path = Path(directory) / "state.json"
+            state = new_state("reference.png")
+            state_path.write_text(json.dumps(state), encoding="utf-8")
+            result = subprocess.run(
+                [sys.executable, str(ROOT / "forge" / "state.py"), "reset", "--state", str(state_path)],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("already active", result.stderr)
 
     def test_all_direct_router_references_exist(self):
         for relative in (


### PR DESCRIPTION
## Summary

When a new session resumes work on a previously-completed reconstruction, `state.json` may still show `"status": "complete"`, causing agents to skip state updates entirely. This PR adds staleness detection and a reset mechanism.

## Changes

### `forge/_shared/workflow_state.py`
- `reset_for_resume()`: Resets complete/stopped state back to active, re-entering from the last completed pass
- `is_stale_complete()`: Detects when state shows 'complete' but pipeline is incomplete
- `status_payload()` now includes `staleComplete` field

### `forge/state.py`
- New `reset` subcommand: `python3 forge/state.py reset --state .img2threejs/state.json --force`
- Refuses without `--force` to prevent accidental resets
- No-op on already-active states

### `forge/next.py`
- Prints WARNING to stderr when state is stale-complete, suggesting `state.py reset`

### `SKILL.md`
- Added "State staleness detection" section to Mandatory Local State Gate

### `forge/tests/test_workflow_state.py`
- 10 new tests covering reset_for_resume, is_stale_complete, staleComplete payload, and CLI behavior
- All 30 tests pass

## Fix

Refs #85
