### PR TITLE
fix(capture): screenshots dropped the canvas alpha, so every photometric signal measured the backdrop

### DIFF
--- a/forge/tests/test_capture_alpha_contract.py
+++ b/forge/tests/test_capture_alpha_contract.py
@@ -1,0 +1,40 @@
+"""The browser capture must preserve the canvas alpha.
+
+divine_eye.py's photometric signals (ssim, blowoutParity, tonalParity, hueZoneParity) compare
+full frames. If the capture is composited onto the page background while the reference carries
+alpha, those four signals measure the BACKDROP, not the model -- and the mask-based signals
+(silhouette IoU, scale) are unaffected, so the result looks like a real material failure rather
+than a measurement fault.
+
+Observed on the reconstruction that produced this test, same render both ways:
+
+    composited onto white   fidelity 0.5075   ssim 0.000  blowout 0.000  tonal 0.217
+    like-for-like           fidelity 0.8349   ssim 0.916  blowout 0.987  tonal 0.876
+
+Three correction rounds were spent tuning geometry against the first number.
+"""
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+ADAPTER = ROOT / "scripts" / "capture_threejs_playwright.py"
+
+
+class CaptureAlphaContract(unittest.TestCase):
+    def setUp(self) -> None:
+        self.text = ADAPTER.read_text(encoding="utf-8")
+
+    def test_every_screenshot_call_omits_the_background(self) -> None:
+        calls = [line for line in self.text.splitlines() if ".screenshot(path=" in line]
+        self.assertTrue(calls, "expected at least one screenshot call in the adapter")
+        for line in calls:
+            self.assertIn("omit_background=True", line, f"screenshot call drops alpha: {line.strip()}")
+
+    def test_the_reason_is_recorded_next_to_the_call(self) -> None:
+        self.assertIn("measures the BACKDROP rather than the model", self.text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/capture_threejs_playwright.py
+++ b/scripts/capture_threejs_playwright.py
@@ -163,9 +163,17 @@ def capture(manifest_path_value: Path, capture_ids: list[str], headed: bool, tim
                     if pass_result.get("ok") is False:
                         raise RuntimeError(str(pass_result.get("reason", "beauty pass failed")))
                     selector = str(pass_result.get("selector", "canvas"))
-                    page.locator(selector).screenshot(path=str(screenshot))
+                    page.locator(selector).screenshot(path=str(screenshot), omit_background=True)
                 else:
-                    page.screenshot(path=str(screenshot), full_page=False)
+                    # omit_background keeps the canvas's own alpha instead of compositing the
+                    # page behind it. Without it every photometric signal in divine_eye.py
+                    # measures the BACKDROP rather than the model: on the reconstruction that
+                    # found this, a white-composited capture scored ssim 0.000, blowoutParity
+                    # 0.000 and tonalParity 0.217 against an RGBA reference, and the same render
+                    # compared like-for-like scored 0.916 / 0.987 / 0.876 -- fidelity 0.5075 vs
+                    # 0.8349. The mask-based signals (IoU, scale) were unaffected, which is why
+                    # it read as a real material failure for several correction rounds.
+                    page.screenshot(path=str(screenshot), full_page=False, omit_background=True)
                 ready_value = page.evaluate("() => window.__IMG2THREEJS_READY__")
                 if mode == "reference":
                     record_reference_capture(
@@ -208,7 +216,10 @@ def capture(manifest_path_value: Path, capture_ids: list[str], headed: bool, tim
                             if pass_result.get("ok") is False:
                                 raise RuntimeError(str(pass_result.get("reason", "diagnostic pass failed")))
                             selector = str(pass_result.get("selector", "canvas"))
-                            page.locator(selector).screenshot(path=str(pass_path))
+                            # same rule for the v2 pass captures: the alpha-silhouette pass is
+                            # meaningless composited, and per-region scoring on the others reads
+                            # cleaner masks without the page behind them
+                            page.locator(selector).screenshot(path=str(pass_path), omit_background=True)
                         record_capture_pass(
                             manifest_path_value,
                             manifest,


### PR DESCRIPTION
## The bug

`divine_eye.py`'s `ssim`, `blowoutParity`, `tonalParity` and `hueZoneParity` compare **full frames**. The Playwright adapter composited the page background behind the canvas, so whenever the reference carries alpha — which it does for every cutout reference this pipeline is built around — those four signals were comparing a white field against a transparent one.

Same render, measured both ways:

| | fidelity | ssim | blowoutParity | tonalParity |
|---|---|---|---|---|
| composited (before) | **0.5075** | 0.000 | 0.000 | 0.217 |
| like-for-like (after) | **0.8349** | 0.916 | 0.987 | 0.876 |

## Why it was expensive

The **mask-based** signals were unaffected — silhouette IoU 0.874, scale 0.982, objectness 0.860. So the evaluator reported *strong geometry, dead materials*, which is a completely plausible and completely wrong diagnosis. Three correction rounds went into rebuilding geometry that was never the problem, while the model actually sat around 0.78 and the number said 0.51.

`self_correction.md` already warns that pixel-aligned signals are "dominated by framing + background + scale + lighting differences" in photo-vs-procedural mode. This is that failure mode arriving from inside the harness rather than from the reference.

## The fix

One argument, on all three screenshot calls: `omit_background=True`.

## Test

`forge/tests/test_capture_alpha_contract.py` asserts every `screenshot(path=...)` call in the adapter preserves alpha, and that the reason is recorded next to it.

It earned its keep immediately: it caught the third call — the v2 `capturePass` path — that the first pass of this fix missed.

Full suite: **677 tests, OK.**
