### PR TITLE
guard: the mandatory reads and Divine Eye were prose, so they were skippable

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -146,6 +146,32 @@ manifest, and a machine-readable CS2 review before AI review; `character` requir
 contracts and landmark evidence. Every profile records suitability, projection applicability, and
 material-evidence applicability; conditional steps require evidence or an explicit skip reason.
 
+## What the state gate now enforces (and why)
+
+The mandatory reads and the primary evaluator used to live only in this file's prose. Prose is not
+a control: an agent can run the whole pipeline, mark every checklist step, and never open
+`geometry_patterns.md` or run `divine_eye.py`, because nothing asked. That happened, and the rules
+it skipped were the exact ones that then broke the reconstruction ("do NOT eyeball proportions",
+"never report a 2D-gate pass as done"). So they are checklist steps now:
+
+| Step | Enforces |
+| --- | --- |
+| `topology-contract-read` | `surface_topology.md` + `detail_inventory.md`, before any primitive is chosen |
+| `build-contract-read` | `geometry_patterns.md` + `shading_realism.md`, before any geometry is generated |
+| `character-pipeline-read` | `standard_character_pipeline.md` on the character profile |
+| `divine-eye` | `divine_eye.py` runs on every pass; it is the harness heart, not an optional extra |
+
+Two guards back them up:
+
+- **A contract-read step must name its documents.** `state.py mark review-contract-read --evidence
+  object-sculpt-spec.json` is refused; the evidence has to include every required path. Nothing can
+  prove a document was read, but marking the step is no longer free.
+- **`append_review.py` refuses a score it cannot check.** A visual pass requires
+  `--divine-eye-json`, and a claim more than 0.15 above the measured fidelity needs
+  `--over-claim-reason` in writing. This exists because a review was once recorded at 0.72 while
+  Divine Eye measured 0.5072 on the same render. `self_correction.md` opens with a section about
+  over-claiming; it did not stop it, because it was only prose.
+
 ## The Loop (scripts do enforcement; agent vision does judgment)
 
 Run scripts from the skill root (`forge/...`). Pure Python 3.10+ stdlib, no pip installs.

--- a/forge/_shared/workflow_state.py
+++ b/forge/_shared/workflow_state.py
@@ -14,6 +14,34 @@ STEP_STATUSES: Final = {"pending", "done", "skipped"}
 REFINE_ACTIONS: Final = {"refine-spec", "refine-code"}
 
 
+# A "contract-read" step is self-certified: nothing can prove an agent read a document. What CAN
+# be enforced is that it names the right ones. Marking `review-contract-read` done with evidence
+# "object-sculpt-spec.json" is how those reads got skipped in practice -- the step passed while
+# the documents went unread, and the rules they carry ("do NOT eyeball proportions", "never report
+# a 2D-gate pass as done") were the exact rules then broken. So the evidence must include every
+# required path, which at minimum forces the agent to look up what they are.
+CONTRACT_DOCS: Final = {
+    "topology-contract-read": (
+        "grimoire/intake/surface_topology.md",
+        "grimoire/intake/detail_inventory.md",
+    ),
+    "build-contract-read": (
+        "grimoire/build/geometry_patterns.md",
+        "grimoire/feedback/shading_realism.md",
+    ),
+    "character-contract-read": (
+        "grimoire/character/reconstruction.md",
+        "grimoire/character/likeness_maximization.md",
+    ),
+    "character-pipeline-read": ("grimoire/readiness/standard_character_pipeline.md",),
+    "review-contract-read": (
+        "grimoire/review/gates_reference.md",
+        "grimoire/review/self_correction.md",
+    ),
+    "cs2-contract-read": ("grimoire/intake/cs2_intake_contract.md",),
+}
+
+
 SETUP_STEPS: Final = (
     ("image-analysis", "Read grimoire/intake/image_analysis.md and analyze {reference}"),
     (
@@ -28,6 +56,11 @@ SETUP_STEPS: Final = (
         "projection-route",
         "Record whether projection is required; if required run solve_camera_pose.py, delight_albedo.py, and bake_projected_texture.py, otherwise skip with a reason",
     ),
+    (
+        "topology-contract-read",
+        "Read grimoire/intake/surface_topology.md and grimoire/intake/detail_inventory.md completely"
+        " -- classify every component's topologyClass BEFORE choosing its primitive",
+    ),
     ("spec-authoring", "python3 forge/stage2_spec/new_sculpt_spec.py \"<name>\" --image {reference} --assessment assessment.json --out object-sculpt-spec.json"),
     (
         "material-evidence",
@@ -36,6 +69,12 @@ SETUP_STEPS: Final = (
     ),
     ("material-spec-wiring", "python3 forge/stage2_spec/apply_material_analysis.py {spec} material-analysis.json --in-place"),
     ("strict-validation", "python3 forge/stage2_spec/validate_sculpt_spec.py {spec} --strict-quality"),
+    (
+        "build-contract-read",
+        "Read grimoire/build/geometry_patterns.md and grimoire/feedback/shading_realism.md completely"
+        " -- in particular 'do NOT eyeball proportions, extract 1-to-1 from the reference', the"
+        " distinctZ slab test, and the discriminating tests for a wrong attribution",
+    ),
 )
 
 CHARACTER_STEPS: Final = (
@@ -46,6 +85,12 @@ CHARACTER_STEPS: Final = (
     (
         "character-landmarks",
         "python3 forge/stage1_intake/extract_landmarks.py {reference} --out anatomy.json --overlay landmarks.png",
+    ),
+    (
+        "character-pipeline-read",
+        "Read grimoire/readiness/standard_character_pipeline.md completely -- route selection, required"
+        " artifacts, the required capture batch, the acceptance order, and the rule that ONE correction"
+        " group changes per loop (camera, silhouette, face, clothing, accessory, materials, lighting)",
     ),
 )
 
@@ -60,6 +105,13 @@ PASS_STEPS: Final = (
     ("render-capture", "Render {pass_id} and capture the fixed review view plus meaningful orbit views"),
     ("review-contract-read", "Read grimoire/review/gates_reference.md and grimoire/review/self_correction.md completely"),
     ("tier1-diagnostics", "python3 forge/stage4_review/diagnose_render.py --reference {reference} --render <shot> --spec {spec} --pass-id {pass_id} --in-place"),
+    (
+        "divine-eye",
+        "python3 forge/stage4_review/divine_eye.py --reference {reference} --render <shot> --json"
+        " -- the harness heart, and the single authority on how close the render is. Record its"
+        " fidelity BEFORE scoring anything yourself; append_review.py will refuse a score that"
+        " sits far above it.",
+    ),
     ("multi-angle-review", "python3 forge/stage4_review/diagnose_render_multi_angle.py --reference <fixed-shot> --orbit <orbit-shot> --orbit <orbit-shot>"),
     ("pass-gate-check", "python3 forge/stage3_build/orchestrate_passes.py check {spec} --pass-id {pass_id}"),
     ("ai-review-recorded", "Create the comparison sheet, inspect it with agent vision, and append exactly one review action"),
@@ -277,6 +329,19 @@ def mark_steps(
         raise WorkflowStateError("mark status must be done, skipped, or pending")
     if status == "done" and not evidence:
         raise WorkflowStateError("completing a mandatory step requires at least one --evidence value")
+    if status == "done":
+        for step_id in step_ids:
+            required = CONTRACT_DOCS.get(step_id)
+            if not required:
+                continue
+            joined = " ".join(evidence or [])
+            missing = [doc for doc in required if doc not in joined]
+            if missing:
+                raise WorkflowStateError(
+                    f"step {step_id!r} is a contract read: its --evidence must name every required "
+                    f"document, and these are missing: {', '.join(missing)}. Read them, then mark "
+                    f"the step with each path as evidence."
+                )
     if status == "skipped" and not reason.strip():
         raise WorkflowStateError("skipping a mandatory step requires --reason")
     by_id = {entry["id"]: entry for entry in state["checklist"]}

--- a/forge/stage4_review/append_review.py
+++ b/forge/stage4_review/append_review.py
@@ -208,6 +208,22 @@ def sync_pipeline(spec: dict) -> None:
     )
 
 
+OVER_CLAIM_MARGIN: float = 0.15
+
+
+def load_divine_eye_json(value: str, label: str):
+    """Accept either inline JSON or a path to a divine_eye.py --json report."""
+    import json as _json
+    from pathlib import Path as _Path
+    candidate = _Path(value).expanduser()
+    if candidate.exists():
+        return _json.loads(candidate.read_text(encoding="utf-8"))
+    try:
+        return _json.loads(value)
+    except _json.JSONDecodeError as exc:
+        raise ValueError(f"{label} must be inline JSON or an existing JSON file path") from exc
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("spec", type=Path)
@@ -246,6 +262,16 @@ def main(argv: list[str]) -> int:
         action="store_true",
         help="Require local screenshot paths to exist before writing the review",
     )
+    parser.add_argument(
+        "--divine-eye-json",
+        help="divine_eye.py --json output (inline JSON or a file path). Required for a visual pass: "
+        "it is the deterministic measurement your own score is checked against.",
+    )
+    parser.add_argument(
+        "--over-claim-reason",
+        help="Justification for scoring more than %.2f above the Divine Eye's measured fidelity. "
+        "Required, and recorded in the review." % OVER_CLAIM_MARGIN,
+    )
     parser.add_argument("--in-place", action="store_true", help="Write back to the input spec")
     parser.add_argument("--out", type=Path, help="Output JSON path when not using --in-place")
     args = parser.parse_args(argv)
@@ -259,6 +285,40 @@ def main(argv: list[str]) -> int:
             "visual pass cannot use action=continue without --render-screenshot; "
             "capture a browser screenshot or choose refine-code/request-input"
         )
+
+    divine = None
+    # --- over-claim guard -------------------------------------------------------------------
+    # A visual pass is scored by the agent looking at a comparison sheet, and an agent looking at
+    # its own work grades it generously: on the reconstruction that produced this guard, the
+    # recorded ai-vision-score was 0.72 while divine_eye.py measured 0.5072 on the same render,
+    # and the user's read was lower than both. self_correction.md's first section is about
+    # exactly this ("Over-claiming destroys trust and makes iterative improvement impossible"),
+    # and prose did not stop it. So the measurement is now required, and a score far above it
+    # has to be argued for in writing rather than simply asserted.
+    if args.divine_eye_json:
+        divine = load_divine_eye_json(args.divine_eye_json, "--divine-eye-json")
+    if args.pass_id in VISUAL_PASS_IDS:
+        if divine is None:
+            raise ValueError(
+                "visual pass requires --divine-eye-json: run "
+                "forge/stage4_review/divine_eye.py --reference <ref> --render <shot> --json first. "
+                "It is the harness heart and the single authority on how close the render is; a "
+                "self-reported score with nothing to check it against is not evidence."
+            )
+        measured = divine.get("fidelity")
+        if not isinstance(measured, (int, float)):
+            raise ValueError("--divine-eye-json has no numeric `fidelity`")
+        claimed = args.ai_vision_score if args.ai_vision_score is not None else args.fidelity
+        if claimed - float(measured) > OVER_CLAIM_MARGIN and not args.over_claim_reason:
+            raise ValueError(
+                f"claimed score {claimed:.3f} exceeds the Divine Eye's measured fidelity "
+                f"{float(measured):.3f} by more than {OVER_CLAIM_MARGIN:.2f}. Either lower the "
+                "score to what the render supports, or pass --over-claim-reason explaining what "
+                "the deterministic signals miss. Note that ssim/edgeOverlap are known to be "
+                "dominated by framing against a photo (see self_correction.md's Divine Eye "
+                "caveat), which is a legitimate reason -- 'it looks better to me' is not."
+            )
+
 
     spec_path = args.spec.expanduser().resolve()
     spec = load_spec(spec_path)
@@ -379,6 +439,16 @@ def main(argv: list[str]) -> int:
     }
     if args.force_out_of_order:
         entry["outOfSequence"] = True
+    if divine is not None:
+        entry["divineEye"] = {
+            "fidelity": divine.get("fidelity"),
+            "fidelityTarget": divine.get("fidelityTarget"),
+            "verdict": divine.get("verdict"),
+            "action": divine.get("action"),
+            "hardGateFailures": divine.get("hardGateFailures"),
+            "signals": divine.get("signals"),
+            "overClaimReason": args.over_claim_reason,
+        }
     if args.map_stripped_render:
         entry["mapStrippedRender"] = args.map_stripped_render
     if args.review_viewpoints_json:

--- a/forge/tests/test_pipeline.py
+++ b/forge/tests/test_pipeline.py
@@ -621,6 +621,32 @@ class PipelineTest(unittest.TestCase):
                           "--in-place")
         self.assertNotEqual(no_evidence.returncode, 0)
         self.assertIn("render-screenshot", no_evidence.stdout + no_evidence.stderr)
+        # GATE: a visual pass must carry the Divine Eye's own measurement. A self-reported score
+        # with nothing to check it against is not evidence -- this guard exists because a review
+        # was once recorded at 0.72 while divine_eye.py measured 0.5072 on the same render.
+        de = run("stage4_review/divine_eye.py", "--reference", self.ref, "--render", self.render, "--json")
+        divine = self.dir / "divine.json"
+        divine.write_text(de.stdout)
+        no_eye = run("stage4_review/append_review.py", self.spec, "--pass-id", "blockout",
+                     "--fidelity", "0.8", "--action", "refine-code",
+                     "--summary", "no divine eye", "--ai-vision-score", "0.8", "--in-place")
+        self.assertNotEqual(no_eye.returncode, 0)
+        self.assertIn("divine-eye-json", no_eye.stdout + no_eye.stderr)
+
+        # GATE: a score far above the measured fidelity needs an argument, not an assertion.
+        # Uses a fixed low measurement so the gate is tested directly rather than through
+        # whatever score the synthetic render happens to earn.
+        measured = json.loads(de.stdout)["fidelity"]
+        low = self.dir / "divine-low.json"
+        low.write_text(json.dumps({"fidelity": 0.20, "verdict": "reject", "action": "refine-spec",
+                                   "hardGateFailures": [], "signals": {}}))
+        over = run("stage4_review/append_review.py", self.spec, "--pass-id", "blockout",
+                   "--fidelity", "0.9", "--action", "refine-code",
+                   "--summary", "over-claimed", "--ai-vision-score", "0.9",
+                   "--divine-eye-json", low, "--in-place")
+        self.assertNotEqual(over.returncode, 0)
+        self.assertIn("exceeds the Divine Eye", over.stdout + over.stderr)
+
         # WITH evidence: the review is recorded.
         cmp = self.dir / "cmp.png"
         run("stage4_review/make_comparison_sheet.py", "--reference", self.ref,
@@ -645,10 +671,15 @@ class PipelineTest(unittest.TestCase):
                 "--map-stripped-render", self.render,
                 "--ai-vision-score", "0.8", "--layer-scores-json", layers,
                 "--feature-reviews-json", freviews,
+                "--divine-eye-json", divine,
+                "--over-claim-reason", "ssim/edgeOverlap are dominated by framing against a photo",
                 "--camera-view", "front", "--in-place")
         self.assertEqual(r.returncode, 0, r.stderr)
         spec = json.loads(self.spec.read_text())
         self.assertTrue(len(spec.get("reviewHistory", [])) >= 1)
+        # the measurement is recorded alongside the claim, so the two can never drift apart again
+        self.assertIn("divineEye", spec["reviewHistory"][-1])
+        self.assertAlmostEqual(spec["reviewHistory"][-1]["divineEye"]["fidelity"], measured, places=6)
 
     def test_pbr_extraction_runs(self):
         # low-detail synthetic image: either passes or refuses (non-zero) — both are valid,

--- a/forge/tests/test_workflow_state.py
+++ b/forge/tests/test_workflow_state.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT / "forge" / "_shared"))
 
 from workflow_state import (  # noqa: E402
+    CONTRACT_DOCS,
     WorkflowStateError,
     mark_steps,
     new_state,
@@ -19,6 +20,16 @@ from workflow_state import (  # noqa: E402
     status_payload,
     sync_from_spec,
 )
+
+
+def bulk_evidence(*extra: str) -> list[str]:
+    """Evidence for a bulk mark that walks past the contract-read steps.
+
+    Those steps require their own document paths by name, so a bulk walk has to carry them.
+    That is the guard working as intended, not a test inconvenience.
+    """
+    docs = [doc for paths in CONTRACT_DOCS.values() for doc in paths]
+    return list(extra) + docs
 
 
 class WorkflowStateTest(unittest.TestCase):
@@ -100,13 +111,13 @@ class WorkflowStateTest(unittest.TestCase):
     def test_new_pass_archives_and_resets_pass_checklist(self):
         state = new_state("reference.png")
         setup_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "setup"]
-        mark_steps(state, setup_ids, status="done", evidence=["setup-evidence.json"])
+        mark_steps(state, setup_ids, status="done", evidence=bulk_evidence("setup-evidence.json"))
         set_current_pass(state, "blockout")
         mark_steps(
             state,
             ["build-current-pass", "render-capture", "review-contract-read", "tier1-diagnostics"],
             status="done",
-            evidence=["shot.png"],
+            evidence=bulk_evidence("shot.png"),
         )
         set_current_pass(state, "structural-pass")
         self.assertEqual(state["passHistory"][0]["passId"], "blockout")
@@ -122,9 +133,9 @@ class WorkflowStateTest(unittest.TestCase):
         state = new_state("reference.png")
         setup_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "setup"]
         pass_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "pass"]
-        mark_steps(state, setup_ids, status="done", evidence=["setup.json"])
+        mark_steps(state, setup_ids, status="done", evidence=bulk_evidence("setup.json"))
         set_current_pass(state, "blockout")
-        mark_steps(state, pass_ids, status="done", evidence=["review.json"])
+        mark_steps(state, pass_ids, status="done", evidence=bulk_evidence("review.json"))
         self.assertEqual(status_payload(state)["currentStep"], "await-pass-transition")
 
         spec = {"reviewHistory": [{"passId": "blockout", "action": "refine-code"}]}
@@ -141,7 +152,7 @@ class WorkflowStateTest(unittest.TestCase):
     def test_new_pass_and_refine_spec_regenerate_with_force(self):
         state = new_state("reference.png", spec="spec.json")
         setup_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "setup"]
-        mark_steps(state, setup_ids, status="done", evidence=["setup.json"])
+        mark_steps(state, setup_ids, status="done", evidence=bulk_evidence("setup.json"))
         set_current_pass(state, "blockout")
         self.assertNotIn("--force", status_payload(state)["nextCommand"])
         set_current_pass(state, "structural-pass")
@@ -218,7 +229,7 @@ class WorkflowStateTest(unittest.TestCase):
             spec_path = Path(directory) / "spec.json"
             state = new_state("reference.png", spec=str(spec_path))
             setup_ids = [entry["id"] for entry in state["checklist"] if entry["scope"] == "setup"]
-            mark_steps(state, setup_ids, status="done", evidence=["setup.json"])
+            mark_steps(state, setup_ids, status="done", evidence=bulk_evidence("setup.json"))
             state_path.write_text(json.dumps(state), encoding="utf-8")
             spec_path.write_text(
                 json.dumps({"buildPasses": [{"id": "blockout", "acceptance": []}], "reviewHistory": []}),
@@ -313,3 +324,55 @@ class WorkflowStateTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class ContractReadGuardTest(unittest.TestCase):
+    """A contract-read step must name every document it certifies.
+
+    Nothing can prove a document was read. What can be enforced is that the step names the right
+    ones -- and the failure this guards against is concrete: `review-contract-read` was once
+    marked done with evidence "object-sculpt-spec.json", the step passed, the documents went
+    unread, and the rules they carry were the exact rules then broken.
+    """
+
+    def setUp(self) -> None:
+        self.base = new_state("reference.png", profile="character")
+
+    def _upto(self, target: str) -> dict:
+        state = json.loads(json.dumps(self.base))
+        ids = [e["id"] for e in state["checklist"]]
+        prior = ids[: ids.index(target)]
+        if prior:
+            mark_steps(state, prior, status="done", evidence=bulk_evidence("prior.json"))
+        return state
+
+    def test_wrong_evidence_is_refused(self) -> None:
+        state = self._upto("review-contract-read")
+        with self.assertRaises(WorkflowStateError) as ctx:
+            mark_steps(state, ["review-contract-read"], status="done",
+                       evidence=["object-sculpt-spec.json"])
+        self.assertIn("gates_reference.md", str(ctx.exception))
+        self.assertIn("self_correction.md", str(ctx.exception))
+
+    def test_partial_evidence_is_refused(self) -> None:
+        state = self._upto("build-contract-read")
+        with self.assertRaises(WorkflowStateError) as ctx:
+            mark_steps(state, ["build-contract-read"], status="done",
+                       evidence=["grimoire/build/geometry_patterns.md"])
+        self.assertIn("shading_realism.md", str(ctx.exception))
+
+    def test_naming_every_document_is_accepted(self) -> None:
+        state = self._upto("build-contract-read")
+        mark_steps(state, ["build-contract-read"], status="done",
+                   evidence=["grimoire/build/geometry_patterns.md",
+                             "grimoire/feedback/shading_realism.md"])
+        entry = next(s for s in state["checklist"] if s["id"] == "build-contract-read")
+        self.assertEqual(entry["status"], "done")
+
+    def test_character_profile_requires_the_pipeline_doc(self) -> None:
+        state = self._upto("build-contract-read")
+        ids = [s["id"] for s in state["checklist"]]
+        self.assertIn("character-pipeline-read", ids)
+        self.assertIn("divine-eye", ids)
+        self.assertIn("build-contract-read", ids)
+        self.assertIn("topology-contract-read", ids)


### PR DESCRIPTION
## What happened

An agent ran this skill end to end on a character reconstruction, marked every checklist step, and never opened `geometry_patterns.md`, `surface_topology.md` or `standard_character_pipeline.md` — and never ran `divine_eye.py`.

Not one gate objected. Those requirements live in `SKILL.md`'s prose ("MUST read", "the harness heart") while the state machine enforces a different, shorter list. The single mandatory read that *is* a checklist step, `review-contract-read`, is the only one that got caught — and only because it was marked out of order.

The rules that went unread were the ones that then broke the reconstruction:

- `geometry_patterns.md`: *"Do NOT eyeball proportions — extract 1-to-1 from reference. Eyeballed shapes are consistently wrong."* Every radius in that spec was eyeballed, which is exactly why the figure read as a stack of unrelated pods.
- `self_correction.md`: *"NEVER report a 2D-gate PASS as done."* A silhouette IoU was reported as if it were a likeness score.

## Four steps added

| Step | Enforces | Scope |
|---|---|---|
| `topology-contract-read` | `surface_topology.md` + `detail_inventory.md`, before a primitive is ever chosen | setup |
| `build-contract-read` | `geometry_patterns.md` + `shading_realism.md`, before any geometry is generated | setup |
| `character-pipeline-read` | `standard_character_pipeline.md` | character profile |
| `divine-eye` | `divine_eye.py` on every pass | pass |

`build-contract-read` is setup-scoped on purpose: read once per reconstruction, not once per correction loop, so the refine → regenerate flow is unchanged.

`divine-eye` is the notable gap — `SKILL.md` calls it "the harness heart" and "the single authority the correction loop asks", and only `diagnose_render.py`, explicitly labelled *legacy*, was in the checklist.

## Two guards, because a checklist step is self-certified

**1. A contract-read step must name its documents.**

```
$ state.py mark review-contract-read --evidence object-sculpt-spec.json
WorkflowStateError: step 'review-contract-read' is a contract read: its --evidence must name
every required document, and these are missing: grimoire/review/gates_reference.md,
grimoire/review/self_correction.md
```

That exact call is how the reads were skipped in practice. Nothing can prove a document was read; marking the step is at least no longer free.

**2. `append_review.py` refuses a score it cannot check.**

A visual pass now requires `--divine-eye-json`, and a claim more than 0.15 above the measured fidelity requires `--over-claim-reason` in writing. The review that prompted this was recorded at **0.72 while `divine_eye.py` measured 0.5072 on the same render** — and the human's read was lower than both.

The measurement is stored on the review entry, so claim and measurement can never drift apart unrecorded again.

`self_correction.md` opens with a section titled *"Transparency and Process Debugging"* whose whole subject is over-claiming. It did not stop it, because it was only prose.

## Tests

- `ContractReadGuardTest` in `test_workflow_state.py` — wrong evidence refused, partial evidence refused, naming every document accepted, character profile carries all four new steps.
- `test_pipeline.py::test_append_review_gate_and_record` extended — a visual pass without `--divine-eye-json` is refused; a claim 0.9 against a measured 0.20 is refused; the recorded review carries the measurement.

Full suite: **677 tests, OK.**
