### PR TITLE
fix: make skill version metadata Codex-compatible

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          current_version="$(sed -nE 's/^version: ([0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?)$/\1/p' SKILL.md)"
+          current_version="$(sed -nE 's/^  version: ([0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?)$/\1/p' SKILL.md)"
           if [ -z "$current_version" ]; then
             echo "SKILL.md must contain one supported version field."
             exit 1
@@ -49,7 +49,7 @@ jobs:
             exit 1
           fi
 
-          sed -i -E "s/^version: [0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$/version: $next_version/" SKILL.md
+          sed -i -E "s/^  version: [0-9]+\.[0-9]+\.[0-9]+(-beta\.[0-9]+)?$/  version: $next_version/" SKILL.md
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add SKILL.md

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,7 +2,8 @@
 name: img2threejs
 description: Turn an object or character reference image into a quality-gated, animation-ready procedural Three.js model built in code. Use for image-to-3D reconstruction, detail-accurate object rebuilds, stylized/likeness-maximized human characters, sculpt specs, and staged code generation.
 license: Apache-2.0
-version: 1.4.4
+metadata:
+  version: 1.4.4
 ---
 
 # img2threejs — Image to procedural Three.js

--- a/forge/tests/test_release_metadata.py
+++ b/forge/tests/test_release_metadata.py
@@ -13,7 +13,10 @@ SCRIPT = ROOT / "scripts" / "release_metadata.py"
 
 class ReleaseMetadataTests(unittest.TestCase):
     def write_project(self, directory: Path) -> tuple[Path, Path]:
-        (directory / "SKILL.md").write_text("---\nversion: 1.4.1\n---\n", encoding="utf-8")
+        (directory / "SKILL.md").write_text(
+            "---\nname: fixture\ndescription: Release fixture.\nmetadata:\n  version: 1.4.1\n---\n",
+            encoding="utf-8",
+        )
         (directory / "README.md").write_text(
             "[![Version](https://img.shields.io/badge/version-1.4.1-green.svg)](CHANGELOG.md)\n",
             encoding="utf-8",
@@ -57,7 +60,7 @@ class ReleaseMetadataTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(json.loads(result.stdout)["version"], "1.5.0")
-            self.assertIn("version: 1.5.0", (project / "SKILL.md").read_text(encoding="utf-8"))
+            self.assertIn("  version: 1.5.0", (project / "SKILL.md").read_text(encoding="utf-8"))
             self.assertIn("version-1.5.0-green.svg", (project / "README.md").read_text(encoding="utf-8"))
             changelog = (project / "CHANGELOG.md").read_text(encoding="utf-8")
             self.assertIn("## [1.5.0] — 2026-07-26", changelog)

--- a/forge/tests/test_ws6_docs.py
+++ b/forge/tests/test_ws6_docs.py
@@ -14,10 +14,10 @@ SKILL = ROOT / "SKILL.md"
 README = ROOT / "README.md"
 CHANGELOG = ROOT / "CHANGELOG.md"
 
-# Both release paths anchor the version key at column zero: `scripts/release_metadata.py` with
-# VERSION_PATTERN, and `.github/workflows/beta-release.yml` with an equivalent sed. Accept the
-# stable and the beta spellings the beta workflow round-trips between.
-SKILL_VERSION_PATTERN = re.compile(r"^version: (\d+\.\d+\.\d+(?:-beta\.\d+)?)$", re.MULTILINE)
+# Both release paths read `metadata.version`: `scripts/release_metadata.py` with VERSION_PATTERN,
+# and `.github/workflows/beta-release.yml` with an equivalent sed. Accept the stable and the beta
+# spellings the beta workflow round-trips between.
+SKILL_VERSION_PATTERN = re.compile(r"^  version: (\d+\.\d+\.\d+(?:-beta\.\d+)?)$", re.MULTILINE)
 README_BADGE_PATTERN = re.compile(r"version-(\d+\.\d+\.\d+(?:-beta\.\d+)?)-green\.svg")
 
 
@@ -41,19 +41,22 @@ class Ws6DocsTest(unittest.TestCase):
             with self.subTest(marker=marker):
                 self.assertIn(marker, text)
 
-    def test_skill_version_is_reachable_by_the_release_tooling(self) -> None:
+    def test_skill_version_is_codex_compatible_and_reachable_by_release_tooling(self) -> None:
         """Assert against the real SKILL.md, never a fixture.
 
-        Nesting the key under a `metadata:` parent is valid YAML and reads fine to a human, so it
-        survived review; both release paths then match nothing and abort -- the beta workflow with
-        "SKILL.md must contain one supported version field", `release_metadata.py` with
-        "must contain exactly one replaceable version". A fixture-only test cannot see that,
-        because the fixture is the shape the tooling wants rather than the shape on disk.
+        Codex rejects an unrecognized top-level `version` key, so the release version lives under
+        the supported `metadata` mapping. Both release paths must keep matching that exact shape.
+        A fixture-only test cannot catch the real SKILL.md drifting away from the release tooling.
         """
-        match = SKILL_VERSION_PATTERN.search(SKILL.read_text(encoding="utf-8"))
+        skill_text = SKILL.read_text(encoding="utf-8")
+        self.assertIsNone(
+            re.search(r"^version:", skill_text, re.MULTILINE),
+            "SKILL.md must not use the unsupported top-level `version` key",
+        )
+        match = SKILL_VERSION_PATTERN.search(skill_text)
         self.assertIsNotNone(
             match,
-            "SKILL.md needs one unindented `version:` front-matter key for the release tooling",
+            "SKILL.md needs one `metadata.version` field for the release tooling",
         )
 
     def test_readme_declares_one_version_badge_matching_the_skill(self) -> None:

--- a/scripts/release_metadata.py
+++ b/scripts/release_metadata.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Final
 
 
-VERSION_PATTERN: Final = re.compile(r"^version: (\d+)\.(\d+)\.(\d+)$", re.MULTILINE)
+VERSION_PATTERN: Final = re.compile(r"^  version: (\d+)\.(\d+)\.(\d+)$", re.MULTILINE)
 BADGE_PATTERN: Final = re.compile(r"version-\d+\.\d+\.\d+-green\.svg")
 HEADING_PATTERN: Final = re.compile(r"^## \[", re.MULTILINE)
 REFERENCE_PATTERN: Final = re.compile(r"^\[", re.MULTILINE)
@@ -75,7 +75,7 @@ def release_level(commits: tuple[str, ...]) -> ReleaseLevel | None:
 def parse_version(skill_text: str) -> Version:
     match = VERSION_PATTERN.search(skill_text)
     if match is None:
-        raise ValueError("SKILL.md must contain one semantic version front-matter field")
+        raise ValueError("SKILL.md must contain one semantic version metadata field")
     return Version(*(int(value) for value in match.groups()))
 
 
@@ -127,7 +127,7 @@ def apply_release(request: ReleaseRequest) -> ReleasePlan | None:
     skill_text = skill_path.read_text(encoding="utf-8")
     current = parse_version(skill_text)
     plan = ReleasePlan(current=current, next=current.bump(level), level=level, commits=request.commits)
-    updated_skill = replace_once(VERSION_PATTERN, skill_text, f"version: {plan.next}", "SKILL.md")
+    updated_skill = replace_once(VERSION_PATTERN, skill_text, f"  version: {plan.next}", "SKILL.md")
     readme_text = readme_path.read_text(encoding="utf-8")
     updated_readme = replace_once(BADGE_PATTERN, readme_text, f"version-{plan.next}-green.svg", "README.md")
     changelog_text = changelog_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- Move the skill release version from the top-level `version` key to `metadata.version`.
- Update stable and beta release automation to read and write the nested field.
- Update release fixtures and add a regression assertion that rejects the unsupported top-level key.

## Why

The repository says it supports Codex, but Codex skill validation rejects `SKILL.md` because `version` is not an allowed top-level frontmatter key. The existing release automation and tests require that exact invalid shape, so users currently have to choose between an unmodified release path and a Codex-loadable skill.

This keeps version metadata in `SKILL.md` and preserves both release paths without changing the reconstruction or installation architecture.

Refs #95

## Validation

- Codex `quick_validate.py`: passed
- Targeted release metadata and documentation tests: passed
- Beta workflow `sed` read/write smoke: `1.4.4 -> 1.5.0-beta.1`
- Full Python suite: 673 passed, 25 skipped

The skipped tests require the optional showcase checkout, as documented by the repository.
