### PR TITLE
Add adaptive harsh multi-view critic

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -324,6 +324,30 @@ Full flags: `grimoire/scripts.md`. Never let a script *score* visuals — that i
    grid, and neither can represent any of these defects. Read `sampledVertexCount` /
    `unmeasuredAttachments` / `missingAzimuths` before believing a clean verdict: each names the part of
    the model the gate did not actually look at.
+7b. **Adaptive hostile scene critic — escalate beyond a fixed turntable when off-axis quality is
+   important.** Read `grimoire/review/adaptive_harsh_critic.md` completely. Initialize the six-face
+   cube-map sphere with `adaptive_harsh_critic.py init`, send `nextViews` into the real browser scene
+   with `render_bridge.py schedule-adaptive`, capture them with
+   `scripts/capture_threejs_playwright.py` (the generic `render_bridge.py record` path is forbidden
+   for adaptive evidence), then run `adaptive_harsh_critic.py request`. The runtime must return the
+   nonce-bound scene digest and actual camera matrices required by `getEvidenceSnapshot`; strict
+   ready, viewport/DPR/canvas/drawing-buffer dimensions, encoded/decoded pixel hashes and distinct
+   (including non-near-identical alpha-composited visible-RGB and demeaned-luma structure)
+   pixels/matrices across directions are
+   fail-closed. Treat the
+   receipt as trusted local-runner attestation, not cryptographic proof; the generic record CLI
+   cannot mint it. Every init uses random session-scoped capture IDs/paths. `request` locks the first
+   scene build, source reference, per-view GLB reference captures, and historical evidence ledger,
+   then pins its complete canonical digest in
+   `state.pendingRequest`, and
+   `advance` rejects any changed request before consuming that pin. Create a separate critic agent
+   for that request; the contract rejects
+   `critic.id == creator.id`. Every review and every finding must bind the actual PNG SHA-256 and
+   exact unit view direction. With the default `minimumUniformLevel=1`, six clean face centres MUST
+   still expand to 24 level-1 captures, so fewer than 30 real reviewed views cannot pass. After that
+   uniform floor, any defective cell splits into four child views. A critical finding is an AND
+   failure and cannot be hidden by averages or clean sides. Repeat only until pass,
+   repeated-defect, plateau, max-views, or max-rounds.
 8. Package one side-by-side sheet, then inspect it with agent vision:
    `forge/stage4_review/make_comparison_sheet.py --reference <img> --render <shot> --out cmp.png --json`.
 9. Record the review (overall + per-layer + per-feature scores + decision):
@@ -464,6 +488,22 @@ evidence caused it, what still differs, and choose exactly one next action:
   `forge/stage4_review/diagnose_render_multi_angle.py` flags `degenerate-view` when an orbited
   silhouette collapses (a flat plane faking a volume). Orbit angles use reference-free
   self-consistency — never scored against a reference angle the photo doesn't cover.
+- **Adaptive harsh critic (independent, pixel-bound, bounded)**:
+  `forge/stage4_review/adaptive_harsh_critic.py` starts from six cube-map sides, recursively
+  first enforces 6+24 uniformly captured views by default, then subdivides directions that expose
+  defects and emits `nextViews` for the Playwright adapter to capture from the real scene. Adaptive
+  captures require a nonce-bound browser/runtime/scene/camera trusted local-runner receipt and reject
+  duplicate or near-identical alpha-composited visible-RGB/structure pixels and duplicate camera matrices across different
+  directions. The receipt is not cryptographic proof and cannot be minted by the generic record CLI.
+  Scheduling validates canonical session/view/cell/round geometry and confines every generated
+  capture/reference/pass path below the manifest evidence root. Random session-scoped IDs/paths prevent stale-name reuse; the first scene build, original reference
+  source, required per-view GLB reference captures, and historical evidence ledger remain immutable.
+  Every issued request is canonical-digest pinned in state until one successful `advance --in-place`
+  consumes it; branch-like `advance --out` is intentionally unsupported. The critic ID
+  must differ from the creator ID; every finding is bound to a
+  capture hash + view direction; one critical finding blocks the run with no averaging. Fixed
+  turntable coverage remains mandatory. Repeated defects, plateau, max views, and max rounds
+  guarantee termination. Full contract: `grimoire/review/adaptive_harsh_critic.md`.
 - **CS2 review contract**: `forge/stage4_review/cs2_review.py` consumes the manifest and
   versioned scene fixture, then blocks wrong family identity, missing projection coverage,
   painted-region mismatch, critical identity-detail failure, finish/material response failure,
@@ -603,6 +643,10 @@ riggers are offline inference whose value here is the serialized payload, not a 
 Executable entry points are `forge/stage4_review/render_bridge.py` and
 `scripts/capture_threejs_playwright.py`. Run `init → browser capture → validate → diagnose`;
 capture must operate on the real showcase/browser route and leave readable PNGs in the workspace.
+For hostile multi-view escalation, add `adaptive_harsh_critic.py init → render_bridge.py
+schedule-adaptive → browser capture → adaptive_harsh_critic.py request → independent critic agent
+→ adaptive_harsh_critic.py advance`; adaptive browser capture specifically uses
+`scripts/capture_threejs_playwright.py` and requires the runtime `getEvidenceSnapshot` contract.
 
 ## Output
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,10 @@ flowchart TD
     F --> G[Generate Three.js factory: current pass only]
     G --> H[Render in browser and screenshot]
     H --> I[Package one side-by-side sheet]
+    H -. hostile off-axis escalation .-> H2[Adaptive cube-map captures: 6+24 minimum]
+    H2 --> H3[Independent hash-bound critic]
+    H3 -- defective direction --> H2
+    H3 -- clean or bounded stop --> I
     I --> J{Agent vision review}
     J -- score below threshold --> K[Self-correct: refine-spec or refine-code]
     K --> F
@@ -115,6 +119,7 @@ The net effect: you still get a faithful 3D model from an image, but the expensi
 | `stage4_review/material_gate.py` | Blocking material acceptance and cross-pass compatibility gate. |
 | `stage4_review/validate_render_profile.py` | Validate the shared GLB/procedural renderer, camera and six-pass profile. |
 | `stage4_review/compare_region_passes.py` | Compare paired browser diagnostic passes and block unsupported per-region claims. |
+| `stage4_review/adaptive_harsh_critic.py` | Schedule a six-face then recursively refined real-scene view sphere; pin each complete issued request by canonical digest in state, require nonce-bound Playwright/WebGL/scene/camera receipts with non-collapsed pixels, and validate an independent critic plus bounded termination without averaging critical defects. |
 | `stage4_review/cs2_review.py` | Evaluate the blocking CS2 knife review contract and versioned scene thresholds. |
 | `_shared/feature_acceptance_policy.py` | Internal helper enforcing per-feature score thresholds. |
 | `stage1_intake/build_detail_inventory.py` | Slice the reference into zones and scaffold a detail inventory. |

--- a/docs/specs/adaptive-harsh-critic.v1.schema.json
+++ b/docs/specs/adaptive-harsh-critic.v1.schema.json
@@ -1,0 +1,481 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://img2threejs.local/specs/adaptive-harsh-critic.v1.schema.json",
+  "title": "img2threejs adaptive harsh critic v1 artifacts",
+  "description": "State, pixel-bound independent-critic request, and critic response contracts. Runtime validation is implemented by forge/stage4_review/adaptive_harsh_critic.py with no external dependencies.",
+  "oneOf": [
+    { "$ref": "#/$defs/state" },
+    { "$ref": "#/$defs/request" },
+    { "$ref": "#/$defs/response" }
+  ],
+  "$defs": {
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    },
+    "direction": {
+      "type": "array",
+      "prefixItems": [
+        { "type": "number", "minimum": -1, "maximum": 1 },
+        { "type": "number", "minimum": -1, "maximum": 1 },
+        { "type": "number", "minimum": -1, "maximum": 1 }
+      ],
+      "minItems": 3,
+      "maxItems": 3
+    },
+    "cell": {
+      "type": "object",
+      "required": ["projection", "face", "uMin", "uMax", "vMin", "vMax", "level", "path"],
+      "properties": {
+        "projection": { "const": "cube-map" },
+        "face": { "enum": ["front", "right", "rear", "left", "top", "bottom"] },
+        "uMin": { "type": "number", "minimum": -1, "maximum": 1 },
+        "uMax": { "type": "number", "minimum": -1, "maximum": 1 },
+        "vMin": { "type": "number", "minimum": -1, "maximum": 1 },
+        "vMax": { "type": "number", "minimum": -1, "maximum": 1 },
+        "level": { "type": "integer", "minimum": 0 },
+        "path": { "type": "string", "pattern": "^[0-3]*$" }
+      },
+      "additionalProperties": false
+    },
+    "viewPlan": {
+      "type": "object",
+      "required": ["id", "round", "parentId", "direction", "azimuthDegrees", "elevationDegrees", "angularRadiusDegrees", "cell"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^ahc-[a-f0-9]{20}-harsh-(front|right|rear|left|top|bottom)-(root|[0-3]+)$" },
+        "round": { "type": "integer", "minimum": 0 },
+        "parentId": { "type": ["string", "null"] },
+        "direction": { "$ref": "#/$defs/direction" },
+        "azimuthDegrees": { "type": "number", "minimum": -180, "maximum": 180 },
+        "elevationDegrees": { "type": "number", "minimum": -90, "maximum": 90 },
+        "angularRadiusDegrees": { "type": "number", "exclusiveMinimum": 0, "maximum": 90 },
+        "cell": { "$ref": "#/$defs/cell" }
+      },
+      "additionalProperties": false
+    },
+    "pendingRequest": {
+      "type": "object",
+      "required": ["requestId", "canonicalSha256", "round", "manifestSha256", "viewIds"],
+      "properties": {
+        "requestId": { "type": "string", "pattern": "^ahcr-[a-f0-9]{24}$" },
+        "canonicalSha256": { "$ref": "#/$defs/sha256" },
+        "round": { "type": "integer", "minimum": 0 },
+        "manifestSha256": { "$ref": "#/$defs/sha256" },
+        "viewIds": { "type": "array", "minItems": 1, "items": { "type": "string", "minLength": 1 } }
+      },
+      "additionalProperties": false
+    },
+    "evidenceLedgerEntry": {
+      "type": "object",
+      "required": ["viewId", "round", "capturePath", "captureSha256", "capturePixelSha256", "browserEvidenceSha256", "sceneBuildSha256", "direction"],
+      "properties": {
+        "viewId": { "type": "string", "pattern": "^ahc-[a-f0-9]{20}-harsh-" },
+        "round": { "type": "integer", "minimum": 0 },
+        "capturePath": { "type": "string", "minLength": 1 },
+        "captureSha256": { "$ref": "#/$defs/sha256" },
+        "capturePixelSha256": { "$ref": "#/$defs/sha256" },
+        "browserEvidenceSha256": { "$ref": "#/$defs/sha256" },
+        "sceneBuildSha256": { "$ref": "#/$defs/sha256" },
+        "direction": { "$ref": "#/$defs/direction" },
+        "referenceCapturePath": { "type": "string", "minLength": 1 },
+        "referenceCaptureSha256": { "$ref": "#/$defs/sha256" }
+      },
+      "dependentRequired": {
+        "referenceCapturePath": ["referenceCaptureSha256"],
+        "referenceCaptureSha256": ["referenceCapturePath"]
+      },
+      "additionalProperties": false
+    },
+    "browserEvidence": {
+      "type": "object",
+      "required": ["kind", "schemaVersion", "adapter", "sessionNonce", "captureId", "runtime", "browser", "camera", "canvas", "screenshot"],
+      "properties": {
+        "kind": { "const": "img2threejs.playwright-capture-receipt" },
+        "schemaVersion": { "const": 1 },
+        "adapter": {
+          "type": "object",
+          "required": ["name", "version"],
+          "properties": {
+            "name": { "const": "capture_threejs_playwright" },
+            "version": { "const": 1 }
+          },
+          "additionalProperties": false
+        },
+        "sessionNonce": { "type": "string", "pattern": "^[a-f0-9]{32,64}$" },
+        "captureId": { "type": "string", "minLength": 1 },
+        "runtime": {
+          "type": "object",
+          "required": ["requestedUrl", "documentUrl", "documentSha256", "readySignal", "captureContract", "snapshotEcho", "sceneBuildSha256", "objectCount"],
+          "properties": {
+            "requestedUrl": { "type": "string", "minLength": 1 },
+            "documentUrl": { "type": "string", "minLength": 1 },
+            "documentSha256": { "$ref": "#/$defs/sha256" },
+            "readySignal": {
+              "type": "object",
+              "required": ["expression", "value", "valueType"],
+              "properties": {
+                "expression": { "const": "window.__IMG2THREEJS_READY__" },
+                "value": { "const": true },
+                "valueType": { "const": "boolean" }
+              },
+              "additionalProperties": false
+            },
+            "captureContract": {
+              "type": "object",
+              "required": ["name", "setCamera", "getEvidenceSnapshot"],
+              "properties": {
+                "name": { "const": "window.__IMG2THREEJS_CAPTURE__" },
+                "setCamera": { "const": true },
+                "getEvidenceSnapshot": { "const": true }
+              },
+              "additionalProperties": false
+            },
+            "snapshotEcho": {
+              "type": "object",
+              "required": ["captureId", "sessionNonce"],
+              "properties": {
+                "captureId": { "type": "string", "minLength": 1 },
+                "sessionNonce": { "type": "string", "pattern": "^[a-f0-9]{32,64}$" }
+              },
+              "additionalProperties": false
+            },
+            "sceneBuildSha256": { "$ref": "#/$defs/sha256" },
+            "objectCount": { "type": "integer", "minimum": 1 }
+          },
+          "additionalProperties": false
+        },
+        "browser": {
+          "type": "object",
+          "required": ["name", "version", "headless"],
+          "properties": {
+            "name": { "const": "chromium" },
+            "version": { "type": "string", "minLength": 1 },
+            "headless": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        },
+        "camera": {
+          "type": "object",
+          "required": ["direction", "matrixWorld", "projectionMatrix"],
+          "properties": {
+            "direction": { "$ref": "#/$defs/direction" },
+            "matrixWorld": { "type": "array", "minItems": 16, "maxItems": 16, "items": { "type": "number" } },
+            "projectionMatrix": { "type": "array", "minItems": 16, "maxItems": 16, "items": { "type": "number" } }
+          },
+          "additionalProperties": false
+        },
+        "canvas": {
+          "type": "object",
+          "required": ["selector", "cssWidth", "cssHeight", "width", "height", "drawingBufferWidth", "drawingBufferHeight", "devicePixelRatio", "webgl"],
+          "properties": {
+            "selector": { "const": "canvas" },
+            "cssWidth": { "type": "integer", "minimum": 1 },
+            "cssHeight": { "type": "integer", "minimum": 1 },
+            "width": { "type": "integer", "minimum": 1 },
+            "height": { "type": "integer", "minimum": 1 },
+            "drawingBufferWidth": { "type": "integer", "minimum": 1 },
+            "drawingBufferHeight": { "type": "integer", "minimum": 1 },
+            "devicePixelRatio": { "type": "number", "minimum": 0.25, "maximum": 8 },
+            "webgl": { "const": true }
+          },
+          "additionalProperties": false
+        },
+        "screenshot": {
+          "type": "object",
+          "required": ["sha256", "pixelSha256", "width", "height"],
+          "properties": {
+            "sha256": { "$ref": "#/$defs/sha256" },
+            "pixelSha256": { "$ref": "#/$defs/sha256" },
+            "width": { "type": "integer", "minimum": 1 },
+            "height": { "type": "integer", "minimum": 1 }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "finding": {
+      "type": "object",
+      "required": ["defectKey", "severity", "category", "description", "viewId", "captureSha256", "direction"],
+      "properties": {
+        "defectKey": { "type": "string", "minLength": 1 },
+        "severity": { "enum": ["minor", "major", "critical"] },
+        "category": { "type": "string", "minLength": 1 },
+        "description": { "type": "string", "minLength": 1 },
+        "viewId": { "type": "string", "minLength": 1 },
+        "captureSha256": { "$ref": "#/$defs/sha256" },
+        "direction": { "$ref": "#/$defs/direction" }
+      },
+      "additionalProperties": false
+    },
+    "review": {
+      "type": "object",
+      "required": ["viewId", "captureSha256", "direction", "verdict", "findings"],
+      "properties": {
+        "viewId": { "type": "string", "minLength": 1 },
+        "captureSha256": { "$ref": "#/$defs/sha256" },
+        "direction": { "$ref": "#/$defs/direction" },
+        "verdict": { "enum": ["pass", "defect", "unreviewable"] },
+        "findings": { "type": "array", "items": { "$ref": "#/$defs/finding" } }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "verdict": { "const": "pass" } }, "required": ["verdict"] },
+          "then": { "properties": { "findings": { "maxItems": 0 } } }
+        },
+        {
+          "if": { "properties": { "verdict": { "const": "defect" } }, "required": ["verdict"] },
+          "then": { "properties": { "findings": { "minItems": 1 } } }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "state": {
+      "type": "object",
+      "required": ["kind", "schemaVersion", "sessionId", "creator", "scene", "policy", "currentRound", "rounds", "nextViews", "scheduledViewCount", "status", "action", "pendingRequest", "evidenceLedger"],
+      "properties": {
+        "kind": { "const": "img2threejs.adaptive-harsh-critic-state" },
+        "schemaVersion": { "const": 1 },
+        "sessionId": { "type": "string", "pattern": "^ahc-[a-f0-9]{20}$" },
+        "creator": {
+          "type": "object",
+          "required": ["id", "role"],
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "role": { "const": "scene-creator" }
+          },
+          "additionalProperties": false
+        },
+        "scene": {
+          "type": "object",
+          "required": ["manifestPath", "manifestSha256AtInit", "runtimeUrl", "referenceKind", "referencePath", "referenceSha256", "sceneBuildSha256"],
+          "properties": {
+            "manifestPath": { "type": "string", "minLength": 1 },
+            "manifestSha256AtInit": { "$ref": "#/$defs/sha256" },
+            "runtimeUrl": { "type": "string", "minLength": 1 },
+            "referenceKind": { "enum": ["image", "glb"] },
+            "referencePath": { "type": "string", "minLength": 1 },
+            "referenceSha256": { "$ref": "#/$defs/sha256" },
+            "sceneBuildSha256": {
+              "oneOf": [
+                { "type": "null" },
+                { "$ref": "#/$defs/sha256" }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        "policy": {
+          "type": "object",
+          "required": ["baseCoverage", "subdivision", "criticalRule", "maxRounds", "maxViews", "repeatedDefectRounds", "plateauRounds", "minDefectReduction", "minimumUniformLevel", "allowHoles"],
+          "properties": {
+            "baseCoverage": { "const": "cube-map-6" },
+            "subdivision": { "const": "defect-cell-quadtree" },
+            "criticalRule": { "const": "logical-and-no-averaging" },
+            "maxRounds": { "type": "integer", "minimum": 1 },
+            "maxViews": { "type": "integer", "minimum": 6 },
+            "repeatedDefectRounds": { "type": "integer", "minimum": 2 },
+            "plateauRounds": { "type": "integer", "minimum": 1 },
+            "minDefectReduction": { "type": "integer", "minimum": 1 },
+            "minimumUniformLevel": { "type": "integer", "minimum": 0, "default": 1 },
+            "allowHoles": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        },
+        "currentRound": { "type": "integer", "minimum": 0 },
+        "rounds": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["round", "views", "evidence"],
+            "properties": {
+              "round": { "type": "integer", "minimum": 0 },
+              "views": { "type": "array", "items": { "$ref": "#/$defs/viewPlan" } },
+              "evidence": { "type": "array", "items": { "$ref": "#/$defs/evidenceLedgerEntry" } }
+            },
+            "additionalProperties": true
+          }
+        },
+        "nextViews": { "type": "array", "items": { "$ref": "#/$defs/viewPlan" } },
+        "evidenceLedger": { "type": "array", "items": { "$ref": "#/$defs/evidenceLedgerEntry" } },
+        "pendingRequest": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/pendingRequest" }
+          ]
+        },
+        "scheduledViewCount": { "type": "integer", "minimum": 6 },
+        "status": { "enum": ["needs-render", "passed", "blocked"] },
+        "action": { "enum": ["capture-next-views", "continue", "refine-code", "request-input"] },
+        "stopReason": { "type": ["string", "null"] },
+        "blockingDefects": { "type": "array", "items": { "$ref": "#/$defs/finding" } },
+        "plateauStreak": { "type": "integer", "minimum": 0 },
+        "note": { "type": "string" },
+        "refinementMode": { "enum": ["minimum-uniform-coverage", "defect-directed"] },
+        "repeatedDefects": { "type": "array", "items": { "type": "string" } },
+        "unscheduledNextViewCount": { "type": "integer", "minimum": 0 }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "status": { "const": "needs-render" } }, "required": ["status"] },
+          "then": {
+            "properties": {
+              "action": { "const": "capture-next-views" },
+              "nextViews": { "minItems": 1 },
+              "stopReason": { "type": "null" }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "status": { "const": "passed" } }, "required": ["status"] },
+          "then": {
+            "required": ["stopReason"],
+            "properties": {
+              "action": { "const": "continue" },
+              "nextViews": { "maxItems": 0 },
+              "pendingRequest": { "type": "null" },
+              "stopReason": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "status": { "const": "blocked" } }, "required": ["status"] },
+          "then": {
+            "required": ["stopReason"],
+            "properties": {
+              "action": { "enum": ["refine-code", "request-input"] },
+              "nextViews": { "maxItems": 0 },
+              "pendingRequest": { "type": "null" },
+              "stopReason": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      ],
+      "additionalProperties": false
+    },
+    "captureEvidence": {
+      "type": "object",
+      "required": ["viewId", "capturePath", "captureSha256", "capturePixelSha256", "browserEvidenceSha256", "browserEvidence", "direction", "azimuthDegrees", "elevationDegrees", "angularRadiusDegrees", "cell"],
+      "properties": {
+        "viewId": { "type": "string", "minLength": 1 },
+        "capturePath": { "type": "string", "minLength": 1 },
+        "captureSha256": { "$ref": "#/$defs/sha256" },
+        "capturePixelSha256": { "$ref": "#/$defs/sha256" },
+        "browserEvidenceSha256": { "$ref": "#/$defs/sha256" },
+        "browserEvidence": { "$ref": "#/$defs/browserEvidence" },
+        "direction": { "$ref": "#/$defs/direction" },
+        "azimuthDegrees": { "type": "number" },
+        "elevationDegrees": { "type": "number" },
+        "angularRadiusDegrees": { "type": "number", "exclusiveMinimum": 0 },
+        "cell": { "$ref": "#/$defs/cell" },
+        "referenceCapturePath": { "type": "string", "minLength": 1 },
+        "referenceCaptureSha256": { "$ref": "#/$defs/sha256" }
+      },
+      "dependentRequired": {
+        "referenceCapturePath": ["referenceCaptureSha256"],
+        "referenceCaptureSha256": ["referenceCapturePath"]
+      },
+      "additionalProperties": false
+    },
+    "request": {
+      "type": "object",
+      "required": ["kind", "schemaVersion", "requestId", "requestDigest", "sessionId", "round", "creator", "scene", "fixedTurntableBaseline", "captureSetIntegrity", "views", "criticContract"],
+      "properties": {
+        "kind": { "const": "img2threejs.adaptive-harsh-critic-request" },
+        "schemaVersion": { "const": 1 },
+        "requestId": { "type": "string", "pattern": "^ahcr-[a-f0-9]{24}$" },
+        "requestDigest": { "$ref": "#/$defs/sha256" },
+        "sessionId": { "type": "string" },
+        "round": { "type": "integer", "minimum": 0 },
+        "creator": {
+          "type": "object",
+          "required": ["id", "role"],
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "role": { "const": "scene-creator" }
+          },
+          "additionalProperties": false
+        },
+        "scene": {
+          "type": "object",
+          "required": ["manifestPath", "manifestSha256", "runtimeUrl", "referenceKind", "referencePath", "referenceSha256", "sceneBuildSha256"],
+          "properties": {
+            "manifestPath": { "type": "string", "minLength": 1 },
+            "manifestSha256": { "$ref": "#/$defs/sha256" },
+            "runtimeUrl": { "type": "string", "minLength": 1 },
+            "referenceKind": { "enum": ["image", "glb"] },
+            "referencePath": { "type": "string", "minLength": 1 },
+            "referenceSha256": { "$ref": "#/$defs/sha256" },
+            "sceneBuildSha256": { "$ref": "#/$defs/sha256" }
+          },
+          "additionalProperties": false
+        },
+        "fixedTurntableBaseline": {
+          "type": "object",
+          "required": ["passed"],
+          "properties": { "passed": { "const": true } },
+          "additionalProperties": true
+        },
+        "captureSetIntegrity": {
+          "type": "object",
+          "required": ["recordedCaptureCount", "uniquePixelCount", "uniqueCameraMatrixCount", "sceneBuildSha256"],
+          "properties": {
+            "recordedCaptureCount": { "type": "integer", "minimum": 1 },
+            "uniquePixelCount": { "type": "integer", "minimum": 1 },
+            "uniqueCameraMatrixCount": { "type": "integer", "minimum": 1 },
+            "sceneBuildSha256": { "$ref": "#/$defs/sha256" }
+          },
+          "additionalProperties": false
+        },
+        "views": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/captureEvidence" } },
+        "criticContract": {
+          "type": "object",
+          "required": ["requiredRole", "identityRule", "pixelRule", "stance", "criticalRule", "requiredAcknowledgements", "minimumUniformLevel", "responseKind", "schema"],
+          "properties": {
+            "requiredRole": { "const": "independent-harsh-critic" },
+            "identityRule": { "type": "string", "minLength": 1 },
+            "pixelRule": { "type": "string", "minLength": 1 },
+            "stance": { "type": "string", "minLength": 1 },
+            "criticalRule": { "type": "string", "minLength": 1 },
+            "requiredAcknowledgements": { "type": "array", "items": { "type": "string" } },
+            "minimumUniformLevel": { "type": "integer", "minimum": 0 },
+            "responseKind": { "const": "img2threejs.adaptive-harsh-critic-response" },
+            "schema": { "const": "docs/specs/adaptive-harsh-critic.v1.schema.json" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "response": {
+      "type": "object",
+      "required": ["kind", "schemaVersion", "requestId", "critic", "views"],
+      "properties": {
+        "kind": { "const": "img2threejs.adaptive-harsh-critic-response" },
+        "schemaVersion": { "const": 1 },
+        "requestId": { "type": "string", "pattern": "^ahcr-[a-f0-9]{24}$" },
+        "critic": {
+          "type": "object",
+          "required": ["id", "role", "acknowledgements"],
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "role": { "const": "independent-harsh-critic" },
+            "acknowledgements": {
+              "type": "object",
+              "required": ["inspectedPixels", "noScoreAveraging", "criticalDefectsAreBlocking"],
+              "properties": {
+                "inspectedPixels": { "const": true },
+                "noScoreAveraging": { "const": true },
+                "criticalDefectsAreBlocking": { "const": true }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "views": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/review" } }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/forge/stage4_review/adaptive_harsh_critic.py
+++ b/forge/stage4_review/adaptive_harsh_critic.py
@@ -1,0 +1,1999 @@
+#!/usr/bin/env python3
+"""Adaptive, adversarial multi-view review controller for a real Three.js scene.
+
+The module is deliberately model-free.  It schedules browser camera captures,
+packages immutable pixel evidence for a *separate* critic agent, validates the
+critic response, and recursively subdivides only view cells where a defect was
+observed.  It never calls an LLM and it never turns scores into visual truth.
+
+The view sphere is represented by six cube-map faces.  A defective face cell is
+split into four children, so angular resolution can keep increasing without a
+fixed list of camera sides.  Runtime work is nevertheless bounded by repeated-
+defect, plateau, max-round and max-view stop policies.
+
+Security / evidence invariants:
+
+* ``critic.id`` MUST differ from ``creator.id``;
+* every reviewed view MUST bind to a browser-produced capture SHA-256 and exact
+  unit view direction from the request;
+* every finding repeats that binding (view ID + SHA-256 + direction), so prose
+  detached from pixels is rejected;
+* one critical finding blocks the run.  There is no averaging path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import math
+import secrets
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    from .render_bridge import (  # type: ignore[import-not-found]
+        canonical_sha256 as _canonical_sha256,
+        decoded_pixel_sha256 as _decoded_pixel_sha256,
+        validate_adaptive_capture_set,
+    )
+except ImportError:  # direct ``python forge/stage4_review/...py`` execution
+    from render_bridge import (  # type: ignore[no-redef]
+        canonical_sha256 as _canonical_sha256,
+        decoded_pixel_sha256 as _decoded_pixel_sha256,
+        validate_adaptive_capture_set,
+    )
+
+
+KIND_STATE = "img2threejs.adaptive-harsh-critic-state"
+KIND_REQUEST = "img2threejs.adaptive-harsh-critic-request"
+KIND_RESPONSE = "img2threejs.adaptive-harsh-critic-response"
+SCHEMA_VERSION = 1
+
+DEFAULT_MAX_ROUNDS = 6
+DEFAULT_MAX_VIEWS = 96
+DEFAULT_REPEATED_DEFECT_ROUNDS = 2
+DEFAULT_PLATEAU_ROUNDS = 2
+DEFAULT_MIN_DEFECT_REDUCTION = 1
+DEFAULT_MINIMUM_UNIFORM_LEVEL = 1
+
+SEVERITY_RANK = {"minor": 1, "major": 2, "critical": 3}
+FACE_ORDER = ("front", "right", "rear", "left", "top", "bottom")
+EQUATOR_FACES = ("front", "right", "rear", "left")
+REQUIRED_ACKNOWLEDGEMENTS = (
+    "inspectedPixels",
+    "noScoreAveraging",
+    "criticalDefectsAreBlocking",
+)
+FORBIDDEN_AGGREGATE_FIELDS = {"score", "globalScore", "averageScore", "fidelity"}
+SESSION_ID_PREFIX_LENGTH = 24  # ``ahc-`` plus 20 random lowercase hex chars
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"JSON root must be an object: {path}")
+    return value
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(json.dumps(value, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def _canonical_request_digest(request: dict[str, Any]) -> str:
+    payload = {
+        key: value
+        for key, value in request.items()
+        if key not in {"requestId", "requestDigest"}
+    }
+    return _canonical_sha256(payload)
+
+
+def _request_id_from_digest(digest: str) -> str:
+    return "ahcr-" + digest[:24]
+
+
+def _reject_extra_fields(value: dict[str, Any], allowed: set[str], label: str) -> None:
+    extra = sorted(set(value) - allowed)
+    if extra:
+        raise ValueError(f"{label} contains schema-forbidden fields: {extra}")
+
+
+def _valid_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(char in "0123456789abcdef" for char in value)
+    )
+
+
+def _scope_view_to_session(view: dict[str, Any], session_id: str) -> dict[str, Any]:
+    scoped = dict(view)
+    scoped["id"] = f"{session_id}-{view['id']}"
+    if view.get("parentId") is not None:
+        scoped["parentId"] = f"{session_id}-{view['parentId']}"
+    scoped["cell"] = dict(view["cell"])
+    return scoped
+
+
+def _finite_number(value: Any) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(float(value))
+    )
+
+
+def _unit(vector: tuple[float, float, float]) -> tuple[float, float, float]:
+    length = math.sqrt(sum(value * value for value in vector))
+    if length <= 0.0:
+        raise ValueError("view direction cannot be the zero vector")
+    return tuple(value / length for value in vector)
+
+
+def _rounded_direction(vector: tuple[float, float, float]) -> list[float]:
+    return [round(value, 12) for value in _unit(vector)]
+
+
+def _cube_direction(face: str, u: float, v: float) -> list[float]:
+    """Map one cube-map face coordinate to a Three.js orbit direction.
+
+    Front is +Z and right is +X.  The exact face orientation is part of the
+    serialized cell contract, so subdivision remains deterministic at seams.
+    """
+    vectors = {
+        "front": (u, v, 1.0),
+        "right": (1.0, v, -u),
+        "rear": (-u, v, -1.0),
+        "left": (-1.0, v, u),
+        "top": (u, 1.0, -v),
+        "bottom": (u, -1.0, v),
+    }
+    if face not in vectors:
+        raise ValueError(f"unknown cube-map face: {face}")
+    return _rounded_direction(vectors[face])
+
+
+def _orbit_angles(direction: list[float]) -> tuple[float, float]:
+    x, y, z = direction
+    azimuth = math.degrees(math.atan2(x, z))
+    if azimuth <= -180.0:
+        azimuth = 180.0
+    elevation = math.degrees(math.asin(max(-1.0, min(1.0, y))))
+    return round(azimuth, 9), round(elevation, 9)
+
+
+def _angular_distance(a: list[float], b: list[float]) -> float:
+    dot = max(-1.0, min(1.0, sum(left * right for left, right in zip(a, b))))
+    return math.degrees(math.acos(dot))
+
+
+def _make_view(
+    face: str,
+    bounds: tuple[float, float, float, float],
+    *,
+    path: str,
+    parent_id: str | None,
+    round_index: int,
+    level: int,
+) -> dict[str, Any]:
+    u_min, u_max, v_min, v_max = bounds
+    u_center = (u_min + u_max) / 2.0
+    v_center = (v_min + v_max) / 2.0
+    direction = _cube_direction(face, u_center, v_center)
+    azimuth, elevation = _orbit_angles(direction)
+    corners = [
+        _cube_direction(face, u, v)
+        for u, v in (
+            (u_min, v_min),
+            (u_min, v_max),
+            (u_max, v_min),
+            (u_max, v_max),
+        )
+    ]
+    angular_radius = max(_angular_distance(direction, corner) for corner in corners)
+    suffix = path if path else "root"
+    view_id = f"harsh-{face}-{suffix}"
+    return {
+        "id": view_id,
+        "round": round_index,
+        "parentId": parent_id,
+        "direction": direction,
+        "azimuthDegrees": azimuth,
+        "elevationDegrees": elevation,
+        "angularRadiusDegrees": round(angular_radius, 9),
+        "cell": {
+            "projection": "cube-map",
+            "face": face,
+            "uMin": u_min,
+            "uMax": u_max,
+            "vMin": v_min,
+            "vMax": v_max,
+            "level": level,
+            "path": path,
+        },
+    }
+
+
+def base_views() -> list[dict[str, Any]]:
+    """Return the six cube-map root cells covering the complete view sphere."""
+    return [
+        _make_view(
+            face,
+            (-1.0, 1.0, -1.0, 1.0),
+            path="",
+            parent_id=None,
+            round_index=0,
+            level=0,
+        )
+        for face in FACE_ORDER
+    ]
+
+
+def subdivide_view(view: dict[str, Any], round_index: int) -> list[dict[str, Any]]:
+    """Split one cube-map cell into four deterministic child view cells."""
+    cell = view.get("cell")
+    if not isinstance(cell, dict) or cell.get("projection") != "cube-map":
+        raise ValueError(f"view {view.get('id')!r} has no cube-map cell")
+    face = str(cell.get("face", ""))
+    u_min, u_max = float(cell["uMin"]), float(cell["uMax"])
+    v_min, v_max = float(cell["vMin"]), float(cell["vMax"])
+    u_mid, v_mid = (u_min + u_max) / 2.0, (v_min + v_max) / 2.0
+    parent_path = str(cell.get("path", ""))
+    level = int(cell.get("level", 0)) + 1
+    # Stable Morton-like order: lower-left, lower-right, upper-left, upper-right.
+    quadrants = (
+        ("0", (u_min, u_mid, v_min, v_mid)),
+        ("1", (u_mid, u_max, v_min, v_mid)),
+        ("2", (u_min, u_mid, v_mid, v_max)),
+        ("3", (u_mid, u_max, v_mid, v_max)),
+    )
+    children = [
+        _make_view(
+            face,
+            bounds,
+            path=parent_path + digit,
+            parent_id=str(view["id"]),
+            round_index=round_index,
+            level=level,
+        )
+        for digit, bounds in quadrants
+    ]
+    parent_id = str(view["id"])
+    marker = parent_id.find("harsh-")
+    namespace = parent_id[:marker] if marker > 0 else ""
+    if namespace:
+        for child in children:
+            child["id"] = namespace + str(child["id"])
+    return children
+
+
+def _validate_policy(policy: dict[str, Any]) -> None:
+    required_fields = {
+        "baseCoverage",
+        "subdivision",
+        "criticalRule",
+        "maxRounds",
+        "maxViews",
+        "repeatedDefectRounds",
+        "plateauRounds",
+        "minDefectReduction",
+        "minimumUniformLevel",
+        "allowHoles",
+    }
+    _reject_extra_fields(
+        policy,
+        required_fields,
+        "state.policy",
+    )
+    if set(policy) != required_fields:
+        raise ValueError(
+            f"state.policy is missing required fields: {sorted(required_fields - set(policy))}"
+        )
+    integer_fields = {
+        "maxRounds": 1,
+        "maxViews": len(FACE_ORDER),
+        "repeatedDefectRounds": 2,
+        "plateauRounds": 1,
+        "minDefectReduction": 1,
+        "minimumUniformLevel": 0,
+    }
+    for field, minimum in integer_fields.items():
+        value = policy.get(field)
+        if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+            raise ValueError(f"policy.{field} must be an integer >= {minimum}")
+    if policy.get("baseCoverage") != "cube-map-6":
+        raise ValueError("policy.baseCoverage must be cube-map-6")
+    if policy.get("subdivision") != "defect-cell-quadtree":
+        raise ValueError("policy.subdivision must be defect-cell-quadtree")
+    if policy.get("criticalRule") != "logical-and-no-averaging":
+        raise ValueError("policy.criticalRule must be logical-and-no-averaging")
+    if not isinstance(policy.get("allowHoles"), bool):
+        raise ValueError("policy.allowHoles must be a boolean")
+
+
+def _bounds_for_cell_path(path: str) -> tuple[float, float, float, float]:
+    """Reconstruct the exact quadtree cell encoded by a Morton-like path."""
+    u_min, u_max, v_min, v_max = -1.0, 1.0, -1.0, 1.0
+    for digit in path:
+        u_mid = (u_min + u_max) / 2.0
+        v_mid = (v_min + v_max) / 2.0
+        if digit == "0":
+            u_max, v_max = u_mid, v_mid
+        elif digit == "1":
+            u_min, v_max = u_mid, v_mid
+        elif digit == "2":
+            u_max, v_min = u_mid, v_mid
+        elif digit == "3":
+            u_min, v_min = u_mid, v_mid
+        else:  # guarded by the caller; keep this helper fail closed alone too
+            raise ValueError(f"invalid cube-cell path digit: {digit}")
+    return u_min, u_max, v_min, v_max
+
+
+def _validate_view_plan(
+    view: dict[str, Any], label: str, *, session_id: str | None = None
+) -> None:
+    required_view_fields = {
+        "id",
+        "round",
+        "parentId",
+        "direction",
+        "azimuthDegrees",
+        "elevationDegrees",
+        "angularRadiusDegrees",
+        "cell",
+    }
+    _reject_extra_fields(
+        view,
+        required_view_fields,
+        label,
+    )
+    if set(view) != required_view_fields:
+        raise ValueError(
+            f"{label} is missing required fields: {sorted(required_view_fields - set(view))}"
+        )
+    view_id = view.get("id")
+    if not isinstance(view_id, str) or not view_id:
+        raise ValueError(f"{label}.id is required")
+    if session_id is not None and not view_id.startswith(f"{session_id}-harsh-"):
+        raise ValueError(f"{label}.id is not scoped to state.sessionId")
+    parent_id = view.get("parentId")
+    if parent_id is not None and (
+        not isinstance(parent_id, str)
+        or (session_id is not None and not parent_id.startswith(f"{session_id}-harsh-"))
+    ):
+        raise ValueError(f"{label}.parentId is invalid")
+    round_index = view.get("round")
+    if isinstance(round_index, bool) or not isinstance(round_index, int) or round_index < 0:
+        raise ValueError(f"{label}.round must be a non-negative integer")
+    direction = view.get("direction")
+    if not isinstance(direction, list) or len(direction) != 3 or not all(
+        _finite_number(value) for value in direction
+    ):
+        raise ValueError(f"{label}.direction must be a finite 3-vector")
+    magnitude = math.sqrt(sum(float(value) ** 2 for value in direction))
+    if abs(magnitude - 1.0) > 1e-8:
+        raise ValueError(f"{label}.direction must be a unit vector")
+    for field in ("azimuthDegrees", "elevationDegrees", "angularRadiusDegrees"):
+        if not _finite_number(view.get(field)):
+            raise ValueError(f"{label}.{field} must be finite")
+    if not -180.0 <= float(view["azimuthDegrees"]) <= 180.0:
+        raise ValueError(f"{label}.azimuthDegrees is outside [-180, 180]")
+    if not -90.0 <= float(view["elevationDegrees"]) <= 90.0:
+        raise ValueError(f"{label}.elevationDegrees is outside [-90, 90]")
+    if not 0.0 < float(view["angularRadiusDegrees"]) <= 90.0:
+        raise ValueError(f"{label}.angularRadiusDegrees must be in (0, 90]")
+    cell = view.get("cell")
+    if not isinstance(cell, dict):
+        raise ValueError(f"{label}.cell is required")
+    required_cell_fields = {
+        "projection",
+        "face",
+        "uMin",
+        "uMax",
+        "vMin",
+        "vMax",
+        "level",
+        "path",
+    }
+    _reject_extra_fields(
+        cell,
+        required_cell_fields,
+        f"{label}.cell",
+    )
+    if set(cell) != required_cell_fields:
+        raise ValueError(
+            f"{label}.cell is missing required fields: "
+            f"{sorted(required_cell_fields - set(cell))}"
+        )
+    if cell.get("projection") != "cube-map" or cell.get("face") not in FACE_ORDER:
+        raise ValueError(f"{label}.cell projection/face is invalid")
+    for field in ("uMin", "uMax", "vMin", "vMax"):
+        if not _finite_number(cell.get(field)) or not -1.0 <= float(cell[field]) <= 1.0:
+            raise ValueError(f"{label}.cell.{field} must be finite and inside [-1, 1]")
+    if float(cell["uMin"]) >= float(cell["uMax"]):
+        raise ValueError(f"{label}.cell requires uMin < uMax")
+    if float(cell["vMin"]) >= float(cell["vMax"]):
+        raise ValueError(f"{label}.cell requires vMin < vMax")
+    level = cell.get("level")
+    if isinstance(level, bool) or not isinstance(level, int) or level < 0:
+        raise ValueError(f"{label}.cell.level must be a non-negative integer")
+    path = cell.get("path")
+    if not isinstance(path, str) or any(char not in "0123" for char in path):
+        raise ValueError(f"{label}.cell.path is invalid")
+    if len(path) != level:
+        raise ValueError(f"{label}.cell.path length must equal cell.level")
+    if round_index != level:
+        raise ValueError(f"{label}.round must equal cell.level")
+    face = str(cell["face"])
+    suffix = path if path else "root"
+    expected_id = f"harsh-{face}-{suffix}"
+    if session_id is not None:
+        expected_id = f"{session_id}-{expected_id}"
+    if view_id != expected_id:
+        raise ValueError(f"{label}.id does not encode its cube cell")
+    expected_parent: str | None = None
+    if level > 0:
+        parent_suffix = path[:-1] if path[:-1] else "root"
+        expected_parent = f"harsh-{face}-{parent_suffix}"
+        if session_id is not None:
+            expected_parent = f"{session_id}-{expected_parent}"
+    if parent_id != expected_parent:
+        raise ValueError(f"{label}.parentId does not encode the parent cube cell")
+    expected_bounds = _bounds_for_cell_path(path)
+    actual_bounds = tuple(float(cell[field]) for field in ("uMin", "uMax", "vMin", "vMax"))
+    if any(abs(actual - expected) > 1e-12 for actual, expected in zip(actual_bounds, expected_bounds)):
+        raise ValueError(f"{label}.cell bounds do not match its quadtree path")
+    expected_view = _make_view(
+        face,
+        expected_bounds,
+        path=path,
+        parent_id=expected_parent,
+        round_index=round_index,
+        level=level,
+    )
+    if not _directions_equal(direction, expected_view["direction"]):
+        raise ValueError(f"{label}.direction does not point at its cube-cell centre")
+    for field in ("azimuthDegrees", "elevationDegrees", "angularRadiusDegrees"):
+        if abs(float(view[field]) - float(expected_view[field])) > 1e-8:
+            raise ValueError(f"{label}.{field} does not match its cube-cell geometry")
+
+
+EVIDENCE_LEDGER_REQUIRED_FIELDS = {
+    "viewId",
+    "round",
+    "capturePath",
+    "captureSha256",
+    "capturePixelSha256",
+    "browserEvidenceSha256",
+    "sceneBuildSha256",
+    "direction",
+}
+EVIDENCE_LEDGER_OPTIONAL_FIELDS = {
+    "referenceCapturePath",
+    "referenceCaptureSha256",
+}
+
+
+def _validate_ledger_entry(entry: dict[str, Any], label: str) -> None:
+    _reject_extra_fields(
+        entry,
+        EVIDENCE_LEDGER_REQUIRED_FIELDS | EVIDENCE_LEDGER_OPTIONAL_FIELDS,
+        label,
+    )
+    if not EVIDENCE_LEDGER_REQUIRED_FIELDS <= set(entry):
+        missing = sorted(EVIDENCE_LEDGER_REQUIRED_FIELDS - set(entry))
+        raise ValueError(f"{label} is missing required fields: {missing}")
+    if not isinstance(entry.get("viewId"), str) or not entry["viewId"]:
+        raise ValueError(f"{label}.viewId is required")
+    if (
+        isinstance(entry.get("round"), bool)
+        or not isinstance(entry.get("round"), int)
+        or entry["round"] < 0
+    ):
+        raise ValueError(f"{label}.round must be a non-negative integer")
+    if not isinstance(entry.get("capturePath"), str) or not entry["capturePath"]:
+        raise ValueError(f"{label}.capturePath is required")
+    for field in (
+        "captureSha256",
+        "capturePixelSha256",
+        "browserEvidenceSha256",
+        "sceneBuildSha256",
+    ):
+        if not _valid_sha256(entry.get(field)):
+            raise ValueError(f"{label}.{field} is invalid")
+    if not isinstance(entry.get("direction"), list) or not _directions_equal(
+        entry["direction"], entry["direction"]
+    ):
+        raise ValueError(f"{label}.direction is invalid")
+    has_reference_path = "referenceCapturePath" in entry
+    has_reference_hash = "referenceCaptureSha256" in entry
+    if has_reference_path != has_reference_hash:
+        raise ValueError(f"{label} reference path/hash must appear together")
+    if has_reference_path:
+        if (
+            not isinstance(entry["referenceCapturePath"], str)
+            or not entry["referenceCapturePath"]
+            or not _valid_sha256(entry["referenceCaptureSha256"])
+        ):
+            raise ValueError(f"{label} reference capture binding is invalid")
+
+
+def _validate_state(state: dict[str, Any]) -> None:
+    required_state_fields = {
+        "kind",
+        "schemaVersion",
+        "sessionId",
+        "creator",
+        "scene",
+        "policy",
+        "currentRound",
+        "rounds",
+        "nextViews",
+        "scheduledViewCount",
+        "status",
+        "action",
+        "pendingRequest",
+        "evidenceLedger",
+    }
+    allowed_state_fields = required_state_fields | {
+        "stopReason",
+        "blockingDefects",
+        "plateauStreak",
+        "note",
+        "refinementMode",
+        "repeatedDefects",
+        "unscheduledNextViewCount",
+    }
+    _reject_extra_fields(
+        state,
+        allowed_state_fields,
+        "state",
+    )
+    if not required_state_fields <= set(state):
+        raise ValueError(
+            "state is missing required fields: "
+            f"{sorted(required_state_fields - set(state))}"
+        )
+    if state.get("kind") != KIND_STATE or state.get("schemaVersion") != SCHEMA_VERSION:
+        raise ValueError("not an adaptive harsh critic v1 state")
+    session_id = state.get("sessionId")
+    if (
+        not isinstance(session_id, str)
+        or len(session_id) != SESSION_ID_PREFIX_LENGTH
+        or not session_id.startswith("ahc-")
+        or any(char not in "0123456789abcdef" for char in session_id[4:])
+    ):
+        raise ValueError("state.sessionId must be ahc- plus 20 lowercase hex characters")
+    creator = state.get("creator")
+    if not isinstance(creator, dict) or not isinstance(creator.get("id"), str) or not creator["id"].strip():
+        raise ValueError("state.creator.id is required")
+    _reject_extra_fields(creator, {"id", "role"}, "state.creator")
+    if creator.get("role") != "scene-creator":
+        raise ValueError("state.creator.role must be scene-creator")
+    scene = state.get("scene")
+    if not isinstance(scene, dict):
+        raise ValueError("state.scene must be an object")
+    required_scene_fields = {
+        "manifestPath",
+        "manifestSha256AtInit",
+        "runtimeUrl",
+        "referenceKind",
+        "referencePath",
+        "referenceSha256",
+        "sceneBuildSha256",
+    }
+    _reject_extra_fields(
+        scene,
+        required_scene_fields,
+        "state.scene",
+    )
+    if set(scene) != required_scene_fields:
+        raise ValueError(
+            f"state.scene is missing required fields: {sorted(required_scene_fields - set(scene))}"
+        )
+    if not isinstance(scene.get("manifestPath"), str) or not scene["manifestPath"].strip():
+        raise ValueError("state.scene.manifestPath is required")
+    if not _valid_sha256(scene.get("manifestSha256AtInit")):
+        raise ValueError("state.scene.manifestSha256AtInit is invalid")
+    if not isinstance(scene.get("runtimeUrl"), str) or not scene["runtimeUrl"].strip():
+        raise ValueError("state.scene.runtimeUrl is required")
+    if not isinstance(scene.get("referencePath"), str) or not scene["referencePath"]:
+        raise ValueError("state.scene.referencePath is required")
+    if scene.get("referenceKind") not in {"image", "glb"}:
+        raise ValueError("state.scene.referenceKind must be image or glb")
+    if not _valid_sha256(scene.get("referenceSha256")):
+        raise ValueError("state.scene.referenceSha256 is invalid")
+    if scene.get("sceneBuildSha256") is not None and not _valid_sha256(
+        scene.get("sceneBuildSha256")
+    ):
+        raise ValueError("state.scene.sceneBuildSha256 is invalid")
+    policy = state.get("policy")
+    if not isinstance(policy, dict):
+        raise ValueError("state.policy must be an object")
+    _validate_policy(policy)
+    if not isinstance(state.get("rounds"), list) or not isinstance(state.get("nextViews"), list):
+        raise ValueError("state rounds/nextViews must be lists")
+    status = state.get("status")
+    action = state.get("action")
+    legal_actions = {
+        "needs-render": {"capture-next-views"},
+        "passed": {"continue"},
+        "blocked": {"refine-code", "request-input"},
+    }
+    if status not in legal_actions:
+        raise ValueError("state.status is invalid")
+    if action not in legal_actions[status]:
+        raise ValueError(f"state.status/action combination is invalid: {status}/{action}")
+    stop_reason = state.get("stopReason")
+    if stop_reason is not None and not isinstance(stop_reason, str):
+        raise ValueError("state.stopReason must be a string or null")
+    if status == "needs-render" and stop_reason is not None:
+        raise ValueError("needs-render state.stopReason must be null")
+    if status in {"passed", "blocked"} and (
+        not isinstance(stop_reason, str) or not stop_reason.strip()
+    ):
+        raise ValueError(f"{status} state.stopReason must be a non-empty string")
+    blocking_defects = state.get("blockingDefects")
+    if blocking_defects is not None and not isinstance(blocking_defects, list):
+        raise ValueError("state.blockingDefects must be a list")
+    plateau_streak = state.get("plateauStreak")
+    if plateau_streak is not None and (
+        isinstance(plateau_streak, bool)
+        or not isinstance(plateau_streak, int)
+        or plateau_streak < 0
+    ):
+        raise ValueError("state.plateauStreak must be a non-negative integer")
+    if "note" in state and not isinstance(state["note"], str):
+        raise ValueError("state.note must be a string")
+    if "refinementMode" in state and state["refinementMode"] not in {
+        "minimum-uniform-coverage",
+        "defect-directed",
+    }:
+        raise ValueError("state.refinementMode is invalid")
+    if "repeatedDefects" in state and (
+        not isinstance(state["repeatedDefects"], list)
+        or not all(isinstance(item, str) for item in state["repeatedDefects"])
+    ):
+        raise ValueError("state.repeatedDefects must be a string list")
+    unscheduled_count = state.get("unscheduledNextViewCount")
+    if unscheduled_count is not None and (
+        isinstance(unscheduled_count, bool)
+        or not isinstance(unscheduled_count, int)
+        or unscheduled_count < 0
+    ):
+        raise ValueError("state.unscheduledNextViewCount must be a non-negative integer")
+    current_round = state.get("currentRound")
+    if isinstance(current_round, bool) or not isinstance(current_round, int) or current_round < 0:
+        raise ValueError("state.currentRound must be a non-negative integer")
+    scheduled_views_by_id: dict[str, dict[str, Any]] = {}
+    next_view_ids: list[str] = []
+    for index, view in enumerate(state["nextViews"]):
+        if not isinstance(view, dict):
+            raise ValueError(f"state.nextViews[{index}] must be an object")
+        _validate_view_plan(view, f"state.nextViews[{index}]", session_id=session_id)
+        view_id = str(view["id"])
+        if view_id in scheduled_views_by_id:
+            raise ValueError(f"state.nextViews contains duplicate view id: {view_id}")
+        if view["round"] != current_round:
+            raise ValueError(f"state.nextViews view is bound to the wrong round: {view_id}")
+        scheduled_views_by_id[view_id] = view
+        next_view_ids.append(view_id)
+    ledger = state.get("evidenceLedger")
+    if not isinstance(ledger, list):
+        raise ValueError("state.evidenceLedger must be a list")
+    ledger_by_id: dict[str, dict[str, Any]] = {}
+    for index, entry in enumerate(ledger):
+        if not isinstance(entry, dict):
+            raise ValueError(f"state.evidenceLedger[{index}] must be an object")
+        _validate_ledger_entry(entry, f"state.evidenceLedger[{index}]")
+        view_id = str(entry["viewId"])
+        if view_id in ledger_by_id:
+            raise ValueError(f"state.evidenceLedger has duplicate viewId: {view_id}")
+        if not view_id.startswith(f"{session_id}-harsh-"):
+            raise ValueError(f"state.evidenceLedger view is from another session: {view_id}")
+        ledger_by_id[view_id] = entry
+    completed_view_ids: set[str] = set()
+    completed_rounds: set[int] = set()
+    for round_index, record in enumerate(state["rounds"]):
+        if not isinstance(record, dict):
+            raise ValueError(f"state.rounds[{round_index}] must be an object")
+        record_round = record.get("round")
+        if (
+            isinstance(record_round, bool)
+            or not isinstance(record_round, int)
+            or record_round < 0
+        ):
+            raise ValueError(f"state.rounds[{round_index}].round is invalid")
+        if record_round in completed_rounds:
+            raise ValueError(f"state.rounds has duplicate round: {record_round}")
+        completed_rounds.add(record_round)
+        evidence = record.get("evidence")
+        if not isinstance(evidence, list):
+            raise ValueError(f"state.rounds[{round_index}].evidence must be a list")
+        views = record.get("views")
+        if not isinstance(views, list):
+            raise ValueError(f"state.rounds[{round_index}].views must be a list")
+        for view_index, view in enumerate(views):
+            if not isinstance(view, dict):
+                raise ValueError(
+                    f"state.rounds[{round_index}].views[{view_index}] must be an object"
+                )
+            _validate_view_plan(
+                view,
+                f"state.rounds[{round_index}].views[{view_index}]",
+                session_id=session_id,
+            )
+            view_id = str(view["id"])
+            if view["round"] != record_round:
+                raise ValueError(
+                    f"state.rounds[{round_index}] view is bound to the wrong round: {view_id}"
+                )
+            if view_id in scheduled_views_by_id:
+                raise ValueError(f"state contains duplicate scheduled view id: {view_id}")
+            scheduled_views_by_id[view_id] = view
+            completed_view_ids.add(view_id)
+        round_evidence: dict[str, dict[str, Any]] = {}
+        for evidence_index, entry in enumerate(evidence):
+            if not isinstance(entry, dict):
+                raise ValueError(
+                    f"state.rounds[{round_index}].evidence[{evidence_index}] must be an object"
+                )
+            _validate_ledger_entry(
+                entry, f"state.rounds[{round_index}].evidence[{evidence_index}]"
+            )
+            view_id = str(entry["viewId"])
+            if view_id in round_evidence:
+                raise ValueError(
+                    f"state.rounds[{round_index}].evidence has duplicate viewId: {view_id}"
+                )
+            if entry["round"] != record_round:
+                raise ValueError(
+                    f"state.rounds[{round_index}] evidence is bound to the wrong round: {view_id}"
+                )
+            round_evidence[view_id] = entry
+        expected_ids = {str(view["id"]) for view in views}
+        if set(round_evidence) != expected_ids:
+            raise ValueError(
+                f"state.rounds[{round_index}] lost scheduled evidence ledger entries"
+            )
+        for view_id, entry in round_evidence.items():
+            if ledger_by_id.get(view_id) != entry:
+                raise ValueError(
+                    f"state.rounds[{round_index}] evidence differs from state ledger: {view_id}"
+                )
+    scheduled_count = state.get("scheduledViewCount")
+    if (
+        isinstance(scheduled_count, bool)
+        or not isinstance(scheduled_count, int)
+        or scheduled_count < len(FACE_ORDER)
+        or scheduled_count != len(scheduled_views_by_id)
+    ):
+        raise ValueError("state.scheduledViewCount differs from unique scheduled views")
+    for view_id, entry in ledger_by_id.items():
+        planned = scheduled_views_by_id.get(view_id)
+        if planned is None:
+            raise ValueError(f"state.evidenceLedger contains an unscheduled view: {view_id}")
+        if entry["round"] != planned["round"] or not _directions_equal(
+            entry["direction"], planned["direction"]
+        ):
+            raise ValueError(f"state.evidenceLedger binding differs from view plan: {view_id}")
+    pending = state.get("pendingRequest")
+    if status != "needs-render" and pending is not None:
+        raise ValueError(f"{status} state.pendingRequest must be null")
+    if status == "needs-render" and not state["nextViews"]:
+        raise ValueError("needs-render state.nextViews must be non-empty")
+    if status in {"passed", "blocked"} and state["nextViews"]:
+        raise ValueError(f"{status} state.nextViews must be empty")
+    if pending is not None:
+        if not isinstance(pending, dict):
+            raise ValueError("state.pendingRequest must be an object or null")
+        _reject_extra_fields(
+            pending,
+            {"requestId", "canonicalSha256", "round", "manifestSha256", "viewIds"},
+            "state.pendingRequest",
+        )
+        required_pending_fields = {
+            "requestId",
+            "canonicalSha256",
+            "round",
+            "manifestSha256",
+            "viewIds",
+        }
+        if set(pending) != required_pending_fields:
+            raise ValueError(
+                "state.pendingRequest is missing required fields: "
+                f"{sorted(required_pending_fields - set(pending))}"
+            )
+        digest = pending.get("canonicalSha256")
+        request_id = pending.get("requestId")
+        round_index = pending.get("round")
+        view_ids = pending.get("viewIds")
+        if (
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or any(char not in "0123456789abcdef" for char in digest)
+        ):
+            raise ValueError("state.pendingRequest.canonicalSha256 is invalid")
+        if request_id != _request_id_from_digest(digest):
+            raise ValueError("state.pendingRequest.requestId is not derived from canonicalSha256")
+        if not _valid_sha256(pending.get("manifestSha256")):
+            raise ValueError("state.pendingRequest.manifestSha256 is invalid")
+        if round_index != state.get("currentRound"):
+            raise ValueError("state.pendingRequest.round differs from currentRound")
+        if not isinstance(view_ids, list) or not all(isinstance(item, str) for item in view_ids):
+            raise ValueError("state.pendingRequest.viewIds must be a string list")
+        if len(view_ids) != len(set(view_ids)):
+            raise ValueError("state.pendingRequest.viewIds contains duplicates")
+        if view_ids != next_view_ids:
+            raise ValueError("state.pendingRequest.viewIds differs from ordered state.nextViews")
+        if any(view_id not in ledger_by_id for view_id in view_ids):
+            raise ValueError("state.pendingRequest refers to evidence absent from state.evidenceLedger")
+    expected_ledger_ids = completed_view_ids | (
+        set(next_view_ids) if pending is not None else set()
+    )
+    if set(ledger_by_id) != expected_ledger_ids:
+        raise ValueError(
+            "state.evidenceLedger must contain exactly completed-round evidence plus pending views"
+        )
+
+
+def init_state(
+    manifest_path: Path,
+    creator_id: str,
+    *,
+    max_rounds: int = DEFAULT_MAX_ROUNDS,
+    max_views: int = DEFAULT_MAX_VIEWS,
+    repeated_defect_rounds: int = DEFAULT_REPEATED_DEFECT_ROUNDS,
+    plateau_rounds: int = DEFAULT_PLATEAU_ROUNDS,
+    min_defect_reduction: int = DEFAULT_MIN_DEFECT_REDUCTION,
+    minimum_uniform_level: int = DEFAULT_MINIMUM_UNIFORM_LEVEL,
+    allow_holes: bool = False,
+) -> dict[str, Any]:
+    manifest_path = manifest_path.expanduser().resolve()
+    manifest = _read_json(manifest_path)
+    if not creator_id.strip():
+        raise ValueError("creator_id must be non-empty")
+    runtime = manifest.get("runtime")
+    reference = manifest.get("reference")
+    if not isinstance(runtime, dict) or not runtime.get("url"):
+        raise ValueError("render manifest runtime.url is required")
+    if not isinstance(reference, dict) or not reference.get("sha256"):
+        raise ValueError("render manifest reference.sha256 is required")
+    reference_source = _validate_reference_source(manifest_path, manifest)
+    policy = {
+        "baseCoverage": "cube-map-6",
+        "subdivision": "defect-cell-quadtree",
+        "criticalRule": "logical-and-no-averaging",
+        "maxRounds": max_rounds,
+        "maxViews": max_views,
+        "repeatedDefectRounds": repeated_defect_rounds,
+        "plateauRounds": plateau_rounds,
+        "minDefectReduction": min_defect_reduction,
+        "minimumUniformLevel": minimum_uniform_level,
+        "allowHoles": bool(allow_holes),
+    }
+    _validate_policy(policy)
+    # A new invocation is a new evidence session even if all inputs are the
+    # same.  Deterministic IDs allowed stale captures from an earlier run to be
+    # mistaken for the newly scheduled evidence.
+    session_id = "ahc-" + secrets.token_hex(10)
+    views = [_scope_view_to_session(view, session_id) for view in base_views()]
+    state = {
+        "kind": KIND_STATE,
+        "schemaVersion": SCHEMA_VERSION,
+        "sessionId": session_id,
+        "creator": {"id": creator_id.strip(), "role": "scene-creator"},
+        "scene": {
+            "manifestPath": str(manifest_path),
+            "manifestSha256AtInit": _sha256(manifest_path),
+            "runtimeUrl": str(runtime["url"]),
+            "referenceKind": reference.get("kind"),
+            "referencePath": str(reference_source),
+            "referenceSha256": str(reference["sha256"]),
+            "sceneBuildSha256": None,
+        },
+        "policy": policy,
+        "currentRound": 0,
+        "rounds": [],
+        "nextViews": views,
+        "scheduledViewCount": len(views),
+        "status": "needs-render",
+        "action": "capture-next-views",
+        "stopReason": None,
+        "blockingDefects": [],
+        "pendingRequest": None,
+        "evidenceLedger": [],
+        "plateauStreak": 0,
+        "note": (
+            "all six root faces are uniformly subdivided through minimumUniformLevel before "
+            "a clean pass is possible; defect cells can then refine without a fixed angular-"
+            "resolution ceiling, while policy caps still guarantee termination"
+        ),
+    }
+    _validate_state(state)
+    return state
+
+
+def _all_views(state: dict[str, Any]) -> list[dict[str, Any]]:
+    views: list[dict[str, Any]] = []
+    for round_record in state.get("rounds", []):
+        if isinstance(round_record, dict) and isinstance(round_record.get("views"), list):
+            views.extend(item for item in round_record["views"] if isinstance(item, dict))
+    views.extend(item for item in state.get("nextViews", []) if isinstance(item, dict))
+    return views
+
+
+def _find_capture(manifest: dict[str, Any], view_id: str) -> dict[str, Any]:
+    for capture in manifest.get("captures", []):
+        if isinstance(capture, dict) and capture.get("id") == view_id:
+            return capture
+    raise ValueError(f"render manifest has no scheduled capture for view {view_id}")
+
+
+def _manifest_path(manifest_path: Path, value: str) -> Path:
+    candidate = Path(value).expanduser()
+    return candidate if candidate.is_absolute() else (manifest_path.parent / candidate).resolve()
+
+
+def _validate_reference_source(
+    manifest_path: Path,
+    manifest: dict[str, Any],
+    *,
+    expected_sha256: str | None = None,
+    expected_path: str | None = None,
+) -> Path:
+    """Re-open the actual source image/GLB rather than trusting manifest prose."""
+    reference = manifest.get("reference")
+    if not isinstance(reference, dict):
+        raise ValueError("render manifest reference must be an object")
+    path_value = reference.get("path")
+    declared_hash = reference.get("sha256")
+    if not isinstance(path_value, str) or not path_value:
+        raise ValueError("render manifest reference.path is required")
+    if not _valid_sha256(declared_hash):
+        raise ValueError("render manifest reference.sha256 is invalid")
+    source = _manifest_path(manifest_path, path_value)
+    if not source.is_file():
+        raise ValueError(f"reference source file is missing: {source}")
+    actual_hash = _sha256(source)
+    if actual_hash != declared_hash:
+        raise ValueError("reference source file hash differs from render manifest")
+    if expected_sha256 is not None and actual_hash != expected_sha256:
+        raise ValueError("reference source file hash differs from adaptive state lock")
+    if expected_path is not None and source != Path(expected_path).expanduser().resolve():
+        raise ValueError("reference source path differs from adaptive state lock")
+    return source
+
+
+def _directions_equal(left: Any, right: Any, tolerance: float = 1e-9) -> bool:
+    if not isinstance(left, list) or not isinstance(right, list) or len(left) != 3 or len(right) != 3:
+        return False
+    if not all(_finite_number(value) for value in left + right):
+        return False
+    return all(abs(float(a) - float(b)) <= tolerance for a, b in zip(left, right))
+
+
+def _capture_evidence(
+    manifest_path: Path,
+    manifest: dict[str, Any],
+    view: dict[str, Any],
+    *,
+    expected_session_id: str,
+    require_reference: bool = False,
+) -> dict[str, Any]:
+    view_id = str(view["id"])
+    capture = _find_capture(manifest, view_id)
+    if capture.get("status") != "recorded":
+        raise ValueError(f"adaptive view has not been browser-captured: {view_id}")
+    binding = capture.get("adaptiveCritic")
+    if not isinstance(binding, dict):
+        raise ValueError(f"capture {view_id} lacks adaptiveCritic scene binding")
+    if not _directions_equal(binding.get("direction"), view.get("direction")):
+        raise ValueError(f"capture {view_id} direction differs from adaptive view plan")
+    if binding.get("sessionId") != expected_session_id:
+        raise ValueError(f"capture {view_id} belongs to a different adaptive critic session")
+    if capture.get("azimuthDegrees") != view.get("azimuthDegrees"):
+        raise ValueError(f"capture {view_id} azimuth differs from adaptive view plan")
+    if capture.get("elevationDegrees") != view.get("elevationDegrees"):
+        raise ValueError(f"capture {view_id} elevation differs from adaptive view plan")
+    screenshot_value = capture.get("path")
+    if not isinstance(screenshot_value, str) or not screenshot_value:
+        raise ValueError(f"capture {view_id} has no screenshot path")
+    screenshot = _manifest_path(manifest_path, screenshot_value)
+    if not screenshot.is_file():
+        raise ValueError(f"capture file is missing: {screenshot}")
+    current_hash = _sha256(screenshot)
+    if capture.get("screenshotSha256") != current_hash:
+        raise ValueError(f"capture hash changed or was never recorded: {view_id}")
+    pixel_hash = _decoded_pixel_sha256(screenshot)
+    if capture.get("pixelSha256") != pixel_hash:
+        raise ValueError(f"capture decoded-pixel hash changed or was never recorded: {view_id}")
+    browser_evidence = capture.get("browserEvidence")
+    browser_evidence_hash = capture.get("browserEvidenceSha256")
+    if not isinstance(browser_evidence, dict) or not isinstance(browser_evidence_hash, str):
+        raise ValueError(f"capture lacks Playwright browser provenance: {view_id}")
+    if _canonical_sha256(browser_evidence) != browser_evidence_hash:
+        raise ValueError(f"capture browser provenance hash changed: {view_id}")
+    evidence: dict[str, Any] = {
+        "viewId": view_id,
+        "capturePath": str(screenshot),
+        "captureSha256": current_hash,
+        "capturePixelSha256": pixel_hash,
+        "browserEvidenceSha256": browser_evidence_hash,
+        "browserEvidence": browser_evidence,
+        "direction": view["direction"],
+        "azimuthDegrees": view["azimuthDegrees"],
+        "elevationDegrees": view["elevationDegrees"],
+        "angularRadiusDegrees": view["angularRadiusDegrees"],
+        "cell": view["cell"],
+    }
+    reference = capture.get("reference")
+    if isinstance(reference, dict) and reference.get("status") == "recorded" and reference.get("path"):
+        if require_reference and (
+            reference.get("readySignal") is not True or reference.get("consoleErrors")
+        ):
+            raise ValueError(
+                f"GLB reference capture lacks clean strict-ready browser evidence: {view_id}"
+            )
+        reference_path = _manifest_path(manifest_path, str(reference["path"]))
+        if not reference_path.is_file():
+            raise ValueError(f"reference capture file is missing: {reference_path}")
+        reference_hash = _sha256(reference_path)
+        if reference.get("screenshotSha256") != reference_hash:
+            raise ValueError(f"reference capture hash changed: {view_id}")
+        evidence["referenceCapturePath"] = str(reference_path)
+        evidence["referenceCaptureSha256"] = reference_hash
+    elif require_reference:
+        raise ValueError(
+            f"GLB adaptive view has no recorded browser reference capture: {view_id}"
+        )
+    return evidence
+
+
+def _ledger_entry_from_evidence(
+    evidence: dict[str, Any], round_index: int
+) -> dict[str, Any]:
+    browser_evidence = evidence.get("browserEvidence")
+    scene_hash = (
+        browser_evidence.get("runtime", {}).get("sceneBuildSha256")
+        if isinstance(browser_evidence, dict)
+        else None
+    )
+    entry = {
+        "viewId": str(evidence["viewId"]),
+        "round": round_index,
+        "capturePath": str(evidence["capturePath"]),
+        "captureSha256": str(evidence["captureSha256"]),
+        "capturePixelSha256": str(evidence["capturePixelSha256"]),
+        "browserEvidenceSha256": str(evidence["browserEvidenceSha256"]),
+        "sceneBuildSha256": scene_hash,
+        "direction": list(evidence["direction"]),
+    }
+    if "referenceCapturePath" in evidence or "referenceCaptureSha256" in evidence:
+        entry["referenceCapturePath"] = evidence.get("referenceCapturePath")
+        entry["referenceCaptureSha256"] = evidence.get("referenceCaptureSha256")
+    _validate_ledger_entry(entry, f"evidence ledger entry {entry['viewId']}")
+    return entry
+
+
+def _validate_historical_evidence(
+    state: dict[str, Any], manifest_path: Path, manifest: dict[str, Any]
+) -> None:
+    """Re-open every ledger item and reject disappearance or mutation.
+
+    The manifest is expected to grow as new rounds are scheduled, so pinning one
+    manifest-file hash for the entire run would be incorrect.  Instead this
+    ledger pins every evidence-critical capture field and revalidates the live
+    file and receipt on each request.
+    """
+    views_by_id = {str(view["id"]): view for view in _all_views(state)}
+    for index, saved in enumerate(state.get("evidenceLedger", [])):
+        if not isinstance(saved, dict):
+            raise ValueError(f"state.evidenceLedger[{index}] must be an object")
+        view_id = str(saved.get("viewId", ""))
+        planned = views_by_id.get(view_id)
+        if planned is None:
+            raise ValueError(f"historical scheduled evidence view disappeared: {view_id}")
+        current = _ledger_entry_from_evidence(
+            _capture_evidence(
+                manifest_path,
+                manifest,
+                planned,
+                expected_session_id=state["sessionId"],
+                require_reference=state["scene"].get("referenceKind") == "glb",
+            ),
+            int(planned["round"]),
+        )
+        if current != saved:
+            raise ValueError(f"historical adaptive evidence changed: {view_id}")
+
+
+def _base_turntable_result(
+    state: dict[str, Any], manifest_path: Path, manifest: dict[str, Any]
+) -> dict[str, Any]:
+    views_by_face = {
+        str(view.get("cell", {}).get("face")): view
+        for view in _all_views(state)
+        if isinstance(view.get("cell"), dict)
+        and int(view["cell"].get("level", -1)) == 0
+    }
+    missing = [face for face in EQUATOR_FACES if face not in views_by_face]
+    if missing:
+        raise ValueError(f"adaptive state is missing fixed turntable base faces: {missing}")
+    captures: list[tuple[float, Path]] = []
+    for face in EQUATOR_FACES:
+        evidence = _capture_evidence(
+            manifest_path,
+            manifest,
+            views_by_face[face],
+            expected_session_id=state["sessionId"],
+            require_reference=state["scene"].get("referenceKind") == "glb",
+        )
+        captures.append((float(evidence["azimuthDegrees"]), Path(evidence["capturePath"])))
+    try:
+        from .turntable_gate import analyze_turntable  # type: ignore[import-not-found]
+    except ImportError:  # direct ``python forge/stage4_review/...py`` execution
+        from turntable_gate import analyze_turntable
+
+    result = analyze_turntable(
+        captures,
+        allow_holes=bool(state["policy"].get("allowHoles", False)),
+    )
+    if not result.get("passed"):
+        raise ValueError(
+            "fixed turntable baseline failed before independent critique: "
+            f"missing={result.get('missingAzimuths')} "
+            f"unsegmented={result.get('unsegmentedAzimuths')} "
+            f"degenerate={result.get('degenerate')} holed={result.get('holed')}"
+        )
+    return result
+
+
+def build_critic_request(
+    state: dict[str, Any], manifest_path: Path
+) -> dict[str, Any]:
+    # Treat direct API calls transactionally just like the CLI's atomic state
+    # file write. All locks/ledger/pending mutations happen on a deep copy and
+    # are committed to the caller only after every baseline/history gate and
+    # final state validation succeeds.
+    caller_state = state
+    state = copy.deepcopy(state)
+    _validate_state(state)
+    if state.get("status") != "needs-render" or not state.get("nextViews"):
+        raise ValueError("state has no nextViews awaiting real scene captures")
+    if state.get("pendingRequest") is not None:
+        raise ValueError(
+            "state already has an unconsumed pending critic request; advance it before issuing another"
+        )
+    manifest_path = manifest_path.expanduser().resolve()
+    expected_manifest = Path(str(state["scene"]["manifestPath"])).expanduser().resolve()
+    if manifest_path != expected_manifest:
+        raise ValueError("manifest path differs from the scene pinned in state")
+    manifest = _read_json(manifest_path)
+    if str(manifest.get("runtime", {}).get("url")) != state["scene"]["runtimeUrl"]:
+        raise ValueError("runtime URL changed from the scene pinned at critic init")
+    reference = manifest.get("reference", {})
+    if reference.get("kind") != state["scene"]["referenceKind"]:
+        raise ValueError("reference kind changed from the scene pinned at critic init")
+    if reference.get("sha256") != state["scene"]["referenceSha256"]:
+        raise ValueError("reference hash changed from the scene pinned at critic init")
+    reference_source = _validate_reference_source(
+        manifest_path,
+        manifest,
+        expected_sha256=state["scene"]["referenceSha256"],
+        expected_path=state["scene"]["referencePath"],
+    )
+
+    capture_set_integrity = validate_adaptive_capture_set(
+        manifest_path,
+        manifest,
+        session_id=state["sessionId"],
+    )
+    scene_build_hash = capture_set_integrity.get("sceneBuildSha256")
+    if not _valid_sha256(scene_build_hash):
+        raise ValueError("adaptive capture set has no single valid sceneBuildSha256")
+    locked_scene_hash = state["scene"].get("sceneBuildSha256")
+    if locked_scene_hash is None:
+        state["scene"]["sceneBuildSha256"] = scene_build_hash
+    elif locked_scene_hash != scene_build_hash:
+        raise ValueError(
+            "adaptive capture sceneBuildSha256 differs from the first-round state lock"
+        )
+
+    _validate_historical_evidence(state, manifest_path, manifest)
+    expected_view_ids = {str(view["id"]) for view in _all_views(state)}
+    recorded_view_ids = {
+        str(capture.get("id"))
+        for capture in manifest.get("captures", [])
+        if isinstance(capture, dict)
+        and capture.get("role") == "adaptive-critic"
+        and capture.get("status") == "recorded"
+        and isinstance(capture.get("adaptiveCritic"), dict)
+        and capture["adaptiveCritic"].get("sessionId") == state["sessionId"]
+    }
+    if recorded_view_ids != expected_view_ids:
+        raise ValueError(
+            "adaptive session evidence does not exactly match all scheduled views; "
+            f"missing={sorted(expected_view_ids - recorded_view_ids)} "
+            f"extra={sorted(recorded_view_ids - expected_view_ids)}"
+        )
+
+    evidence = [
+        _capture_evidence(
+            manifest_path,
+            manifest,
+            view,
+            expected_session_id=state["sessionId"],
+            require_reference=state["scene"].get("referenceKind") == "glb",
+        )
+        for view in state["nextViews"]
+    ]
+    current_ledger = [
+        _ledger_entry_from_evidence(item, int(state["currentRound"]))
+        for item in evidence
+    ]
+    existing_ledger_ids = {
+        str(item["viewId"])
+        for item in state["evidenceLedger"]
+        if isinstance(item, dict) and item.get("viewId")
+    }
+    repeated_ids = sorted(
+        str(item["viewId"])
+        for item in current_ledger
+        if str(item["viewId"]) in existing_ledger_ids
+    )
+    if repeated_ids:
+        raise ValueError(f"current evidence was already consumed into the ledger: {repeated_ids}")
+    state["evidenceLedger"].extend(current_ledger)
+    baseline = _base_turntable_result(state, manifest_path, manifest)
+    request: dict[str, Any] = {
+        "kind": KIND_REQUEST,
+        "schemaVersion": SCHEMA_VERSION,
+        "sessionId": state["sessionId"],
+        "round": state["currentRound"],
+        "creator": state["creator"],
+        "scene": {
+            "manifestPath": str(manifest_path),
+            "manifestSha256": _sha256(manifest_path),
+            "runtimeUrl": state["scene"]["runtimeUrl"],
+            "referenceKind": state["scene"]["referenceKind"],
+            "referencePath": str(reference_source),
+            "referenceSha256": state["scene"]["referenceSha256"],
+            "sceneBuildSha256": state["scene"]["sceneBuildSha256"],
+        },
+        "fixedTurntableBaseline": baseline,
+        "captureSetIntegrity": capture_set_integrity,
+        "views": evidence,
+        "criticContract": {
+            "requiredRole": "independent-harsh-critic",
+            "identityRule": "critic.id MUST differ from creator.id",
+            "pixelRule": (
+                "open every capture at native resolution; bind every finding to its "
+                "viewId, captureSha256, and exact direction"
+            ),
+            "stance": (
+                "assume the scene is wrong until observable geometry, attachment, "
+                "material response, camera readability, and off-axis form survive inspection"
+            ),
+            "criticalRule": (
+                "one critical finding blocks the entire run; never average defects "
+                "across views or features"
+            ),
+            "requiredAcknowledgements": list(REQUIRED_ACKNOWLEDGEMENTS),
+            "minimumUniformLevel": state["policy"]["minimumUniformLevel"],
+            "responseKind": KIND_RESPONSE,
+            "schema": "docs/specs/adaptive-harsh-critic.v1.schema.json",
+        },
+    }
+    digest = _canonical_request_digest(request)
+    request["requestDigest"] = digest
+    request["requestId"] = _request_id_from_digest(digest)
+    state["pendingRequest"] = {
+        "requestId": request["requestId"],
+        "canonicalSha256": digest,
+        "round": state["currentRound"],
+        "manifestSha256": request["scene"]["manifestSha256"],
+        "viewIds": [str(item["viewId"]) for item in evidence],
+    }
+    _validate_state(state)
+    caller_state.clear()
+    caller_state.update(copy.deepcopy(state))
+    return request
+
+
+def _validate_response_identity(
+    state: dict[str, Any], request: dict[str, Any], response: dict[str, Any]
+) -> dict[str, Any]:
+    _reject_extra_fields(
+        response,
+        {"kind", "schemaVersion", "requestId", "critic", "views"},
+        "critic response",
+    )
+    if response.get("kind") != KIND_RESPONSE or response.get("schemaVersion") != SCHEMA_VERSION:
+        raise ValueError("not an adaptive harsh critic v1 response")
+    if response.get("requestId") != request.get("requestId"):
+        raise ValueError("critic response requestId does not match request")
+    critic = response.get("critic")
+    if not isinstance(critic, dict):
+        raise ValueError("response.critic must be an object")
+    _reject_extra_fields(
+        critic, {"id", "role", "acknowledgements"}, "response.critic"
+    )
+    _forbid_aggregate_fields(critic, "response.critic")
+    critic_id = critic.get("id")
+    if not isinstance(critic_id, str) or not critic_id.strip():
+        raise ValueError("response.critic.id is required")
+    if critic_id.strip() == state["creator"]["id"]:
+        raise ValueError("critic.id MUST differ from creator.id")
+    if critic.get("role") != "independent-harsh-critic":
+        raise ValueError("response.critic.role must be independent-harsh-critic")
+    acknowledgements = critic.get("acknowledgements")
+    if not isinstance(acknowledgements, dict):
+        raise ValueError("response.critic.acknowledgements must be an object")
+    _reject_extra_fields(
+        acknowledgements,
+        set(REQUIRED_ACKNOWLEDGEMENTS),
+        "response.critic.acknowledgements",
+    )
+    for field in REQUIRED_ACKNOWLEDGEMENTS:
+        if acknowledgements.get(field) is not True:
+            raise ValueError(f"critic acknowledgement must be true: {field}")
+    return critic
+
+
+def _forbid_aggregate_fields(value: dict[str, Any], label: str) -> None:
+    forbidden = sorted(FORBIDDEN_AGGREGATE_FIELDS & set(value))
+    if forbidden:
+        raise ValueError(
+            f"{label} contains forbidden aggregate score fields {forbidden}; "
+            "adaptive critical defects use logical AND, never averaging"
+        )
+
+
+def _validate_request_integrity(state: dict[str, Any], request: dict[str, Any]) -> None:
+    _reject_extra_fields(
+        request,
+        {
+            "kind",
+            "schemaVersion",
+            "requestId",
+            "requestDigest",
+            "sessionId",
+            "round",
+            "creator",
+            "scene",
+            "fixedTurntableBaseline",
+            "captureSetIntegrity",
+            "views",
+            "criticContract",
+        },
+        "critic request",
+    )
+    pending = state.get("pendingRequest")
+    if not isinstance(pending, dict):
+        raise ValueError("state has no pending critic request to consume")
+    actual_digest = _canonical_request_digest(request)
+    declared_digest = request.get("requestDigest")
+    derived_id = _request_id_from_digest(actual_digest)
+    if declared_digest != actual_digest:
+        raise ValueError("critic request canonical digest does not match its complete content")
+    if request.get("requestId") != derived_id:
+        raise ValueError("critic requestId is not derived from the complete canonical request")
+    if pending.get("canonicalSha256") != actual_digest:
+        raise ValueError("critic request differs from state.pendingRequest canonical digest")
+    if pending.get("requestId") != request.get("requestId"):
+        raise ValueError("critic requestId differs from state.pendingRequest")
+    if pending.get("round") != request.get("round"):
+        raise ValueError("critic request round differs from state.pendingRequest")
+    scene = request.get("scene")
+    if not isinstance(scene, dict) or pending.get("manifestSha256") != scene.get("manifestSha256"):
+        raise ValueError("critic request manifest differs from state.pendingRequest")
+    request_views = request.get("views")
+    if not isinstance(request_views, list):
+        raise ValueError("critic request views must be a list")
+    if pending.get("viewIds") != [str(item.get("viewId")) for item in request_views if isinstance(item, dict)]:
+        raise ValueError("critic request view order differs from state.pendingRequest")
+
+
+def _validate_request_bindings(state: dict[str, Any], request: dict[str, Any]) -> None:
+    if request.get("creator") != state.get("creator"):
+        raise ValueError("critic request creator differs from state")
+    contract = request.get("criticContract")
+    if not isinstance(contract, dict):
+        raise ValueError("critic request criticContract must be an object")
+    _reject_extra_fields(
+        contract,
+        {
+            "requiredRole",
+            "identityRule",
+            "pixelRule",
+            "stance",
+            "criticalRule",
+            "requiredAcknowledgements",
+            "minimumUniformLevel",
+            "responseKind",
+            "schema",
+        },
+        "critic request.criticContract",
+    )
+    if contract.get("requiredRole") != "independent-harsh-critic":
+        raise ValueError("critic request requiredRole was changed")
+    if contract.get("criticalRule") != (
+        "one critical finding blocks the entire run; never average defects "
+        "across views or features"
+    ):
+        raise ValueError("critic request criticalRule was changed")
+    if contract.get("requiredAcknowledgements") != list(REQUIRED_ACKNOWLEDGEMENTS):
+        raise ValueError("critic request requiredAcknowledgements were changed")
+    if contract.get("minimumUniformLevel") != state["policy"]["minimumUniformLevel"]:
+        raise ValueError("critic request minimumUniformLevel was changed")
+    state_views = {str(item["id"]): item for item in state.get("nextViews", [])}
+    ledger_by_id = {
+        str(item["viewId"]): item
+        for item in state.get("evidenceLedger", [])
+        if isinstance(item, dict) and item.get("viewId")
+    }
+    request_views = request.get("views")
+    if not isinstance(request_views, list):
+        raise ValueError("critic request views must be a list")
+    for item in request_views:
+        if not isinstance(item, dict) or str(item.get("viewId")) not in state_views:
+            raise ValueError("critic request contains a view not present in state.nextViews")
+        _reject_extra_fields(
+            item,
+            {
+                "viewId",
+                "capturePath",
+                "captureSha256",
+                "capturePixelSha256",
+                "browserEvidenceSha256",
+                "browserEvidence",
+                "direction",
+                "azimuthDegrees",
+                "elevationDegrees",
+                "angularRadiusDegrees",
+                "cell",
+                "referenceCapturePath",
+                "referenceCaptureSha256",
+            },
+            f"critic request view {item.get('viewId')}",
+        )
+        planned = state_views[str(item["viewId"])]
+        if not _directions_equal(item.get("direction"), planned.get("direction")):
+            raise ValueError(f"critic request direction differs from state: {item.get('viewId')}")
+        if item.get("cell") != planned.get("cell"):
+            raise ValueError(f"critic request cell differs from state: {item.get('viewId')}")
+        ledger_entry = _ledger_entry_from_evidence(item, int(request["round"]))
+        if ledger_by_id.get(str(item["viewId"])) != ledger_entry:
+            raise ValueError(
+                f"critic request evidence differs from state evidence ledger: {item.get('viewId')}"
+            )
+        _validate_capture_still_matches(item)
+    scene = request.get("scene")
+    if not isinstance(scene, dict):
+        raise ValueError("critic request scene must be an object")
+    _reject_extra_fields(
+        scene,
+        {
+            "manifestPath",
+            "manifestSha256",
+            "runtimeUrl",
+            "referenceKind",
+            "referencePath",
+            "referenceSha256",
+            "sceneBuildSha256",
+        },
+        "critic request.scene",
+    )
+    if scene.get("sceneBuildSha256") != state["scene"].get("sceneBuildSha256"):
+        raise ValueError("critic request scene build differs from state lock")
+    if (
+        scene.get("referenceKind") != state["scene"].get("referenceKind")
+        or scene.get("referencePath") != state["scene"].get("referencePath")
+        or scene.get("referenceSha256") != state["scene"].get("referenceSha256")
+    ):
+        raise ValueError("critic request reference source differs from state lock")
+    capture_integrity = request.get("captureSetIntegrity")
+    if not isinstance(capture_integrity, dict):
+        raise ValueError("critic request captureSetIntegrity must be an object")
+    _reject_extra_fields(
+        capture_integrity,
+        {
+            "recordedCaptureCount",
+            "uniquePixelCount",
+            "uniqueCameraMatrixCount",
+            "sceneBuildSha256",
+        },
+        "critic request.captureSetIntegrity",
+    )
+    if capture_integrity.get("sceneBuildSha256") != state["scene"].get(
+        "sceneBuildSha256"
+    ):
+        raise ValueError("critic request capture set differs from state scene build lock")
+    manifest_value = scene.get("manifestPath")
+    manifest_hash = scene.get("manifestSha256")
+    if not isinstance(manifest_value, str) or not isinstance(manifest_hash, str):
+        raise ValueError("critic request scene manifest binding is missing")
+    manifest_path = Path(manifest_value).expanduser().resolve()
+    if manifest_path != Path(str(state["scene"]["manifestPath"])).expanduser().resolve():
+        raise ValueError("critic request scene manifest path differs from state")
+    if not manifest_path.is_file() or _sha256(manifest_path) != manifest_hash:
+        raise ValueError("critic request scene manifest hash changed")
+    manifest = _read_json(manifest_path)
+    if manifest.get("reference", {}).get("kind") != state["scene"]["referenceKind"]:
+        raise ValueError("render manifest reference kind differs from adaptive state lock")
+    _validate_reference_source(
+        manifest_path,
+        manifest,
+        expected_sha256=state["scene"]["referenceSha256"],
+        expected_path=state["scene"]["referencePath"],
+    )
+    actual_integrity = validate_adaptive_capture_set(
+        manifest_path, manifest, session_id=state["sessionId"]
+    )
+    if actual_integrity != capture_integrity:
+        raise ValueError("critic request captureSetIntegrity differs from live scene evidence")
+    _validate_historical_evidence(state, manifest_path, manifest)
+
+
+def _validate_capture_still_matches(view: dict[str, Any]) -> None:
+    capture_path = Path(str(view["capturePath"])).expanduser().resolve()
+    if not capture_path.is_file():
+        raise ValueError(f"critic evidence capture is missing: {capture_path}")
+    if _sha256(capture_path) != view["captureSha256"]:
+        raise ValueError(f"critic evidence capture hash changed: {view['viewId']}")
+    if _decoded_pixel_sha256(capture_path) != view.get("capturePixelSha256"):
+        raise ValueError(f"critic evidence decoded-pixel hash changed: {view['viewId']}")
+    browser_evidence = view.get("browserEvidence")
+    if not isinstance(browser_evidence, dict):
+        raise ValueError(f"critic evidence browser provenance is missing: {view['viewId']}")
+    if _canonical_sha256(browser_evidence) != view.get("browserEvidenceSha256"):
+        raise ValueError(f"critic evidence browser provenance hash changed: {view['viewId']}")
+    has_reference_path = "referenceCapturePath" in view
+    has_reference_hash = "referenceCaptureSha256" in view
+    if has_reference_path != has_reference_hash:
+        raise ValueError(
+            f"critic evidence reference path/hash binding is incomplete: {view['viewId']}"
+        )
+    if has_reference_path:
+        reference_path = Path(str(view["referenceCapturePath"])).expanduser().resolve()
+        if not reference_path.is_file():
+            raise ValueError(
+                f"critic evidence reference capture is missing: {reference_path}"
+            )
+        if _sha256(reference_path) != view["referenceCaptureSha256"]:
+            raise ValueError(
+                f"critic evidence reference capture hash changed: {view['viewId']}"
+            )
+
+
+def _normalize_reviews(
+    request: dict[str, Any], response: dict[str, Any]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], bool]:
+    request_views = {str(item["viewId"]): item for item in request.get("views", [])}
+    raw_reviews = response.get("views")
+    if not isinstance(raw_reviews, list):
+        raise ValueError("response.views must be a list")
+    reviews_by_id: dict[str, dict[str, Any]] = {}
+    findings: list[dict[str, Any]] = []
+    unreviewable = False
+    for index, review in enumerate(raw_reviews):
+        if not isinstance(review, dict):
+            raise ValueError(f"response.views[{index}] must be an object")
+        _reject_extra_fields(
+            review,
+            {"viewId", "captureSha256", "direction", "verdict", "findings"},
+            f"response.views[{index}]",
+        )
+        _forbid_aggregate_fields(review, f"response.views[{index}]")
+        view_id = review.get("viewId")
+        if not isinstance(view_id, str) or view_id not in request_views:
+            raise ValueError(f"response.views[{index}].viewId is not requested")
+        if view_id in reviews_by_id:
+            raise ValueError(f"duplicate critic review for view: {view_id}")
+        requested = request_views[view_id]
+        _validate_capture_still_matches(requested)
+        if review.get("captureSha256") != requested["captureSha256"]:
+            raise ValueError(f"review captureSha256 does not bind requested pixels: {view_id}")
+        if not _directions_equal(review.get("direction"), requested["direction"]):
+            raise ValueError(f"review direction does not bind requested view: {view_id}")
+        verdict = review.get("verdict")
+        if verdict not in {"pass", "defect", "unreviewable"}:
+            raise ValueError(f"invalid review verdict for {view_id}")
+        raw_findings = review.get("findings")
+        if not isinstance(raw_findings, list):
+            raise ValueError(f"review findings must be a list: {view_id}")
+        if verdict == "pass" and raw_findings:
+            raise ValueError(f"pass review cannot contain findings: {view_id}")
+        if verdict == "defect" and not raw_findings:
+            raise ValueError(f"defect review must contain findings: {view_id}")
+        if verdict == "unreviewable":
+            unreviewable = True
+        normalized_findings: list[dict[str, Any]] = []
+        for finding_index, finding in enumerate(raw_findings):
+            if not isinstance(finding, dict):
+                raise ValueError(f"finding {view_id}[{finding_index}] must be an object")
+            prefix = f"finding {view_id}[{finding_index}]"
+            _reject_extra_fields(
+                finding,
+                {
+                    "defectKey",
+                    "severity",
+                    "category",
+                    "description",
+                    "viewId",
+                    "captureSha256",
+                    "direction",
+                },
+                prefix,
+            )
+            _forbid_aggregate_fields(finding, prefix)
+            for field in ("defectKey", "category", "description"):
+                if not isinstance(finding.get(field), str) or not finding[field].strip():
+                    raise ValueError(f"{prefix}.{field} must be a non-empty string")
+            severity = finding.get("severity")
+            if severity not in SEVERITY_RANK:
+                raise ValueError(f"{prefix}.severity must be minor, major, or critical")
+            if finding.get("viewId") != view_id:
+                raise ValueError(f"{prefix}.viewId does not bind the reviewed view")
+            if finding.get("captureSha256") != requested["captureSha256"]:
+                raise ValueError(f"{prefix}.captureSha256 does not bind actual pixels")
+            if not _directions_equal(finding.get("direction"), requested["direction"]):
+                raise ValueError(f"{prefix}.direction does not bind the reviewed camera")
+            normalized = {
+                "defectKey": finding["defectKey"].strip(),
+                "severity": severity,
+                "category": finding["category"].strip(),
+                "description": finding["description"].strip(),
+                "viewId": view_id,
+                "captureSha256": requested["captureSha256"],
+                "direction": requested["direction"],
+            }
+            normalized_findings.append(normalized)
+            findings.append(normalized)
+        reviews_by_id[view_id] = {
+            "viewId": view_id,
+            "captureSha256": requested["captureSha256"],
+            "direction": requested["direction"],
+            "verdict": verdict,
+            "findings": normalized_findings,
+        }
+    missing = sorted(set(request_views) - set(reviews_by_id))
+    extra = sorted(set(reviews_by_id) - set(request_views))
+    if missing or extra:
+        raise ValueError(f"critic must review every requested view exactly once; missing={missing} extra={extra}")
+    ordered = [reviews_by_id[str(item["viewId"])] for item in request["views"]]
+    return ordered, findings, unreviewable
+
+
+def _round_defect_keys(round_record: dict[str, Any]) -> set[str]:
+    return set(str(key) for key in round_record.get("defectKeys", []))
+
+
+def _repeated_defects(rounds: list[dict[str, Any]], count: int) -> list[str]:
+    if len(rounds) < count:
+        return []
+    shared = _round_defect_keys(rounds[-1])
+    for record in rounds[-count:-1]:
+        shared &= _round_defect_keys(record)
+    return sorted(shared)
+
+
+def _defect_profile(findings: list[dict[str, Any]]) -> tuple[int, int]:
+    worst = max((SEVERITY_RANK[item["severity"]] for item in findings), default=0)
+    return worst, len(findings)
+
+
+def _is_improvement(
+    previous: dict[str, Any], current: dict[str, Any], min_reduction: int
+) -> bool:
+    previous_worst = int(previous.get("worstSeverityRank", 0))
+    current_worst = int(current.get("worstSeverityRank", 0))
+    if current_worst < previous_worst:
+        return True
+    if current_worst > previous_worst:
+        return False
+    return int(previous.get("findingCount", 0)) - int(current.get("findingCount", 0)) >= min_reduction
+
+
+def _blocked(
+    state: dict[str, Any], reason: str, action: str, findings: list[dict[str, Any]]
+) -> dict[str, Any]:
+    state["nextViews"] = []
+    state["status"] = "blocked"
+    state["action"] = action
+    state["stopReason"] = reason
+    state["blockingDefects"] = findings
+    state["pendingRequest"] = None
+    return state
+
+
+def advance_state(
+    state: dict[str, Any], request: dict[str, Any], response: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate one independent critique and produce the next adaptive views."""
+    _validate_state(state)
+    if state.get("status") != "needs-render":
+        raise ValueError("only a needs-render state can accept a critic response")
+    if request.get("kind") != KIND_REQUEST or request.get("schemaVersion") != SCHEMA_VERSION:
+        raise ValueError("not an adaptive harsh critic v1 request")
+    if request.get("sessionId") != state.get("sessionId"):
+        raise ValueError("critic request belongs to a different session")
+    if request.get("round") != state.get("currentRound"):
+        raise ValueError("critic request round does not match state")
+    _validate_request_integrity(state, request)
+    _validate_request_bindings(state, request)
+    _forbid_aggregate_fields(response, "critic response")
+    critic = _validate_response_identity(state, request, response)
+    reviews, findings, unreviewable = _normalize_reviews(request, response)
+    requested_ids = [str(item["id"]) for item in state["nextViews"]]
+    request_ids = [str(item["viewId"]) for item in request.get("views", [])]
+    if requested_ids != request_ids:
+        raise ValueError("critic request views differ from state.nextViews")
+
+    worst_rank, finding_count = _defect_profile(findings)
+    critical_count = sum(1 for item in findings if item["severity"] == "critical")
+    defect_keys = sorted({item["defectKey"] for item in findings})
+    ledger_by_id = {
+        str(item["viewId"]): item
+        for item in state["evidenceLedger"]
+        if isinstance(item, dict) and item.get("viewId")
+    }
+    round_evidence = [
+        dict(ledger_by_id[str(view["viewId"])]) for view in request["views"]
+    ]
+    completed = {
+        "round": state["currentRound"],
+        "requestId": request["requestId"],
+        "requestDigest": request["requestDigest"],
+        "captureSetIntegrity": request["captureSetIntegrity"],
+        "critic": {"id": critic["id"], "role": critic["role"]},
+        "views": state["nextViews"],
+        "evidence": round_evidence,
+        "reviews": reviews,
+        "defectKeys": defect_keys,
+        "findingCount": finding_count,
+        "criticalCount": critical_count,
+        "worstSeverityRank": worst_rank,
+        "criticalRulePassed": critical_count == 0,
+    }
+    minimum_uniform_level = int(state["policy"]["minimumUniformLevel"])
+    uniform_sources = [
+        view
+        for view in state["nextViews"]
+        if int(view.get("cell", {}).get("level", -1)) < minimum_uniform_level
+    ]
+    completed["minimumUniformCoverageComplete"] = not uniform_sources
+    rounds = list(state["rounds"])
+    rounds.append(completed)
+    state["rounds"] = rounds
+    state["blockingDefects"] = findings
+
+    if unreviewable:
+        return _blocked(state, "unreviewable-evidence", "request-input", findings)
+    if not findings and not uniform_sources:
+        state["nextViews"] = []
+        state["status"] = "passed"
+        state["action"] = "continue"
+        state["stopReason"] = "no-defects-after-minimum-uniform-coverage"
+        state["blockingDefects"] = []
+        state["pendingRequest"] = None
+        return state
+
+    if findings:
+        repeated = _repeated_defects(rounds, int(state["policy"]["repeatedDefectRounds"]))
+        if repeated:
+            state["repeatedDefects"] = repeated
+            return _blocked(state, "repeated-defect", "refine-code", findings)
+
+    plateau_streak = int(state.get("plateauStreak", 0))
+    if (
+        findings
+        and len(rounds) >= 2
+        and int(rounds[-2].get("findingCount", 0)) > 0
+        and not _is_improvement(
+            rounds[-2], rounds[-1], int(state["policy"]["minDefectReduction"])
+        )
+    ):
+        plateau_streak += 1
+    else:
+        plateau_streak = 0
+    state["plateauStreak"] = plateau_streak
+    if plateau_streak >= int(state["policy"]["plateauRounds"]):
+        return _blocked(state, "plateau", "request-input", findings)
+
+    if len(rounds) >= int(state["policy"]["maxRounds"]):
+        reason = "max-rounds-before-minimum-coverage" if uniform_sources else "max-rounds"
+        return _blocked(state, reason, "request-input", findings)
+
+    next_round = int(state["currentRound"]) + 1
+    next_views: list[dict[str, Any]] = []
+    if uniform_sources:
+        # Fail-closed baseline: even six clean face centres are not enough.
+        # Subdivide EVERY under-covered face cell before defect-only refinement.
+        subdivision_sources = uniform_sources
+        state["refinementMode"] = "minimum-uniform-coverage"
+    else:
+        defective_view_ids = {item["viewId"] for item in findings}
+        subdivision_sources = [
+            view for view in state["nextViews"] if view["id"] in defective_view_ids
+        ]
+        state["refinementMode"] = "defect-directed"
+    for view in subdivision_sources:
+        if isinstance(view, dict):
+            next_views.extend(subdivide_view(view, next_round))
+    # A malformed critic response cannot create a finding detached from a view,
+    # but keep this fail-closed check explicit because no next view would look
+    # deceptively like convergence.
+    if not next_views:
+        return _blocked(state, "defects-without-refinement-cells", "request-input", findings)
+    proposed_total = int(state["scheduledViewCount"]) + len(next_views)
+    if proposed_total > int(state["policy"]["maxViews"]):
+        state["unscheduledNextViewCount"] = len(next_views)
+        reason = "max-views-before-minimum-coverage" if uniform_sources else "max-views"
+        return _blocked(state, reason, "request-input", findings)
+
+    state["currentRound"] = next_round
+    state["nextViews"] = next_views
+    state["scheduledViewCount"] = proposed_total
+    state["status"] = "needs-render"
+    state["action"] = "capture-next-views"
+    state["stopReason"] = None
+    state["pendingRequest"] = None
+    return state
+
+
+def _status_summary(state: dict[str, Any]) -> dict[str, Any]:
+    _validate_state(state)
+    return {
+        "sessionId": state["sessionId"],
+        "status": state["status"],
+        "action": state["action"],
+        "stopReason": state.get("stopReason"),
+        "completedRounds": len(state["rounds"]),
+        "currentRound": state["currentRound"],
+        "scheduledViewCount": state["scheduledViewCount"],
+        "pendingRequest": state.get("pendingRequest"),
+        "nextViews": state["nextViews"],
+        "blockingDefects": state.get("blockingDefects", []),
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    init = commands.add_parser("init", help="initialize six-face adaptive scene review")
+    init.add_argument("--manifest", type=Path, required=True)
+    init.add_argument("--creator-id", required=True)
+    init.add_argument("--out", type=Path, required=True)
+    init.add_argument("--max-rounds", type=int, default=DEFAULT_MAX_ROUNDS)
+    init.add_argument("--max-views", type=int, default=DEFAULT_MAX_VIEWS)
+    init.add_argument("--repeated-defect-rounds", type=int, default=DEFAULT_REPEATED_DEFECT_ROUNDS)
+    init.add_argument("--plateau-rounds", type=int, default=DEFAULT_PLATEAU_ROUNDS)
+    init.add_argument("--min-defect-reduction", type=int, default=DEFAULT_MIN_DEFECT_REDUCTION)
+    init.add_argument("--minimum-uniform-level", type=int, default=DEFAULT_MINIMUM_UNIFORM_LEVEL)
+    init.add_argument("--allow-holes", action="store_true")
+
+    request_parser = commands.add_parser(
+        "request", help="bind real scene captures and emit an independent critic request"
+    )
+    request_parser.add_argument("--state", type=Path, required=True)
+    request_parser.add_argument("--manifest", type=Path)
+    request_parser.add_argument("--out", type=Path, required=True)
+
+    advance = commands.add_parser("advance", help="validate critic response and plan nextViews")
+    advance.add_argument("--state", type=Path, required=True)
+    advance.add_argument("--request", type=Path, required=True)
+    advance.add_argument("--reviews", type=Path, required=True)
+    advance.add_argument(
+        "--in-place",
+        action="store_true",
+        required=True,
+        help="consume the pending request in the canonical source state",
+    )
+
+    status = commands.add_parser("status", help="show current critic state")
+    status.add_argument("--state", type=Path, required=True)
+    status.add_argument("--json", action="store_true")
+
+    try:
+        args = parser.parse_args(argv)
+        if args.command == "init":
+            result = init_state(
+                args.manifest,
+                args.creator_id,
+                max_rounds=args.max_rounds,
+                max_views=args.max_views,
+                repeated_defect_rounds=args.repeated_defect_rounds,
+                plateau_rounds=args.plateau_rounds,
+                min_defect_reduction=args.min_defect_reduction,
+                minimum_uniform_level=args.minimum_uniform_level,
+                allow_holes=args.allow_holes,
+            )
+            output = args.out.expanduser().resolve()
+            if output.exists():
+                raise ValueError(f"refusing to overwrite existing state: {output}")
+            _write_json(output, result)
+            print(json.dumps(_status_summary(result), indent=2, ensure_ascii=False))
+            return 0
+        if args.command == "request":
+            state_path = args.state.expanduser().resolve()
+            state = _read_json(state_path)
+            manifest_path = (
+                args.manifest.expanduser().resolve()
+                if args.manifest
+                else Path(str(state.get("scene", {}).get("manifestPath", ""))).expanduser().resolve()
+            )
+            output = args.out.expanduser().resolve()
+            if output.exists():
+                raise ValueError(f"refusing to overwrite existing critic request: {output}")
+            result = build_critic_request(state, manifest_path)
+            _write_json(output, result)
+            # A request file without its state pin is unusable; write the request
+            # first, then atomically persist the pending digest in the state.
+            # If the second write fails, advance still fails closed because the
+            # on-disk state has no matching pending request.
+            _write_json(state_path, state)
+            print(
+                json.dumps(
+                    {
+                        "request": str(output),
+                        "requestId": result["requestId"],
+                        "requestDigest": result["requestDigest"],
+                        "statePinned": str(state_path),
+                        "views": len(result["views"]),
+                    },
+                    indent=2,
+                )
+            )
+            return 0
+        if args.command == "advance":
+            state_path = args.state.expanduser().resolve()
+            state = _read_json(state_path)
+            result = advance_state(
+                state,
+                _read_json(args.request.expanduser().resolve()),
+                _read_json(args.reviews.expanduser().resolve()),
+            )
+            # There is exactly one canonical state transition.  ``advance``
+            # intentionally has no --out mode because two filesystem targets
+            # cannot be committed atomically and a failed snapshot must never
+            # make a consumed request look retryable.
+            _write_json(state_path, result)
+            print(json.dumps(_status_summary(result), indent=2, ensure_ascii=False))
+            return 1 if result["status"] == "blocked" else 0
+        if args.command == "status":
+            result = _status_summary(_read_json(args.state.expanduser().resolve()))
+            if args.json:
+                print(json.dumps(result, indent=2, ensure_ascii=False))
+            else:
+                print(
+                    f"status={result['status']} action={result['action']} "
+                    f"round={result['currentRound']} views={result['scheduledViewCount']} "
+                    f"stop={result['stopReason']}"
+                )
+            return 1 if result["status"] == "blocked" else 0
+        raise ValueError(f"unknown command: {args.command}")
+    except Exception as exc:  # noqa: BLE001 - CLI boundary must fail closed without a traceback
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/forge/stage4_review/render_bridge.py
+++ b/forge/stage4_review/render_bridge.py
@@ -10,17 +10,27 @@ the actual Three.js pixels.
 from __future__ import annotations
 
 import argparse
+import copy
 import hashlib
 import json
+import math
+import re
 import sys
 from datetime import datetime, timezone
-from pathlib import Path
+from functools import lru_cache
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any
+from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 STAGE1 = Path(__file__).resolve().parents[1] / "stage1_intake"
 sys.path.insert(0, str(STAGE1))
 from probe_image import probe  # noqa: E402
 from probe_glb import probe_glb  # noqa: E402
+from extract_pbr_evidence import load_image  # noqa: E402
+
+SHARED = Path(__file__).resolve().parents[1] / "_shared"
+sys.path.insert(0, str(SHARED))
+from image_hash import hamming, phash, to_grayscale_downsampled  # noqa: E402
 
 REVIEW_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(REVIEW_DIR))
@@ -37,6 +47,23 @@ CAPTURE_PLAN: tuple[dict[str, Any], ...] = (
     {"id": "head-threequarter", "role": "head-closeup", "azimuthDegrees": 35, "elevationDegrees": 0},
 )
 
+ADAPTIVE_BROWSER_RECEIPT_KIND = "img2threejs.playwright-capture-receipt"
+ADAPTIVE_BROWSER_RECEIPT_VERSION = 1
+SHA256_PATTERN = re.compile(r"^[a-f0-9]{64}$")
+NONCE_PATTERN = re.compile(r"^[a-f0-9]{32,64}$")
+ADAPTIVE_SESSION_PATTERN = re.compile(r"^ahc-[a-f0-9]{20}$")
+ADAPTIVE_VIEW_ID_PATTERN = re.compile(
+    r"^ahc-[a-f0-9]{20}-harsh-(front|right|rear|left|top|bottom)-(root|[0-3]+)$"
+)
+# Whole-frame +/-3 LSB noise has MAE ~= 3/255 (0.0118).  A strict
+# visible-color floor rejects that tiny perturbation without relying on pHash,
+# while the structure envelope below catches slightly wider uniform
+# brightness/color shifts whose scene layout did not change.
+NEAR_DUPLICATE_VISIBLE_RGB_MAE = 0.02
+NEAR_DUPLICATE_STRUCTURE_MAE = 0.025
+NEAR_DUPLICATE_MEAN_COLOR_DISTANCE = 0.10
+NEAR_DUPLICATE_PHASH_DISTANCE = 2
+
 
 def sha256(path: Path) -> str:
     digest = hashlib.sha256()
@@ -44,6 +71,588 @@ def sha256(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def canonical_sha256(value: Any) -> str:
+    """Hash one JSON value with the canonical encoding used by evidence receipts."""
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def decoded_pixel_sha256(path: Path) -> str:
+    """Hash decoded RGBA pixels, not PNG container bytes.
+
+    This catches the same frame re-encoded with different PNG compression or
+    metadata, which a file SHA alone cannot detect.
+    """
+    return str(_decoded_image_signature(path)["pixelSha256"])
+
+
+@lru_cache(maxsize=512)
+def _decoded_image_signature_cached(path_value: str, file_hash: str) -> dict[str, Any]:
+    # ``file_hash`` is deliberately part of the key: overwriting a capture at
+    # the same path cannot reuse the old perceptual signature.
+    del file_hash
+    width, height, pixels, _warnings = load_image(Path(path_value))
+    pixel_digest = hashlib.sha256()
+    pixel_digest.update(f"rgba8:{width}x{height}\n".encode("ascii"))
+    for pixel in pixels:
+        pixel_digest.update(bytes(pixel))
+    # Browser screenshots are normally opaque, but treat transparent RGB as
+    # invisible by compositing over white before pHash/luma comparison. This
+    # prevents hidden RGB noise under alpha=0 from masquerading as a new view.
+    composited: list[tuple[int, int, int, int]] = []
+    for red, green, blue, alpha in pixels:
+        opacity = alpha / 255.0
+        composited.append(
+            (
+                round(red * opacity + 255 * (1.0 - opacity)),
+                round(green * opacity + 255 * (1.0 - opacity)),
+                round(blue * opacity + 255 * (1.0 - opacity)),
+                255,
+            )
+        )
+    gray = to_grayscale_downsampled(width, height, composited)
+    grid_size = 32
+    rgb_sums = [[[0.0, 0.0, 0.0, 0] for _x in range(grid_size)] for _y in range(grid_size)]
+    for index, (red, green, blue, _alpha) in enumerate(composited):
+        x = index % width
+        y = index // width
+        cell_x = min(grid_size - 1, x * grid_size // width)
+        cell_y = min(grid_size - 1, y * grid_size // height)
+        cell = rgb_sums[cell_y][cell_x]
+        cell[0] += red
+        cell[1] += green
+        cell[2] += blue
+        cell[3] += 1
+    rgb: list[list[tuple[float, float, float]]] = []
+    for row in rgb_sums:
+        normalized_row: list[tuple[float, float, float]] = []
+        for red_sum, green_sum, blue_sum, count in row:
+            divisor = float(count) if count else 1.0
+            normalized_row.append(
+                (red_sum / divisor, green_sum / divisor, blue_sum / divisor)
+            )
+        rgb.append(normalized_row)
+    return {
+        "width": width,
+        "height": height,
+        "gray": gray,
+        "rgb": rgb,
+        "meanRgb": tuple(
+            sum(pixel[channel] for pixel in composited) / len(composited)
+            for channel in range(3)
+        ) if composited else (0.0, 0.0, 0.0),
+        "phash": phash(gray),
+        "pixelSha256": pixel_digest.hexdigest(),
+    }
+
+
+def _decoded_image_signature(path: Path) -> dict[str, Any]:
+    """Return a compact low-frequency + pHash signature for replay detection."""
+    resolved = path.expanduser().resolve()
+    return _decoded_image_signature_cached(str(resolved), sha256(resolved))
+
+
+def _normalized_visible_rgb_mae(left: dict[str, Any], right: dict[str, Any]) -> float:
+    """Mean alpha-composited RGB error in [0, 1], or 1 for size mismatch.
+
+    Luma alone aliases visibly different isoluminant colors (for example red
+    versus dark green). RGB preserves that chroma evidence. Compositing before
+    downsampling makes hidden RGB beneath alpha=0 irrelevant.
+    """
+    if left["width"] != right["width"] or left["height"] != right["height"]:
+        return 1.0
+    left_rgb = left["rgb"]
+    right_rgb = right["rgb"]
+    if len(left_rgb) != len(right_rgb) or not left_rgb:
+        return 1.0
+    total = 0.0
+    samples = 0
+    for left_row, right_row in zip(left_rgb, right_rgb):
+        if len(left_row) != len(right_row):
+            return 1.0
+        for left_pixel, right_pixel in zip(left_row, right_row):
+            total += sum(
+                abs(float(left_value) - float(right_value))
+                for left_value, right_value in zip(left_pixel, right_pixel)
+            )
+            samples += 3
+    return total / (samples * 255.0) if samples else 1.0
+
+
+def _normalized_demeaned_luma_mae(left: dict[str, Any], right: dict[str, Any]) -> float:
+    """Brightness-shift-invariant low-frequency structure error in [0, 1]."""
+    if left["width"] != right["width"] or left["height"] != right["height"]:
+        return 1.0
+    left_gray = left.get("gray")
+    right_gray = right.get("gray")
+    if not isinstance(left_gray, list) or not isinstance(right_gray, list):
+        return 1.0
+    left_values = [float(value) for row in left_gray for value in row]
+    right_values = [float(value) for row in right_gray for value in row]
+    if not left_values or len(left_values) != len(right_values):
+        return 1.0
+    left_mean = sum(left_values) / len(left_values)
+    right_mean = sum(right_values) / len(right_values)
+    return sum(
+        abs((left_value - left_mean) - (right_value - right_mean))
+        for left_value, right_value in zip(left_values, right_values)
+    ) / (len(left_values) * 255.0)
+
+
+def _normalized_mean_color_distance(left: dict[str, Any], right: dict[str, Any]) -> float:
+    """Mean alpha-composited RGB difference in [0, 1]."""
+    left_mean = left.get("meanRgb")
+    right_mean = right.get("meanRgb")
+    if (
+        not isinstance(left_mean, tuple)
+        or not isinstance(right_mean, tuple)
+        or len(left_mean) != 3
+        or len(right_mean) != 3
+    ):
+        return 1.0
+    return sum(
+        abs(float(left_value) - float(right_value))
+        for left_value, right_value in zip(left_mean, right_mean)
+    ) / (3.0 * 255.0)
+
+
+def _near_identical_image_signatures(
+    left: dict[str, Any], right: dict[str, Any]
+) -> tuple[bool, int, float]:
+    distance = hamming(int(left["phash"]), int(right["phash"]))
+    visible_rgb_mae = _normalized_visible_rgb_mae(left, right)
+    structure_mae = _normalized_demeaned_luma_mae(left, right)
+    mean_color_distance = _normalized_mean_color_distance(left, right)
+    # The extreme critic is intentionally fail closed.  Tiny visible-color
+    # changes never prove a new camera view, even when adversarial structured
+    # noise destabilizes pHash.  A second, brightness-shift-invariant envelope
+    # catches pHash-stable frames with the same spatial structure, but its mean
+    # color guard leaves visibly different isoluminant colors admissible.
+    collapsed = visible_rgb_mae <= NEAR_DUPLICATE_VISIBLE_RGB_MAE or (
+        distance <= NEAR_DUPLICATE_PHASH_DISTANCE
+        and structure_mae <= NEAR_DUPLICATE_STRUCTURE_MAE
+        and mean_color_distance <= NEAR_DUPLICATE_MEAN_COLOR_DISTANCE
+    )
+    return collapsed, distance, visible_rgb_mae
+
+
+def _reject_extra_fields(value: dict[str, Any], allowed: set[str], label: str) -> None:
+    extra = sorted(set(value) - allowed)
+    if extra:
+        raise ValueError(f"{label} contains schema-forbidden fields: {extra}")
+
+
+def _normalized_document_url(value: Any) -> str:
+    """Normalize only browser-safe semantic URL differences.
+
+    Chromium adds ``/`` to an origin-only HTTP(S) URL and may remove a default
+    port.  Everything else (path, query, fragment, origin) remains part of the
+    equality check so a redirect cannot silently become accepted evidence.
+    """
+    if not isinstance(value, str) or not value:
+        raise ValueError("browser URL must be a non-empty string")
+    parsed = urlsplit(value)
+    if not parsed.scheme:
+        raise ValueError("browser URL must be absolute")
+    scheme = parsed.scheme.lower()
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("browser URL credentials are not allowed")
+    hostname = parsed.hostname
+    if hostname is None:
+        # Keep non-network schemes (for example file:) deterministic without
+        # manufacturing an origin.
+        return urlunsplit(parsed)
+    host = hostname.lower()
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    port = parsed.port
+    if port is not None and not (
+        (scheme == "http" and port == 80) or (scheme == "https" and port == 443)
+    ):
+        host = f"{host}:{port}"
+    path = parsed.path or ("/" if scheme in {"http", "https"} else "")
+    normalized = SplitResult(scheme, host, path, parsed.query, parsed.fragment)
+    return urlunsplit(normalized)
+
+
+def _finite_vector(value: Any, length: int) -> bool:
+    return (
+        isinstance(value, list)
+        and len(value) == length
+        and all(
+            not isinstance(item, bool)
+            and isinstance(item, (int, float))
+            and math.isfinite(float(item))
+            for item in value
+        )
+    )
+
+
+def _directions_equal(left: Any, right: Any, tolerance: float = 1e-6) -> bool:
+    return _finite_vector(left, 3) and _finite_vector(right, 3) and all(
+        abs(float(a) - float(b)) <= tolerance for a, b in zip(left, right)
+    )
+
+
+def _camera_back_axis(matrix_world: list[Any]) -> list[float]:
+    axis = [float(matrix_world[8]), float(matrix_world[9]), float(matrix_world[10])]
+    length = math.sqrt(sum(item * item for item in axis))
+    if length <= 1e-12:
+        raise ValueError("browser receipt camera.matrixWorld has a zero back axis")
+    return [item / length for item in axis]
+
+
+def validate_adaptive_browser_receipt(
+    manifest: dict[str, Any],
+    capture: dict[str, Any],
+    screenshot: Path,
+    image: dict[str, Any],
+    receipt: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate a Playwright-minted adaptive capture receipt fail closed.
+
+    The generic ``record`` CLI deliberately cannot supply this object.  It is
+    assembled by ``scripts/capture_threejs_playwright.py`` from live browser
+    observations after the runtime camera has settled.
+    """
+    capture_id = str(capture.get("id", ""))
+    binding = capture.get("adaptiveCritic")
+    if capture.get("role") != "adaptive-critic" or not isinstance(binding, dict):
+        raise ValueError(f"capture is not an adaptive critic view: {capture_id}")
+    if not isinstance(receipt, dict):
+        raise ValueError(f"adaptive capture requires a Playwright browser receipt: {capture_id}")
+    _reject_extra_fields(
+        receipt,
+        {
+            "kind",
+            "schemaVersion",
+            "adapter",
+            "sessionNonce",
+            "captureId",
+            "runtime",
+            "browser",
+            "camera",
+            "canvas",
+            "screenshot",
+        },
+        "adaptive browser receipt",
+    )
+    if receipt.get("kind") != ADAPTIVE_BROWSER_RECEIPT_KIND:
+        raise ValueError(f"adaptive capture receipt kind is invalid: {capture_id}")
+    if receipt.get("schemaVersion") != ADAPTIVE_BROWSER_RECEIPT_VERSION:
+        raise ValueError(f"adaptive capture receipt schemaVersion is invalid: {capture_id}")
+    if receipt.get("captureId") != capture_id:
+        raise ValueError(f"adaptive browser receipt captureId mismatch: {capture_id}")
+    nonce = receipt.get("sessionNonce")
+    if not isinstance(nonce, str) or not NONCE_PATTERN.fullmatch(nonce):
+        raise ValueError(f"adaptive browser receipt sessionNonce is invalid: {capture_id}")
+
+    adapter = receipt.get("adapter")
+    if not isinstance(adapter, dict) or adapter.get("name") != "capture_threejs_playwright":
+        raise ValueError(f"adaptive capture was not minted by the Playwright adapter: {capture_id}")
+    _reject_extra_fields(adapter, {"name", "version"}, "adaptive browser receipt.adapter")
+    if adapter.get("version") != ADAPTIVE_BROWSER_RECEIPT_VERSION:
+        raise ValueError(f"adaptive capture adapter version is invalid: {capture_id}")
+    browser = receipt.get("browser")
+    if (
+        not isinstance(browser, dict)
+        or browser.get("name") != "chromium"
+        or not isinstance(browser.get("version"), str)
+        or not browser["version"].strip()
+        or not isinstance(browser.get("headless"), bool)
+    ):
+        raise ValueError(f"adaptive browser identity is incomplete: {capture_id}")
+    _reject_extra_fields(
+        browser, {"name", "version", "headless"}, "adaptive browser receipt.browser"
+    )
+
+    runtime = receipt.get("runtime")
+    manifest_runtime = manifest.get("runtime")
+    if not isinstance(runtime, dict) or not isinstance(manifest_runtime, dict):
+        raise ValueError(f"adaptive browser runtime snapshot is missing: {capture_id}")
+    _reject_extra_fields(
+        runtime,
+        {
+            "requestedUrl",
+            "documentUrl",
+            "documentSha256",
+            "readySignal",
+            "captureContract",
+            "snapshotEcho",
+            "sceneBuildSha256",
+            "objectCount",
+        },
+        "adaptive browser receipt.runtime",
+    )
+    expected_url = manifest_runtime.get("url")
+    if runtime.get("requestedUrl") != expected_url:
+        raise ValueError(f"adaptive browser runtime URL request does not match manifest: {capture_id}")
+    try:
+        document_matches = _normalized_document_url(
+            runtime.get("documentUrl")
+        ) == _normalized_document_url(expected_url)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"adaptive browser document URL is invalid: {capture_id}") from exc
+    if not document_matches:
+        raise ValueError(f"adaptive browser runtime URL does not match manifest: {capture_id}")
+    document_hash = runtime.get("documentSha256")
+    if not isinstance(document_hash, str) or not SHA256_PATTERN.fullmatch(document_hash):
+        raise ValueError(f"adaptive browser documentSha256 is invalid: {capture_id}")
+    ready = runtime.get("readySignal")
+    if (
+        not isinstance(ready, dict)
+        or ready.get("expression") != manifest_runtime.get("readySignal")
+        or ready.get("value") is not True
+        or ready.get("valueType") != "boolean"
+    ):
+        raise ValueError(f"adaptive browser ready contract was not strictly true: {capture_id}")
+    _reject_extra_fields(
+        ready,
+        {"expression", "value", "valueType"},
+        "adaptive browser receipt.runtime.readySignal",
+    )
+    contract = runtime.get("captureContract")
+    if (
+        not isinstance(contract, dict)
+        or contract.get("name") != manifest_runtime.get("captureContract")
+        or contract.get("setCamera") is not True
+        or contract.get("getEvidenceSnapshot") is not True
+    ):
+        raise ValueError(f"adaptive runtime capture contract is incomplete: {capture_id}")
+    _reject_extra_fields(
+        contract,
+        {"name", "setCamera", "getEvidenceSnapshot"},
+        "adaptive browser receipt.runtime.captureContract",
+    )
+    snapshot_echo = runtime.get("snapshotEcho")
+    if (
+        not isinstance(snapshot_echo, dict)
+        or snapshot_echo.get("captureId") != capture_id
+        or snapshot_echo.get("sessionNonce") != nonce
+    ):
+        raise ValueError(f"adaptive runtime snapshot challenge was not echoed: {capture_id}")
+    _reject_extra_fields(
+        snapshot_echo,
+        {"captureId", "sessionNonce"},
+        "adaptive browser receipt.runtime.snapshotEcho",
+    )
+    scene_hash = runtime.get("sceneBuildSha256")
+    if not isinstance(scene_hash, str) or not SHA256_PATTERN.fullmatch(scene_hash):
+        raise ValueError(f"adaptive runtime sceneBuildSha256 is invalid: {capture_id}")
+    object_count = runtime.get("objectCount")
+    if isinstance(object_count, bool) or not isinstance(object_count, int) or object_count <= 0:
+        raise ValueError(f"adaptive runtime objectCount must be positive: {capture_id}")
+
+    canvas = receipt.get("canvas")
+    if (
+        not isinstance(canvas, dict)
+        or canvas.get("selector") != "canvas"
+        or canvas.get("webgl") is not True
+    ):
+        raise ValueError(f"adaptive capture is not bound to a WebGL canvas: {capture_id}")
+    _reject_extra_fields(
+        canvas,
+        {
+            "selector",
+            "cssWidth",
+            "cssHeight",
+            "width",
+            "height",
+            "drawingBufferWidth",
+            "drawingBufferHeight",
+            "devicePixelRatio",
+            "webgl",
+        },
+        "adaptive browser receipt.canvas",
+    )
+    for field in (
+        "cssWidth",
+        "cssHeight",
+        "width",
+        "height",
+        "drawingBufferWidth",
+        "drawingBufferHeight",
+    ):
+        value = canvas.get(field)
+        if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+            raise ValueError(f"adaptive browser canvas.{field} must be positive: {capture_id}")
+    manifest_viewport = manifest_runtime.get("viewport")
+    manifest_dpr = manifest_runtime.get("devicePixelRatio")
+    if (
+        not isinstance(manifest_viewport, list)
+        or len(manifest_viewport) != 2
+        or any(
+            isinstance(value, bool) or not isinstance(value, int) or value <= 0
+            for value in manifest_viewport
+        )
+        or isinstance(manifest_dpr, bool)
+        or not isinstance(manifest_dpr, (int, float))
+        or not math.isfinite(float(manifest_dpr))
+        or not 0.25 <= float(manifest_dpr) <= 8.0
+    ):
+        raise ValueError(f"adaptive manifest viewport/DPR is invalid: {capture_id}")
+    receipt_dpr = canvas.get("devicePixelRatio")
+    if (
+        isinstance(receipt_dpr, bool)
+        or not isinstance(receipt_dpr, (int, float))
+        or not math.isfinite(float(receipt_dpr))
+        or abs(float(receipt_dpr) - float(manifest_dpr)) > 1e-9
+    ):
+        raise ValueError(f"adaptive browser devicePixelRatio differs from manifest: {capture_id}")
+    if [canvas["cssWidth"], canvas["cssHeight"]] != manifest_viewport:
+        raise ValueError(f"adaptive browser canvas CSS size differs from viewport: {capture_id}")
+    expected_width = round(canvas["cssWidth"] * float(receipt_dpr))
+    expected_height = round(canvas["cssHeight"] * float(receipt_dpr))
+    if canvas["width"] != expected_width or canvas["height"] != expected_height:
+        raise ValueError(f"adaptive browser canvas backing size differs from CSS size/DPR: {capture_id}")
+    if (
+        canvas["drawingBufferWidth"] != canvas["width"]
+        or canvas["drawingBufferHeight"] != canvas["height"]
+    ):
+        raise ValueError(f"adaptive WebGL drawing buffer differs from canvas backing size: {capture_id}")
+
+    camera = receipt.get("camera")
+    if not isinstance(camera, dict):
+        raise ValueError(f"adaptive browser camera snapshot is missing: {capture_id}")
+    _reject_extra_fields(
+        camera,
+        {"direction", "matrixWorld", "projectionMatrix"},
+        "adaptive browser receipt.camera",
+    )
+    expected_direction = binding.get("direction")
+    if not _directions_equal(camera.get("direction"), expected_direction):
+        raise ValueError(f"adaptive browser camera direction mismatch: {capture_id}")
+    matrix_world = camera.get("matrixWorld")
+    projection_matrix = camera.get("projectionMatrix")
+    if not _finite_vector(matrix_world, 16) or not _finite_vector(projection_matrix, 16):
+        raise ValueError(f"adaptive browser camera matrices are invalid: {capture_id}")
+    if not _directions_equal(_camera_back_axis(matrix_world), expected_direction, tolerance=1e-5):
+        raise ValueError(f"adaptive camera matrix does not encode planned direction: {capture_id}")
+
+    screenshot_record = receipt.get("screenshot")
+    file_hash = sha256(screenshot)
+    pixel_hash = decoded_pixel_sha256(screenshot)
+    if not isinstance(screenshot_record, dict):
+        raise ValueError(f"adaptive browser screenshot receipt is missing: {capture_id}")
+    _reject_extra_fields(
+        screenshot_record,
+        {"sha256", "pixelSha256", "width", "height"},
+        "adaptive browser receipt.screenshot",
+    )
+    if screenshot_record.get("sha256") != file_hash:
+        raise ValueError(f"adaptive browser screenshot hash mismatch: {capture_id}")
+    if screenshot_record.get("pixelSha256") != pixel_hash:
+        raise ValueError(f"adaptive browser decoded-pixel hash mismatch: {capture_id}")
+    if screenshot_record.get("width") != image.get("width") or screenshot_record.get("height") != image.get("height"):
+        raise ValueError(f"adaptive browser screenshot dimensions mismatch: {capture_id}")
+    if (
+        screenshot_record.get("width") != canvas["width"]
+        or screenshot_record.get("height") != canvas["height"]
+    ):
+        raise ValueError(f"adaptive browser screenshot is not the full bound canvas: {capture_id}")
+    return copy.deepcopy(receipt)
+
+
+def validate_adaptive_capture_set(
+    manifest_path_value: Path,
+    manifest: dict[str, Any],
+    *,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Validate provenance and reject replay/collapse across camera directions."""
+    recorded: list[dict[str, Any]] = []
+    for capture in manifest.get("captures", []):
+        if not isinstance(capture, dict) or capture.get("role") != "adaptive-critic":
+            continue
+        binding = capture.get("adaptiveCritic")
+        if not isinstance(binding, dict) or (session_id is not None and binding.get("sessionId") != session_id):
+            continue
+        if capture.get("status") != "recorded":
+            continue
+        screenshot_value = capture.get("path")
+        if not isinstance(screenshot_value, str) or not screenshot_value:
+            raise ValueError(f"adaptive capture has no screenshot path: {capture.get('id')}")
+        screenshot = manifest_path(manifest_path_value, screenshot_value)
+        if not screenshot.is_file():
+            raise ValueError(f"adaptive capture screenshot is missing: {screenshot}")
+        image = probe(screenshot)
+        receipt = capture.get("browserEvidence")
+        normalized = validate_adaptive_browser_receipt(manifest, capture, screenshot, image, receipt)
+        receipt_hash = canonical_sha256(normalized)
+        if capture.get("browserEvidenceSha256") != receipt_hash:
+            raise ValueError(f"adaptive browser receipt hash changed: {capture.get('id')}")
+        pixel_hash = decoded_pixel_sha256(screenshot)
+        if capture.get("pixelSha256") != pixel_hash:
+            raise ValueError(f"adaptive decoded-pixel hash changed: {capture.get('id')}")
+        perceptual_signature = _decoded_image_signature(screenshot)
+        recorded.append(
+            {
+                "captureId": str(capture["id"]),
+                "sessionId": str(binding.get("sessionId", "")),
+                "direction": binding.get("direction"),
+                "pixelSha256": pixel_hash,
+                "fileSha256": sha256(screenshot),
+                "cameraMatrixSha256": canonical_sha256(normalized["camera"]["matrixWorld"]),
+                "sceneBuildSha256": normalized["runtime"]["sceneBuildSha256"],
+                "browserEvidenceSha256": receipt_hash,
+                "_imageSignature": perceptual_signature,
+            }
+        )
+    for index, left in enumerate(recorded):
+        for right in recorded[index + 1 :]:
+            # A corrected scene starts a new adaptive session.  Preserve and
+            # validate old evidence, but never compare its pixels, cameras, or
+            # scene-build digest against a later session.
+            if left["sessionId"] != right["sessionId"]:
+                continue
+            if _directions_equal(left["direction"], right["direction"]):
+                continue
+            if left["pixelSha256"] == right["pixelSha256"]:
+                raise ValueError(
+                    "duplicate/collapsed adaptive capture pixels across distinct directions: "
+                    f"{left['captureId']} and {right['captureId']}"
+                )
+            collapsed, phash_distance, visible_rgb_mae = _near_identical_image_signatures(
+                left["_imageSignature"], right["_imageSignature"]
+            )
+            if collapsed:
+                raise ValueError(
+                    "near-identical/collapsed adaptive capture pixels across distinct directions: "
+                    f"{left['captureId']} and {right['captureId']} "
+                    f"(pHash Hamming={phash_distance}, "
+                    f"normalized visible-RGB MAE={visible_rgb_mae:.8f})"
+                )
+            if left["cameraMatrixSha256"] == right["cameraMatrixSha256"]:
+                raise ValueError(
+                    "duplicate adaptive camera matrix across distinct directions: "
+                    f"{left['captureId']} and {right['captureId']}"
+                )
+    session_scene_hashes: dict[str, set[str]] = {}
+    for item in recorded:
+        session_scene_hashes.setdefault(item["sessionId"], set()).add(item["sceneBuildSha256"])
+    inconsistent_sessions = sorted(
+        key for key, hashes in session_scene_hashes.items() if len(hashes) > 1
+    )
+    if inconsistent_sessions:
+        raise ValueError(
+            "adaptive captures were recorded from different scene build digests "
+            f"inside session(s): {', '.join(inconsistent_sessions)}"
+        )
+    scene_hashes = {item["sceneBuildSha256"] for item in recorded}
+    return {
+        "recordedCaptureCount": len(recorded),
+        "uniquePixelCount": len({item["pixelSha256"] for item in recorded}),
+        "uniqueCameraMatrixCount": len({item["cameraMatrixSha256"] for item in recorded}),
+        "sceneBuildSha256": next(iter(scene_hashes), None) if len(scene_hashes) <= 1 else None,
+    }
 
 
 def read_manifest(path: Path) -> dict[str, Any]:
@@ -190,6 +799,280 @@ def find_capture(manifest: dict[str, Any], capture_id: str) -> dict[str, Any]:
     raise ValueError(f"capture id not found: {capture_id}")
 
 
+def _validate_adaptive_schedule_plan(plan: dict[str, Any]) -> None:
+    """Reuse the controller's canonical state/view grammar before path creation."""
+    try:
+        from .adaptive_harsh_critic import _validate_state  # type: ignore[import-not-found]
+    except ImportError:  # direct ``python forge/stage4_review/render_bridge.py`` execution
+        from adaptive_harsh_critic import _validate_state  # type: ignore[no-redef]
+
+    _validate_state(plan)
+
+
+def _safe_relative_evidence_path(
+    value: str,
+    *,
+    manifest_path_value: Path | None,
+    label: str,
+) -> str:
+    """Return one canonical POSIX-relative path confined to the manifest root."""
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty relative path")
+    if "\\" in value or "\x00" in value:
+        raise ValueError(f"{label} contains a forbidden path separator or NUL")
+    raw_parts = value.split("/")
+    if any(part in {"", ".", ".."} for part in raw_parts):
+        raise ValueError(f"{label} contains an unsafe relative path component")
+    posix_path = PurePosixPath(value)
+    windows_path = PureWindowsPath(value)
+    if (
+        posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or bool(windows_path.drive)
+        or bool(windows_path.root)
+    ):
+        raise ValueError(f"{label} must be relative to the manifest evidence root")
+    canonical = posix_path.as_posix()
+    if canonical != value:
+        raise ValueError(f"{label} is not a canonical relative path")
+    if manifest_path_value is not None:
+        evidence_root = manifest_path_value.expanduser().resolve().parent
+        candidate = (evidence_root / Path(*posix_path.parts)).resolve()
+        try:
+            candidate.relative_to(evidence_root)
+        except ValueError as exc:
+            raise ValueError(f"{label} escapes the manifest evidence root") from exc
+    return canonical
+
+
+def _validate_scheduled_evidence_paths(
+    capture: dict[str, Any],
+    *,
+    manifest_path_value: Path | None,
+    label: str,
+) -> None:
+    _safe_relative_evidence_path(
+        capture.get("path"),
+        manifest_path_value=manifest_path_value,
+        label=f"{label}.path",
+    )
+    passes = capture.get("passes")
+    if not isinstance(passes, dict):
+        raise ValueError(f"{label}.passes must be an object")
+    for pass_id in PASS_IDS:
+        record = passes.get(pass_id)
+        if not isinstance(record, dict):
+            raise ValueError(f"{label}.passes.{pass_id} is required")
+        _safe_relative_evidence_path(
+            record.get("path"),
+            manifest_path_value=manifest_path_value,
+            label=f"{label}.passes.{pass_id}.path",
+        )
+    reference = capture.get("reference")
+    if reference is not None:
+        if not isinstance(reference, dict):
+            raise ValueError(f"{label}.reference must be an object")
+        _safe_relative_evidence_path(
+            reference.get("path"),
+            manifest_path_value=manifest_path_value,
+            label=f"{label}.reference.path",
+        )
+        reference_passes = reference.get("passes")
+        if not isinstance(reference_passes, dict):
+            raise ValueError(f"{label}.reference.passes must be an object")
+        for pass_id in PASS_IDS:
+            record = reference_passes.get(pass_id)
+            if not isinstance(record, dict):
+                raise ValueError(f"{label}.reference.passes.{pass_id} is required")
+            _safe_relative_evidence_path(
+                record.get("path"),
+                manifest_path_value=manifest_path_value,
+                label=f"{label}.reference.passes.{pass_id}.path",
+            )
+
+
+def schedule_adaptive_views(
+    manifest: dict[str, Any],
+    plan: dict[str, Any],
+    *,
+    manifest_path: Path | None = None,
+    output_dir: str = "captures/adaptive",
+) -> dict[str, Any]:
+    """Add ``adaptive_harsh_critic.py`` nextViews to the real scene manifest.
+
+    This is the bridge between a deterministic view plan and actual Three.js
+    pixels.  It does not invent screenshots: every new capture starts pending
+    and must go through the same browser adapter + ``record_capture`` hash path
+    as the fixed camera batch.  Re-importing an identical plan is idempotent;
+    reusing a view ID with a different direction/session is rejected.
+    """
+    _validate_adaptive_schedule_plan(plan)
+    if plan.get("status") != "needs-render":
+        raise ValueError("adaptive plan status must be needs-render")
+    session_id = plan.get("sessionId")
+    round_index = plan.get("currentRound")
+    views = plan.get("nextViews")
+    if not isinstance(session_id, str) or ADAPTIVE_SESSION_PATTERN.fullmatch(session_id) is None:
+        raise ValueError("adaptive plan sessionId must be ahc- plus 20 lowercase hex characters")
+    if isinstance(round_index, bool) or not isinstance(round_index, int) or round_index < 0:
+        raise ValueError("adaptive plan currentRound must be a non-negative integer")
+    if not isinstance(views, list) or not views:
+        raise ValueError("adaptive plan nextViews must be a non-empty list")
+    manifest_path_value = manifest_path.expanduser().resolve() if manifest_path is not None else None
+    if manifest_path_value is not None:
+        plan_manifest_path = Path(str(plan["scene"]["manifestPath"])).expanduser().resolve()
+        if plan_manifest_path != manifest_path_value:
+            raise ValueError("adaptive plan scene.manifestPath differs from target manifest")
+    base_dir_value = output_dir.rstrip("/\\")
+    base_dir = _safe_relative_evidence_path(
+        base_dir_value,
+        manifest_path_value=manifest_path_value,
+        label="adaptive output_dir",
+    )
+    # Work transactionally so a later collision/path failure cannot partially
+    # append earlier views to an in-memory manifest used by API callers.
+    working_manifest = copy.deepcopy(manifest)
+    captures = working_manifest.setdefault("captures", [])
+    if not isinstance(captures, list):
+        raise ValueError("manifest captures must be a list")
+    by_id = {
+        str(item.get("id")): item
+        for item in captures
+        if isinstance(item, dict) and item.get("id")
+    }
+    scheduled: list[str] = []
+    already_present: list[str] = []
+    reference = working_manifest.get("reference", {})
+    if not isinstance(reference, dict) or reference.get("kind") not in {"image", "glb"}:
+        raise ValueError("manifest reference.kind must be image or glb")
+    if reference.get("kind") != plan["scene"]["referenceKind"]:
+        raise ValueError("adaptive plan referenceKind differs from target manifest")
+    reference_is_glb = reference.get("kind") == "glb"
+
+    for index, view in enumerate(views):
+        if not isinstance(view, dict):
+            raise ValueError(f"adaptive nextViews[{index}] must be an object")
+        view_id = view.get("id")
+        direction = view.get("direction")
+        azimuth = view.get("azimuthDegrees")
+        elevation = view.get("elevationDegrees")
+        cell = view.get("cell")
+        if not isinstance(view_id, str) or ADAPTIVE_VIEW_ID_PATTERN.fullmatch(view_id) is None:
+            raise ValueError(f"adaptive nextViews[{index}].id is not canonical")
+        if (
+            not isinstance(direction, list)
+            or len(direction) != 3
+            or not all(isinstance(value, (int, float)) and not isinstance(value, bool) for value in direction)
+        ):
+            raise ValueError(f"adaptive view {view_id} direction must be a 3-vector")
+        if not isinstance(azimuth, (int, float)) or isinstance(azimuth, bool):
+            raise ValueError(f"adaptive view {view_id} azimuthDegrees must be numeric")
+        if not isinstance(elevation, (int, float)) or isinstance(elevation, bool):
+            raise ValueError(f"adaptive view {view_id} elevationDegrees must be numeric")
+        if not isinstance(cell, dict):
+            raise ValueError(f"adaptive view {view_id} cell is required")
+        binding = {
+            "sessionId": session_id,
+            "round": round_index,
+            "direction": direction,
+            "angularRadiusDegrees": view.get("angularRadiusDegrees"),
+            "cell": cell,
+            "parentId": view.get("parentId"),
+        }
+        if view_id in by_id:
+            existing = by_id[view_id]
+            if (
+                existing.get("role") != "adaptive-critic"
+                or existing.get("azimuthDegrees") != azimuth
+                or existing.get("elevationDegrees") != elevation
+                or existing.get("adaptiveCritic") != binding
+            ):
+                raise ValueError(f"capture id collision with different adaptive view: {view_id}")
+            _validate_scheduled_evidence_paths(
+                existing,
+                manifest_path_value=manifest_path_value,
+                label=f"adaptive capture {view_id}",
+            )
+            already_present.append(view_id)
+            continue
+
+        # Every adaptive run receives a random session ID.  Keep both capture
+        # IDs and filesystem paths session-scoped so stale evidence from an
+        # earlier run cannot satisfy a fresh plan by name.
+        if not view_id.startswith(f"{session_id}-harsh-"):
+            raise ValueError(
+                f"adaptive view id is not scoped to session {session_id}: {view_id}"
+            )
+        path_prefix = f"{base_dir}/{session_id}/round-{round_index:02d}/{view_id}"
+        capture: dict[str, Any] = {
+            "id": view_id,
+            "role": "adaptive-critic",
+            "azimuthDegrees": azimuth,
+            "elevationDegrees": elevation,
+            "target": [0, 0, 0],
+            "near": 0.01,
+            "far": 100,
+            "path": f"{path_prefix}.png",
+            "status": "pending",
+            "passes": default_pass_records(path_prefix),
+            "adaptiveCritic": binding,
+        }
+        if reference_is_glb:
+            reference_prefix = (
+                f"reference/adaptive/{session_id}/round-{round_index:02d}/{view_id}"
+            )
+            capture["reference"] = {
+                "path": f"{reference_prefix}.png",
+                "status": "pending",
+                "passes": default_pass_records(reference_prefix),
+            }
+        _validate_scheduled_evidence_paths(
+            capture,
+            manifest_path_value=manifest_path_value,
+            label=f"adaptive capture {view_id}",
+        )
+        captures.append(capture)
+        by_id[view_id] = capture
+        scheduled.append(view_id)
+
+    evidence = working_manifest.setdefault("evidence", {})
+    if not isinstance(evidence, dict):
+        raise ValueError("manifest evidence must be an object")
+    plans = evidence.setdefault("adaptiveCriticPlans", [])
+    if not isinstance(plans, list):
+        raise ValueError("manifest evidence.adaptiveCriticPlans must be a list")
+    plan_record = next(
+        (
+            item
+            for item in plans
+            if isinstance(item, dict)
+            and item.get("sessionId") == session_id
+            and item.get("round") == round_index
+        ),
+        None,
+    )
+    expected_view_ids = [str(view["id"]) for view in views]
+    if plan_record is None:
+        plans.append(
+            {
+                "sessionId": session_id,
+                "round": round_index,
+                "viewIds": expected_view_ids,
+            }
+        )
+    elif plan_record.get("viewIds") != expected_view_ids:
+        raise ValueError("adaptive plan round was already registered with different view IDs")
+    manifest.clear()
+    manifest.update(working_manifest)
+    return {
+        "sessionId": session_id,
+        "round": round_index,
+        "scheduled": scheduled,
+        "alreadyPresent": already_present,
+        "captureCount": len(captures),
+    }
+
+
 def record_capture(
     manifest_path_value: Path,
     manifest: dict[str, Any],
@@ -198,6 +1081,7 @@ def record_capture(
     ready_signal: Any = True,
     console_errors: list[str] | None = None,
     browser_snapshot: dict[str, Any] | None = None,
+    browser_receipt: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     screenshot = screenshot.expanduser().resolve()
     if not screenshot.is_file():
@@ -205,8 +1089,83 @@ def record_capture(
     image = probe(screenshot)
     if not image.get("type") or not image.get("width") or not image.get("height"):
         raise ValueError(f"screenshot is not readable: {screenshot}")
-    errors = list(console_errors or [])
     capture = find_capture(manifest, capture_id)
+    errors = list(console_errors or [])
+    normalized_receipt: dict[str, Any] | None = None
+    pixel_hash: str | None = None
+    if capture.get("role") == "adaptive-critic":
+        if ready_signal is not True:
+            raise ValueError(
+                f"adaptive ready signal must be the strict browser boolean true: {capture_id}"
+            )
+        if errors:
+            raise ValueError(f"adaptive browser capture has console/page errors: {capture_id}")
+        if browser_receipt is None:
+            raise ValueError(
+                "adaptive captures cannot be registered from an arbitrary PNG; "
+                "use scripts/capture_threejs_playwright.py"
+            )
+        normalized_receipt = validate_adaptive_browser_receipt(
+            manifest,
+            capture,
+            screenshot,
+            image,
+            browser_receipt,
+        )
+        pixel_hash = decoded_pixel_sha256(screenshot)
+        perceptual_signature = _decoded_image_signature(screenshot)
+        binding = capture.get("adaptiveCritic", {})
+        direction = binding.get("direction") if isinstance(binding, dict) else None
+        matrix_hash = canonical_sha256(normalized_receipt["camera"]["matrixWorld"])
+        scene_hash = normalized_receipt["runtime"]["sceneBuildSha256"]
+        for existing in manifest.get("captures", []):
+            if (
+                not isinstance(existing, dict)
+                or existing is capture
+                or existing.get("role") != "adaptive-critic"
+                or existing.get("status") != "recorded"
+            ):
+                continue
+            existing_binding = existing.get("adaptiveCritic")
+            if (
+                not isinstance(existing_binding, dict)
+                or not isinstance(binding, dict)
+                or existing_binding.get("sessionId") != binding.get("sessionId")
+                or _directions_equal(existing_binding.get("direction"), direction)
+            ):
+                continue
+            if existing.get("pixelSha256") == pixel_hash:
+                raise ValueError(
+                    "duplicate/collapsed adaptive capture pixels across distinct directions: "
+                    f"{existing.get('id')} and {capture_id}"
+                )
+            existing_path_value = existing.get("path")
+            if not isinstance(existing_path_value, str) or not existing_path_value:
+                raise ValueError(f"recorded adaptive capture has no path: {existing.get('id')}")
+            existing_path = manifest_path(manifest_path_value, existing_path_value)
+            if not existing_path.is_file():
+                raise ValueError(f"recorded adaptive capture screenshot is missing: {existing_path}")
+            collapsed, phash_distance, visible_rgb_mae = _near_identical_image_signatures(
+                _decoded_image_signature(existing_path), perceptual_signature
+            )
+            if collapsed:
+                raise ValueError(
+                    "near-identical/collapsed adaptive capture pixels across distinct directions: "
+                    f"{existing.get('id')} and {capture_id} "
+                    f"(pHash Hamming={phash_distance}, "
+                    f"normalized visible-RGB MAE={visible_rgb_mae:.8f})"
+                )
+            existing_receipt = existing.get("browserEvidence")
+            if isinstance(existing_receipt, dict):
+                if canonical_sha256(existing_receipt.get("camera", {}).get("matrixWorld")) == matrix_hash:
+                    raise ValueError(
+                        "duplicate adaptive camera matrix across distinct directions: "
+                        f"{existing.get('id')} and {capture_id}"
+                    )
+                if existing_receipt.get("runtime", {}).get("sceneBuildSha256") != scene_hash:
+                    raise ValueError(
+                        "adaptive captures were recorded from different scene build digests"
+                    )
     capture["path"] = portable_path(manifest_path_value, screenshot)
     capture["status"] = "recorded"
     capture["recordedAt"] = now_utc()
@@ -214,6 +1173,10 @@ def record_capture(
     capture["screenshotSha256"] = sha256(screenshot)
     capture["image"] = image
     capture["consoleErrors"] = errors
+    if normalized_receipt is not None and pixel_hash is not None:
+        capture["pixelSha256"] = pixel_hash
+        capture["browserEvidence"] = normalized_receipt
+        capture["browserEvidenceSha256"] = canonical_sha256(normalized_receipt)
     if browser_snapshot is not None:
         capture["browserSnapshot"] = browser_snapshot
     return capture
@@ -380,6 +1343,21 @@ def validate_manifest(path: Path, require_complete: bool = False) -> dict[str, A
             errors.append(f"screenshot hash changed: {screenshot}")
         if capture.get("consoleErrors"):
             errors.append(f"browser console errors recorded for: {capture_id}")
+        if capture.get("role") == "adaptive-critic":
+            try:
+                validate_adaptive_browser_receipt(
+                    manifest,
+                    capture,
+                    screenshot,
+                    image,
+                    capture.get("browserEvidence"),
+                )
+                if capture.get("browserEvidenceSha256") != canonical_sha256(capture["browserEvidence"]):
+                    errors.append(f"adaptive browser receipt hash changed: {capture_id}")
+                if capture.get("pixelSha256") != decoded_pixel_sha256(screenshot):
+                    errors.append(f"adaptive decoded-pixel hash changed: {capture_id}")
+            except Exception as exc:  # noqa: BLE001 - validation aggregates all failures
+                errors.append(f"adaptive browser provenance invalid for {capture_id}: {exc}")
         errors.extend(
             validate_pass_records(
                 path,
@@ -391,6 +1369,10 @@ def validate_manifest(path: Path, require_complete: bool = False) -> dict[str, A
         )
     if recorded == 0:
         warnings.append("no browser screenshots recorded yet")
+    try:
+        validate_adaptive_capture_set(path, manifest)
+    except Exception as exc:  # noqa: BLE001 - validation aggregates all failures
+        errors.append(f"adaptive capture set invalid: {exc}")
     result = {
         "passed": not errors,
         "errors": errors,
@@ -460,7 +1442,13 @@ def main(argv: list[str]) -> int:
     init.add_argument("--reference-browser-url", help="browser-visible URL/path for the GLB reference mode")
     init.add_argument("--render-profile", type=Path, help="validated render-profile.v2 shared by GLB and procedural routes")
 
-    record = commands.add_parser("record", help="record a browser-produced screenshot into the manifest")
+    record = commands.add_parser(
+        "record",
+        help=(
+            "record a legacy/fixed browser screenshot; adaptive-critic captures are "
+            "accepted only from scripts/capture_threejs_playwright.py"
+        ),
+    )
     record.add_argument("--manifest", type=Path, required=True)
     record.add_argument("--capture-id", required=True)
     record.add_argument("--screenshot", type=Path, required=True)
@@ -488,6 +1476,14 @@ def main(argv: list[str]) -> int:
     diagnostic = commands.add_parser("diagnose", help="run Tier-1 and multi-angle diagnostics")
     diagnostic.add_argument("--manifest", type=Path, required=True)
     diagnostic.add_argument("--out", type=Path, required=True)
+
+    adaptive = commands.add_parser(
+        "schedule-adaptive",
+        help="append adaptive harsh-critic nextViews as pending real-scene captures",
+    )
+    adaptive.add_argument("--manifest", type=Path, required=True)
+    adaptive.add_argument("--plan", type=Path, required=True)
+    adaptive.add_argument("--output-dir", default="captures/adaptive")
 
     args = parser.parse_args(argv)
     try:
@@ -546,6 +1542,17 @@ def main(argv: list[str]) -> int:
             result = diagnose(manifest_path_value, args.out.expanduser().resolve())
             print(json.dumps(result, indent=2, ensure_ascii=False))
             return 0 if result["hero"]["passed"] and not result["multiAngle"]["degenerate"] else 1
+        if args.command == "schedule-adaptive":
+            plan = read_manifest(args.plan.expanduser().resolve())
+            result = schedule_adaptive_views(
+                manifest,
+                plan,
+                manifest_path=manifest_path_value,
+                output_dir=args.output_dir,
+            )
+            write_manifest(manifest_path_value, manifest)
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+            return 0
         raise ValueError(f"unknown command: {args.command}")
     except Exception as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/forge/tests/test_adaptive_harsh_critic.py
+++ b/forge/tests/test_adaptive_harsh_critic.py
@@ -1,0 +1,1379 @@
+#!/usr/bin/env python3
+"""Tests for adaptive, independent, pixel-bound harsh scene critique."""
+
+import copy
+import hashlib
+import io
+import json
+import math
+import struct
+import tempfile
+import unittest
+import zlib
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from unittest import mock
+
+from forge.stage4_review.adaptive_harsh_critic import (
+    KIND_RESPONSE,
+    advance_state,
+    base_views,
+    build_critic_request,
+    init_state,
+    main as adaptive_main,
+    subdivide_view,
+    _validate_state,
+)
+from forge.stage4_review.render_bridge import (
+    ADAPTIVE_BROWSER_RECEIPT_KIND,
+    ADAPTIVE_BROWSER_RECEIPT_VERSION,
+    canonical_sha256,
+    decoded_pixel_sha256,
+    _decoded_image_signature,
+    _near_identical_image_signatures,
+    _normalized_demeaned_luma_mae,
+    init_manifest,
+    main as render_bridge_main,
+    read_manifest,
+    record_capture,
+    schedule_adaptive_views,
+    sha256,
+    write_manifest,
+)
+from forge.stage1_intake.probe_image import probe
+
+
+def write_blob_png(
+    path: Path,
+    width: int = 200,
+    height: int = 200,
+    *,
+    variant: int = 0,
+    compression_level: int = 9,
+    background_value: int = 255,
+    global_delta: int = 0,
+    pixel_nudge: bool = False,
+) -> None:
+    """Write a clearly segmentable dark square on white using stdlib only."""
+    signature = b"\x89PNG\r\n\x1a\n"
+
+    def chunk(kind: bytes, payload: bytes) -> bytes:
+        checksum = zlib.crc32(kind)
+        checksum = zlib.crc32(payload, checksum) & 0xFFFFFFFF
+        return struct.pack(">I", len(payload)) + kind + payload + struct.pack(">I", checksum)
+
+    rows = bytearray()
+    color_value = 20 + ((variant * 37) % 180)
+    x_min = 20 + ((variant * 17) % 45)
+    x_max = width - 20 - ((variant * 29) % 45)
+    y_min = 20 + ((variant * 31) % 45)
+    y_max = height - 20 - ((variant * 13) % 45)
+    for y in range(height):
+        rows.append(0)
+        for x in range(width):
+            base = (
+                color_value
+                if x_min <= x < x_max and y_min <= y < y_max
+                else background_value
+            )
+            value = max(0, min(255, base + global_delta))
+            if pixel_nudge and x == 0 and y == 0:
+                value = value - 1 if value == 255 else value + 1
+            color = (value, value, value)
+            rows.extend(color)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        signature
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(bytes(rows), compression_level))
+        + chunk(b"IEND", b"")
+    )
+
+
+def write_color_field_png(
+    path: Path,
+    color: tuple[int, int, int, int],
+    *,
+    width: int = 200,
+    height: int = 200,
+    structured_delta: int = 0,
+    hidden_rgb_flip: bool = False,
+) -> None:
+    """Write an RGBA field for perceptual-collapse adversarial tests."""
+    signature = b"\x89PNG\r\n\x1a\n"
+
+    def chunk(kind: bytes, payload: bytes) -> bytes:
+        checksum = zlib.crc32(kind)
+        checksum = zlib.crc32(payload, checksum) & 0xFFFFFFFF
+        return struct.pack(">I", len(payload)) + kind + payload + struct.pack(">I", checksum)
+
+    rows = bytearray()
+    for y in range(height):
+        rows.append(0)
+        for x in range(width):
+            red, green, blue, alpha = color
+            if structured_delta:
+                sign = (
+                    1
+                    if ((x * 32 // width) + (y * 32 // height)) % 2
+                    else -1
+                )
+                red = max(0, min(255, red + sign * structured_delta))
+                green = max(0, min(255, green + sign * structured_delta))
+                blue = max(0, min(255, blue + sign * structured_delta))
+            if hidden_rgb_flip and alpha == 0 and (x + y) % 2:
+                red, green, blue = 255 - red, 255 - green, 255 - blue
+            rows.extend((red, green, blue, alpha))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        signature
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(bytes(rows), 9))
+        + chunk(b"IEND", b"")
+    )
+
+
+class AdaptiveHarshCriticTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.reference = self.root / "reference.png"
+        write_blob_png(self.reference)
+        self.manifest_path = self.root / "render-manifest.json"
+        self.manifest = init_manifest(
+            self.reference,
+            "http://127.0.0.1:5173/#/scene",
+            self.manifest_path,
+            (200, 200),
+            1.0,
+            "captures",
+        )
+        write_manifest(self.manifest_path, self.manifest)
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def _new_state(self, **options):
+        return init_state(self.manifest_path, "creator-agent", **options)
+
+    @staticmethod
+    def _camera_matrix(direction):
+        z = [float(item) for item in direction]
+        z_length = math.sqrt(sum(item * item for item in z))
+        z = [item / z_length for item in z]
+        up = [0.0, 0.0, 1.0] if abs(z[1]) > 0.9 else [0.0, 1.0, 0.0]
+        x = [
+            up[1] * z[2] - up[2] * z[1],
+            up[2] * z[0] - up[0] * z[2],
+            up[0] * z[1] - up[1] * z[0],
+        ]
+        x_length = math.sqrt(sum(item * item for item in x))
+        x = [item / x_length for item in x]
+        y = [
+            z[1] * x[2] - z[2] * x[1],
+            z[2] * x[0] - z[0] * x[2],
+            z[0] * x[1] - z[1] * x[0],
+        ]
+        return [
+            x[0], x[1], x[2], 0.0,
+            y[0], y[1], y[2], 0.0,
+            z[0], z[1], z[2], 0.0,
+            z[0] * 3.0, z[1] * 3.0, z[2] * 3.0, 1.0,
+        ]
+
+    def _browser_receipt(
+        self,
+        capture,
+        screenshot,
+        *,
+        ready_value=True,
+        runtime_url=None,
+        document_url=None,
+        scene_build_sha256="3" * 64,
+        matrix_world=None,
+        nonce="a" * 32,
+    ):
+        direction = capture["adaptiveCritic"]["direction"]
+        image = probe(screenshot)
+        css_width, css_height = self.manifest["runtime"]["viewport"]
+        dpr = float(self.manifest["runtime"]["devicePixelRatio"])
+        return {
+            "kind": ADAPTIVE_BROWSER_RECEIPT_KIND,
+            "schemaVersion": ADAPTIVE_BROWSER_RECEIPT_VERSION,
+            "adapter": {
+                "name": "capture_threejs_playwright",
+                "version": ADAPTIVE_BROWSER_RECEIPT_VERSION,
+            },
+            "sessionNonce": nonce,
+            "captureId": capture["id"],
+            "runtime": {
+                "requestedUrl": runtime_url or self.manifest["runtime"]["url"],
+                "documentUrl": (
+                    document_url
+                    if document_url is not None
+                    else runtime_url or self.manifest["runtime"]["url"]
+                ),
+                "documentSha256": "2" * 64,
+                "readySignal": {
+                    "expression": self.manifest["runtime"]["readySignal"],
+                    "value": ready_value,
+                    "valueType": "boolean" if isinstance(ready_value, bool) else type(ready_value).__name__,
+                },
+                "captureContract": {
+                    "name": self.manifest["runtime"]["captureContract"],
+                    "setCamera": True,
+                    "getEvidenceSnapshot": True,
+                },
+                "snapshotEcho": {
+                    "captureId": capture["id"],
+                    "sessionNonce": nonce,
+                },
+                "sceneBuildSha256": scene_build_sha256,
+                "objectCount": 12,
+            },
+            "browser": {"name": "chromium", "version": "test-chromium", "headless": True},
+            "camera": {
+                "direction": direction,
+                "matrixWorld": matrix_world or self._camera_matrix(direction),
+                "projectionMatrix": [
+                    1.0, 0.0, 0.0, 0.0,
+                    0.0, 1.0, 0.0, 0.0,
+                    0.0, 0.0, 1.0, 0.0,
+                    0.0, 0.0, 0.0, 1.0,
+                ],
+            },
+            "canvas": {
+                "selector": "canvas",
+                "cssWidth": css_width,
+                "cssHeight": css_height,
+                "width": round(css_width * dpr),
+                "height": round(css_height * dpr),
+                "drawingBufferWidth": round(css_width * dpr),
+                "drawingBufferHeight": round(css_height * dpr),
+                "devicePixelRatio": dpr,
+                "webgl": True,
+            },
+            "screenshot": {
+                "sha256": sha256(screenshot),
+                "pixelSha256": decoded_pixel_sha256(screenshot),
+                "width": image["width"],
+                "height": image["height"],
+            },
+        }
+
+    def _record_next_views(self, state):
+        schedule_adaptive_views(self.manifest, state)
+        for view in state["nextViews"]:
+            capture = next(item for item in self.manifest["captures"] if item["id"] == view["id"])
+            screenshot = self.manifest_path.parent / capture["path"]
+            variant = 1 + sum(
+                1
+                for item in self.manifest["captures"]
+                if isinstance(item, dict)
+                and item.get("role") == "adaptive-critic"
+                and item.get("status") == "recorded"
+            )
+            write_blob_png(screenshot, variant=variant)
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                view["id"],
+                screenshot,
+                ready_signal=True,
+                browser_receipt=self._browser_receipt(capture, screenshot),
+            )
+        write_manifest(self.manifest_path, self.manifest)
+        return state
+
+    def _capture_next_views(self, state):
+        self._record_next_views(state)
+        return build_critic_request(state, self.manifest_path)
+
+    def _complete_clean_root_round(self, state):
+        request = self._capture_next_views(state)
+        result = advance_state(state, request, self._response(request))
+        self.assertEqual(result["status"], "needs-render")
+        self.assertEqual(result["refinementMode"], "minimum-uniform-coverage")
+        self.assertEqual(len(result["nextViews"]), 24)
+        self.assertTrue(all(view["cell"]["level"] == 1 for view in result["nextViews"]))
+        return result
+
+    @staticmethod
+    def _response(request, findings_by_view=None, critic_id="critic-agent"):
+        findings_by_view = findings_by_view or {}
+        reviews = []
+        for view in request["views"]:
+            templates = findings_by_view.get(view["viewId"], [])
+            findings = []
+            for template in templates:
+                findings.append(
+                    {
+                        "defectKey": template["defectKey"],
+                        "severity": template.get("severity", "major"),
+                        "category": template.get("category", "geometry"),
+                        "description": template.get("description", "observable defect"),
+                        "viewId": view["viewId"],
+                        "captureSha256": view["captureSha256"],
+                        "direction": view["direction"],
+                    }
+                )
+            reviews.append(
+                {
+                    "viewId": view["viewId"],
+                    "captureSha256": view["captureSha256"],
+                    "direction": view["direction"],
+                    "verdict": "defect" if findings else "pass",
+                    "findings": findings,
+                }
+            )
+        return {
+            "kind": KIND_RESPONSE,
+            "schemaVersion": 1,
+            "requestId": request["requestId"],
+            "critic": {
+                "id": critic_id,
+                "role": "independent-harsh-critic",
+                "acknowledgements": {
+                    "inspectedPixels": True,
+                    "noScoreAveraging": True,
+                    "criticalDefectsAreBlocking": True,
+                },
+            },
+            "views": reviews,
+        }
+
+    def test_base_sphere_is_six_cardinal_cube_faces(self):
+        views = base_views()
+        self.assertEqual(len(views), 6)
+        self.assertEqual([item["cell"]["face"] for item in views], ["front", "right", "rear", "left", "top", "bottom"])
+        self.assertEqual(len({tuple(item["direction"]) for item in views}), 6)
+        for view in views:
+            self.assertAlmostEqual(sum(value * value for value in view["direction"]), 1.0, places=9)
+
+    def test_init_is_random_and_scopes_capture_ids_and_paths_to_session(self):
+        first = self._new_state()
+        second = self._new_state()
+        self.assertNotEqual(first["sessionId"], second["sessionId"])
+        self.assertTrue(
+            all(
+                view["id"].startswith(f"{first['sessionId']}-harsh-")
+                for view in first["nextViews"]
+            )
+        )
+        schedule_adaptive_views(self.manifest, first)
+        schedule_adaptive_views(self.manifest, second)
+        first_capture = next(
+            item
+            for item in self.manifest["captures"]
+            if item.get("adaptiveCritic", {}).get("sessionId") == first["sessionId"]
+        )
+        second_capture = next(
+            item
+            for item in self.manifest["captures"]
+            if item.get("adaptiveCritic", {}).get("sessionId") == second["sessionId"]
+        )
+        self.assertIn(first["sessionId"], first_capture["path"])
+        self.assertIn(second["sessionId"], second_capture["path"])
+        self.assertNotEqual(first_capture["id"], second_capture["id"])
+        self.assertNotEqual(first_capture["path"], second_capture["path"])
+
+    def test_subdivision_is_deterministic_and_shrinks_angular_cell(self):
+        parent = base_views()[0]
+        first = subdivide_view(parent, 1)
+        second = subdivide_view(parent, 1)
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 4)
+        self.assertTrue(all(item["parentId"] == parent["id"] for item in first))
+        self.assertTrue(all(item["angularRadiusDegrees"] < parent["angularRadiusDegrees"] for item in first))
+
+    def test_real_scene_captures_produce_pixel_bound_request(self):
+        state = self._new_state()
+        request = self._capture_next_views(state)
+        self.assertTrue(request["fixedTurntableBaseline"]["passed"])
+        self.assertEqual(len(request["views"]), 6)
+        payload = {key: value for key, value in request.items() if key not in {"requestId", "requestDigest"}}
+        self.assertEqual(request["requestDigest"], canonical_sha256(payload))
+        self.assertEqual(request["requestId"], "ahcr-" + request["requestDigest"][:24])
+        self.assertEqual(state["pendingRequest"]["canonicalSha256"], request["requestDigest"])
+        self.assertEqual(state["scene"]["sceneBuildSha256"], "3" * 64)
+        self.assertEqual(len(state["evidenceLedger"]), 6)
+        for view in request["views"]:
+            path = Path(view["capturePath"])
+            self.assertTrue(path.is_file())
+            self.assertEqual(view["captureSha256"], hashlib.sha256(path.read_bytes()).hexdigest())
+            self.assertEqual(view["capturePixelSha256"], decoded_pixel_sha256(path))
+            self.assertEqual(view["browserEvidenceSha256"], canonical_sha256(view["browserEvidence"]))
+
+    def test_clean_independent_review_passes_without_any_average(self):
+        state = self._new_state()
+        state = self._complete_clean_root_round(state)
+        request = self._capture_next_views(state)
+        result = advance_state(state, request, self._response(request))
+        self.assertEqual(result["status"], "passed")
+        self.assertEqual(result["stopReason"], "no-defects-after-minimum-uniform-coverage")
+        self.assertEqual(result["scheduledViewCount"], 30)
+        self.assertIsNone(result["pendingRequest"])
+
+    def test_critic_must_not_be_the_scene_creator(self):
+        state = self._new_state()
+        request = self._capture_next_views(state)
+        with self.assertRaisesRegex(ValueError, "MUST differ"):
+            advance_state(state, request, self._response(request, critic_id="creator-agent"))
+
+    def test_review_and_every_finding_must_bind_real_hash_and_direction(self):
+        state = self._new_state()
+        request = self._capture_next_views(state)
+        view_id = request["views"][0]["viewId"]
+        response = self._response(request, {view_id: [{"defectKey": "rear-seam"}]})
+        response["views"][0]["findings"][0]["captureSha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "actual pixels"):
+            advance_state(state, request, response)
+
+        response = self._response(request, {view_id: [{"defectKey": "rear-seam"}]})
+        response["views"][0]["findings"][0]["direction"] = [1.0, 0.0, 0.0]
+        with self.assertRaisesRegex(ValueError, "reviewed camera"):
+            advance_state(state, request, response)
+
+    def test_request_contract_tampering_and_aggregate_scores_are_rejected(self):
+        state = self._new_state()
+        request = self._capture_next_views(state)
+        tampered = copy.deepcopy(request)
+        tampered["criticContract"]["requiredAcknowledgements"] = []
+        with self.assertRaisesRegex(ValueError, "canonical digest"):
+            advance_state(copy.deepcopy(state), tampered, self._response(request))
+
+        response = self._response(request)
+        response["globalScore"] = 1.0
+        with self.assertRaisesRegex(ValueError, "never averaging"):
+            advance_state(copy.deepcopy(state), request, response)
+
+        # Even an attacker that recomputes the request digest and edits the
+        # pending pin cannot smuggle schema-forbidden fields past the hand
+        # validator used when jsonschema is unavailable.
+        extra = copy.deepcopy(request)
+        extra["approved"] = True
+        payload = {
+            key: value
+            for key, value in extra.items()
+            if key not in {"requestId", "requestDigest"}
+        }
+        extra["requestDigest"] = canonical_sha256(payload)
+        extra["requestId"] = "ahcr-" + extra["requestDigest"][:24]
+        forged_state = copy.deepcopy(state)
+        forged_state["pendingRequest"]["canonicalSha256"] = extra["requestDigest"]
+        forged_state["pendingRequest"]["requestId"] = extra["requestId"]
+        with self.assertRaisesRegex(ValueError, "schema-forbidden"):
+            advance_state(forged_state, extra, self._response(extra))
+
+    def test_complete_request_is_canonical_and_pinned_until_consumed(self):
+        state = self._new_state()
+        request = self._capture_next_views(state)
+        with self.assertRaisesRegex(ValueError, "unconsumed pending"):
+            build_critic_request(state, self.manifest_path)
+
+        alternate = self.root / "alternate.png"
+        write_blob_png(alternate, variant=99)
+        tampered = copy.deepcopy(request)
+        tampered["views"][0]["capturePath"] = str(alternate)
+        tampered["views"][0]["captureSha256"] = sha256(alternate)
+        tampered["views"][0]["capturePixelSha256"] = decoded_pixel_sha256(alternate)
+        response = self._response(tampered)
+        with self.assertRaisesRegex(ValueError, "canonical digest"):
+            advance_state(copy.deepcopy(state), tampered, response)
+
+        tampered = copy.deepcopy(request)
+        tampered["scene"]["runtimeUrl"] = "http://127.0.0.1:9999/fake"
+        with self.assertRaisesRegex(ValueError, "canonical digest"):
+            advance_state(copy.deepcopy(state), tampered, self._response(tampered))
+
+        result = advance_state(state, request, self._response(request))
+        self.assertIsNone(result["pendingRequest"])
+        self.assertEqual(result["status"], "needs-render")
+
+    def test_request_cli_persists_pending_digest_in_state(self):
+        state = self._new_state()
+        self._record_next_views(state)
+        state_path = self.root / "state.json"
+        request_path = self.root / "request.json"
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+        self.assertEqual(
+            adaptive_main(
+                [
+                    "request",
+                    "--state",
+                    str(state_path),
+                    "--out",
+                    str(request_path),
+                ]
+            ),
+            0,
+        )
+        saved_state = json.loads(state_path.read_text(encoding="utf-8"))
+        saved_request = json.loads(request_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            saved_state["pendingRequest"]["canonicalSha256"],
+            saved_request["requestDigest"],
+        )
+        self.assertEqual(saved_state["pendingRequest"]["requestId"], saved_request["requestId"])
+
+    def test_advance_has_one_canonical_in_place_transition_and_no_out_fork(self):
+        state = self._new_state()
+        self._record_next_views(state)
+        state_path = self.root / "state.json"
+        request_path = self.root / "request.json"
+        response_path = self.root / "response.json"
+        state_path.write_text(json.dumps(state), encoding="utf-8")
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(
+                adaptive_main(
+                    ["request", "--state", str(state_path), "--out", str(request_path)]
+                ),
+                0,
+            )
+        request = json.loads(request_path.read_text(encoding="utf-8"))
+        response_path.write_text(json.dumps(self._response(request)), encoding="utf-8")
+        before_rejected_out = state_path.read_bytes()
+        with redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as raised:
+                adaptive_main(
+                    [
+                        "advance",
+                        "--state",
+                        str(state_path),
+                        "--request",
+                        str(request_path),
+                        "--reviews",
+                        str(response_path),
+                        "--out",
+                        str(self.root / "forbidden-snapshot.json"),
+                    ]
+                )
+        self.assertEqual(raised.exception.code, 2)
+        self.assertEqual(state_path.read_bytes(), before_rejected_out)
+        with redirect_stdout(io.StringIO()):
+            self.assertEqual(
+                adaptive_main(
+                    [
+                        "advance",
+                        "--state",
+                        str(state_path),
+                        "--request",
+                        str(request_path),
+                        "--reviews",
+                        str(response_path),
+                        "--in-place",
+                    ]
+                ),
+                0,
+            )
+        source = json.loads(state_path.read_text(encoding="utf-8"))
+        self.assertIsNone(source["pendingRequest"])
+        self.assertEqual(source["currentRound"], 1)
+
+    def test_manual_record_cli_cannot_mint_adaptive_browser_evidence(self):
+        state = self._new_state()
+        schedule_adaptive_views(self.manifest, state)
+        write_manifest(self.manifest_path, self.manifest)
+        capture = next(item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic")
+        screenshot = self.root / "manual.png"
+        write_blob_png(screenshot, variant=1)
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            exit_code = render_bridge_main(
+                [
+                    "record",
+                    "--manifest",
+                    str(self.manifest_path),
+                    "--capture-id",
+                    capture["id"],
+                    "--screenshot",
+                    str(screenshot),
+                ]
+            )
+        self.assertEqual(exit_code, 2)
+        self.assertIn("cannot be registered from an arbitrary PNG", stderr.getvalue())
+        reloaded = read_manifest(self.manifest_path)
+        reloaded_capture = next(item for item in reloaded["captures"] if item["id"] == capture["id"])
+        self.assertEqual(reloaded_capture["status"], "pending")
+
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            exit_code = render_bridge_main(
+                [
+                    "record",
+                    "--manifest",
+                    str(self.manifest_path),
+                    "--capture-id",
+                    capture["id"],
+                    "--screenshot",
+                    str(screenshot),
+                    "--ready-signal",
+                    "window.__IMG2THREEJS_READY__",
+                ]
+            )
+        self.assertEqual(exit_code, 2)
+        self.assertIn("strict browser boolean true", stderr.getvalue())
+
+    def test_browser_receipt_requires_strict_ready_runtime_and_actual_camera_matrix(self):
+        state = self._new_state()
+        schedule_adaptive_views(self.manifest, state)
+        capture = next(item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic")
+        screenshot = self.root / "candidate.png"
+        write_blob_png(screenshot, variant=1)
+
+        receipt = self._browser_receipt(capture, screenshot, ready_value="true")
+        with self.assertRaisesRegex(ValueError, "ready contract"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                capture["id"],
+                screenshot,
+                ready_signal=True,
+                browser_receipt=receipt,
+            )
+
+        receipt = self._browser_receipt(capture, screenshot)
+        receipt["canvas"]["drawingBufferWidth"] = 199
+        with self.assertRaisesRegex(ValueError, "drawing buffer"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                capture["id"],
+                screenshot,
+                ready_signal=True,
+                browser_receipt=receipt,
+            )
+
+        receipt = self._browser_receipt(capture, screenshot)
+        receipt["unexpectedAttestation"] = True
+        with self.assertRaisesRegex(ValueError, "schema-forbidden"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                capture["id"],
+                screenshot,
+                ready_signal=True,
+                browser_receipt=receipt,
+            )
+
+        receipt = self._browser_receipt(capture, screenshot, runtime_url="http://127.0.0.1:9999/fake")
+        with self.assertRaisesRegex(ValueError, "runtime URL"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                capture["id"],
+                screenshot,
+                ready_signal=True,
+                browser_receipt=receipt,
+            )
+
+        bad_matrix = self._camera_matrix(capture["adaptiveCritic"]["direction"])
+        bad_matrix[8:11] = [1.0, 0.0, 0.0]
+        receipt = self._browser_receipt(capture, screenshot, matrix_world=bad_matrix)
+        with self.assertRaisesRegex(ValueError, "matrix does not encode planned direction"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                capture["id"],
+                screenshot,
+                ready_signal=True,
+                browser_receipt=receipt,
+            )
+
+        captures = [item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic"]
+        first_path = self.root / "same-build-first.png"
+        second_path = self.root / "changed-build-second.png"
+        write_blob_png(first_path, variant=10)
+        write_blob_png(second_path, variant=11)
+        record_capture(
+            self.manifest_path,
+            self.manifest,
+            captures[0]["id"],
+            first_path,
+            ready_signal=True,
+            browser_receipt=self._browser_receipt(captures[0], first_path),
+        )
+        with self.assertRaisesRegex(ValueError, "different scene build digests"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                captures[1]["id"],
+                second_path,
+                ready_signal=True,
+                browser_receipt=self._browser_receipt(
+                    captures[1], second_path, scene_build_sha256="4" * 64
+                ),
+            )
+
+    def test_duplicate_pixels_reencoded_for_distinct_directions_fail_closed(self):
+        state = self._new_state()
+        schedule_adaptive_views(self.manifest, state)
+        captures = [item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic"]
+        first_path = self.root / "first.png"
+        second_path = self.root / "second.png"
+        write_blob_png(first_path, variant=7, compression_level=1)
+        write_blob_png(second_path, variant=7, compression_level=9)
+        self.assertNotEqual(sha256(first_path), sha256(second_path))
+        self.assertEqual(decoded_pixel_sha256(first_path), decoded_pixel_sha256(second_path))
+        record_capture(
+            self.manifest_path,
+            self.manifest,
+            captures[0]["id"],
+            first_path,
+            ready_signal=True,
+            browser_receipt=self._browser_receipt(captures[0], first_path),
+        )
+        with self.assertRaisesRegex(ValueError, "duplicate/collapsed"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                captures[1]["id"],
+                second_path,
+                ready_signal=True,
+                browser_receipt=self._browser_receipt(captures[1], second_path),
+            )
+        self.assertEqual(captures[1]["status"], "pending")
+
+    def test_one_pixel_and_one_lsb_noise_cannot_evade_near_duplicate_gate(self):
+        state = self._new_state()
+        schedule_adaptive_views(self.manifest, state)
+        captures = [item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic"]
+        first_path = self.root / "perceptual-first.png"
+        one_pixel_path = self.root / "perceptual-one-pixel.png"
+        one_lsb_path = self.root / "perceptual-one-lsb.png"
+        distinct_path = self.root / "perceptual-distinct.png"
+        write_blob_png(first_path, variant=7, background_value=230)
+        write_blob_png(one_pixel_path, variant=7, background_value=230, pixel_nudge=True)
+        write_blob_png(one_lsb_path, variant=7, background_value=230, global_delta=1)
+        write_blob_png(distinct_path, variant=8, background_value=230)
+        record_capture(
+            self.manifest_path,
+            self.manifest,
+            captures[0]["id"],
+            first_path,
+            ready_signal=True,
+            browser_receipt=self._browser_receipt(captures[0], first_path),
+        )
+        for adversarial_path in (one_pixel_path, one_lsb_path):
+            with self.assertRaisesRegex(ValueError, "near-identical/collapsed"):
+                record_capture(
+                    self.manifest_path,
+                    self.manifest,
+                    captures[1]["id"],
+                    adversarial_path,
+                    ready_signal=True,
+                    browser_receipt=self._browser_receipt(captures[1], adversarial_path),
+                )
+        recorded = record_capture(
+            self.manifest_path,
+            self.manifest,
+            captures[1]["id"],
+            distinct_path,
+            ready_signal=True,
+            browser_receipt=self._browser_receipt(captures[1], distinct_path),
+        )
+        self.assertEqual(recorded["status"], "recorded")
+
+    def test_structured_two_lsb_noise_blocks_even_when_phash_diverges(self):
+        state = self._new_state()
+        schedule_adaptive_views(self.manifest, state)
+        captures = [item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic"]
+        base_path = self.root / "gray-base.png"
+        noisy_path = self.root / "gray-structured-plus-minus-2.png"
+        write_color_field_png(base_path, (128, 128, 128, 255))
+        write_color_field_png(
+            noisy_path,
+            (128, 128, 128, 255),
+            structured_delta=2,
+        )
+        collapsed, phash_distance, visible_rgb_mae = _near_identical_image_signatures(
+            _decoded_image_signature(base_path),
+            _decoded_image_signature(noisy_path),
+        )
+        self.assertGreater(phash_distance, 2)
+        self.assertAlmostEqual(visible_rgb_mae, 2 / 255, places=4)
+        self.assertTrue(collapsed)
+        record_capture(
+            self.manifest_path,
+            self.manifest,
+            captures[0]["id"],
+            base_path,
+            ready_signal=True,
+            browser_receipt=self._browser_receipt(captures[0], base_path),
+        )
+        with self.assertRaisesRegex(ValueError, "near-identical/collapsed"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                captures[1]["id"],
+                noisy_path,
+                ready_signal=True,
+                browser_receipt=self._browser_receipt(captures[1], noisy_path),
+            )
+
+    def test_global_and_structured_one_to_three_lsb_noise_all_fail_closed(self):
+        base_path = self.root / "gray-128.png"
+        write_color_field_png(base_path, (128, 128, 128, 255))
+        base_signature = _decoded_image_signature(base_path)
+        for delta in (1, 2, 3):
+            with self.subTest(kind="global", delta=delta):
+                shifted_path = self.root / f"gray-global-plus-{delta}.png"
+                write_color_field_png(
+                    shifted_path,
+                    (128 + delta, 128 + delta, 128 + delta, 255),
+                )
+                shifted_signature = _decoded_image_signature(shifted_path)
+                collapsed, phash_distance, visible_rgb_mae = (
+                    _near_identical_image_signatures(base_signature, shifted_signature)
+                )
+                self.assertEqual(phash_distance, 0)
+                self.assertAlmostEqual(visible_rgb_mae, delta / 255, places=4)
+                self.assertAlmostEqual(
+                    _normalized_demeaned_luma_mae(base_signature, shifted_signature),
+                    0.0,
+                    places=8,
+                )
+                self.assertTrue(collapsed)
+            with self.subTest(kind="structured", delta=delta):
+                structured_path = self.root / f"gray-structured-plus-minus-{delta}.png"
+                write_color_field_png(
+                    structured_path,
+                    (128, 128, 128, 255),
+                    structured_delta=delta,
+                )
+                structured_signature = _decoded_image_signature(structured_path)
+                collapsed, _phash_distance, visible_rgb_mae = (
+                    _near_identical_image_signatures(base_signature, structured_signature)
+                )
+                self.assertAlmostEqual(visible_rgb_mae, delta / 255, places=4)
+                self.assertTrue(collapsed)
+
+        state = self._new_state()
+        schedule_adaptive_views(self.manifest, state)
+        captures = [
+            item for item in self.manifest["captures"]
+            if item.get("role") == "adaptive-critic"
+        ]
+        plus_three_path = self.root / "gray-plus-three-runtime.png"
+        write_color_field_png(plus_three_path, (131, 131, 131, 255))
+        record_capture(
+            self.manifest_path,
+            self.manifest,
+            captures[0]["id"],
+            base_path,
+            ready_signal=True,
+            browser_receipt=self._browser_receipt(captures[0], base_path),
+        )
+        with self.assertRaisesRegex(ValueError, "near-identical/collapsed"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                captures[1]["id"],
+                plus_three_path,
+                ready_signal=True,
+                browser_receipt=self._browser_receipt(captures[1], plus_three_path),
+            )
+
+    def test_isoluminant_distinct_colors_are_not_collapsed(self):
+        state = self._new_state()
+        schedule_adaptive_views(self.manifest, state)
+        captures = [item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic"]
+        red_path = self.root / "visible-red.png"
+        green_path = self.root / "visible-dark-green.png"
+        write_color_field_png(red_path, (255, 0, 0, 255))
+        write_color_field_png(green_path, (0, 76, 0, 255))
+        collapsed, _phash_distance, visible_rgb_mae = _near_identical_image_signatures(
+            _decoded_image_signature(red_path),
+            _decoded_image_signature(green_path),
+        )
+        self.assertGreater(visible_rgb_mae, 0.4)
+        self.assertFalse(collapsed)
+        record_capture(
+            self.manifest_path,
+            self.manifest,
+            captures[0]["id"],
+            red_path,
+            ready_signal=True,
+            browser_receipt=self._browser_receipt(captures[0], red_path),
+        )
+        result = record_capture(
+            self.manifest_path,
+            self.manifest,
+            captures[1]["id"],
+            green_path,
+            ready_signal=True,
+            browser_receipt=self._browser_receipt(captures[1], green_path),
+        )
+        self.assertEqual(result["status"], "recorded")
+
+    def test_hidden_rgb_under_transparency_is_still_collapsed(self):
+        state = self._new_state()
+        schedule_adaptive_views(self.manifest, state)
+        captures = [item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic"]
+        first_path = self.root / "transparent-red.png"
+        second_path = self.root / "transparent-hidden-noise.png"
+        write_color_field_png(first_path, (255, 0, 0, 0))
+        write_color_field_png(
+            second_path,
+            (255, 0, 0, 0),
+            hidden_rgb_flip=True,
+        )
+        self.assertNotEqual(decoded_pixel_sha256(first_path), decoded_pixel_sha256(second_path))
+        record_capture(
+            self.manifest_path,
+            self.manifest,
+            captures[0]["id"],
+            first_path,
+            ready_signal=True,
+            browser_receipt=self._browser_receipt(captures[0], first_path),
+        )
+        with self.assertRaisesRegex(ValueError, "near-identical/collapsed"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                captures[1]["id"],
+                second_path,
+                ready_signal=True,
+                browser_receipt=self._browser_receipt(captures[1], second_path),
+            )
+
+    def test_scene_lock_and_historical_evidence_ledger_fail_closed(self):
+        state = self._new_state()
+        request = self._capture_next_views(state)
+        locked = copy.deepcopy(state)
+        locked["scene"]["sceneBuildSha256"] = "4" * 64
+        locked["pendingRequest"] = None
+        locked["evidenceLedger"] = []
+        with self.assertRaisesRegex(ValueError, "first-round state lock"):
+            build_critic_request(locked, self.manifest_path)
+
+        state = advance_state(state, request, self._response(request))
+        schedule_adaptive_views(self.manifest, state)
+        previous = next(
+            item
+            for item in self.manifest["captures"]
+            if item.get("adaptiveCritic", {}).get("round") == 0
+        )
+        original = self.manifest_path.parent / previous["path"]
+        replay_path = self.root / "moved-old-evidence.png"
+        replay_path.write_bytes(original.read_bytes())
+        previous["path"] = str(replay_path)
+        for index, view in enumerate(state["nextViews"]):
+            capture = next(item for item in self.manifest["captures"] if item["id"] == view["id"])
+            screenshot = self.manifest_path.parent / capture["path"]
+            write_blob_png(screenshot, variant=40 + index)
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                view["id"],
+                screenshot,
+                ready_signal=True,
+                browser_receipt=self._browser_receipt(capture, screenshot),
+            )
+        write_manifest(self.manifest_path, self.manifest)
+        with self.assertRaisesRegex(ValueError, "historical adaptive evidence changed"):
+            build_critic_request(state, self.manifest_path)
+
+    def test_failed_request_build_is_transactional_for_direct_api_callers(self):
+        state = self._new_state()
+        self._record_next_views(state)
+        before = copy.deepcopy(state)
+        with mock.patch(
+            "forge.stage4_review.adaptive_harsh_critic._base_turntable_result",
+            side_effect=ValueError("forced baseline failure"),
+        ):
+            with self.assertRaisesRegex(ValueError, "forced baseline failure"):
+                build_critic_request(state, self.manifest_path)
+        self.assertEqual(state, before)
+        self.assertIsNone(state["scene"]["sceneBuildSha256"])
+        self.assertEqual(state["evidenceLedger"], [])
+        self.assertIsNone(state["pendingRequest"])
+
+    def test_view_cell_and_policy_hand_validation_matches_fail_closed_schema(self):
+        cases = []
+        missing_bound = self._new_state()
+        missing_bound["nextViews"][0]["cell"].pop("uMin")
+        cases.append(("missing-bound", missing_bound))
+        outside_bound = self._new_state()
+        outside_bound["nextViews"][0]["cell"]["uMin"] = 2
+        cases.append(("outside-bound", outside_bound))
+        reversed_bound = self._new_state()
+        reversed_bound["nextViews"][0]["cell"]["uMin"] = 0.5
+        reversed_bound["nextViews"][0]["cell"]["uMax"] = -0.5
+        cases.append(("reversed-bound", reversed_bound))
+        shrunk_root = self._new_state()
+        shrunk_root["nextViews"][0]["cell"]["uMin"] = -0.1
+        shrunk_root["nextViews"][0]["cell"]["uMax"] = 0.1
+        shrunk_root["nextViews"][0]["cell"]["vMin"] = -0.1
+        shrunk_root["nextViews"][0]["cell"]["vMax"] = 0.1
+        cases.append(("path-bounds-coverage", shrunk_root))
+        negative_level = self._new_state()
+        negative_level["nextViews"][0]["cell"]["level"] = -3
+        cases.append(("negative-level", negative_level))
+        wrong_path_level = self._new_state()
+        wrong_path_level["nextViews"][0]["cell"]["path"] = "0"
+        cases.append(("path-level", wrong_path_level))
+        wrong_radius = self._new_state()
+        wrong_radius["nextViews"][0]["angularRadiusDegrees"] /= 2
+        cases.append(("angular-radius", wrong_radius))
+        for label, invalid in cases:
+            with self.subTest(label=label):
+                with self.assertRaises(ValueError):
+                    _validate_state(invalid)
+
+    def test_state_required_scene_and_status_action_fields_fail_closed(self):
+        cases = []
+        missing_root = self._new_state()
+        missing_root.pop("pendingRequest")
+        cases.append(("missing-root", missing_root))
+        empty_manifest_path = self._new_state()
+        empty_manifest_path["scene"]["manifestPath"] = ""
+        cases.append(("empty-manifest-path", empty_manifest_path))
+        bad_manifest_hash = self._new_state()
+        bad_manifest_hash["scene"]["manifestSha256AtInit"] = "not-a-sha"
+        cases.append(("manifest-init-hash", bad_manifest_hash))
+        empty_runtime = self._new_state()
+        empty_runtime["scene"]["runtimeUrl"] = ""
+        cases.append(("empty-runtime", empty_runtime))
+        bad_action = self._new_state()
+        bad_action["action"] = "continue"
+        cases.append(("needs-render-action", bad_action))
+        fake_pass = self._new_state()
+        fake_pass["status"] = "passed"
+        fake_pass["action"] = "continue"
+        cases.append(("passed-with-views", fake_pass))
+        empty_reference_capture = self._new_state()
+        empty_reference_capture["evidenceLedger"] = [
+            {
+                "viewId": empty_reference_capture["nextViews"][0]["id"],
+                "round": 0,
+                "capturePath": "capture.png",
+                "captureSha256": "1" * 64,
+                "capturePixelSha256": "2" * 64,
+                "browserEvidenceSha256": "3" * 64,
+                "sceneBuildSha256": "4" * 64,
+                "direction": empty_reference_capture["nextViews"][0]["direction"],
+                "referenceCapturePath": "",
+                "referenceCaptureSha256": "5" * 64,
+            }
+        ]
+        empty_reference_capture["pendingRequest"] = {
+            "requestId": "ahcr-" + "a" * 24,
+            "canonicalSha256": "a" * 64,
+            "round": 0,
+            "manifestSha256": "b" * 64,
+            "viewIds": [empty_reference_capture["nextViews"][0]["id"]],
+        }
+        cases.append(("empty-reference-capture", empty_reference_capture))
+        for label, invalid in cases:
+            with self.subTest(label=label):
+                with self.assertRaises(ValueError):
+                    _validate_state(invalid)
+
+        schema = json.loads(
+            Path("docs/specs/adaptive-harsh-critic.v1.schema.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(
+            schema["$defs"]["captureEvidence"]["properties"]
+            ["referenceCapturePath"]["minLength"],
+            1,
+        )
+
+        for field, value in (
+            ("allowHoles", "false"),
+            ("baseCoverage", "pretend-full-sphere"),
+            ("subdivision", "skip-defects"),
+        ):
+            invalid = self._new_state()
+            invalid["policy"][field] = value
+            with self.subTest(policy_field=field):
+                with self.assertRaises(ValueError):
+                    _validate_state(invalid)
+
+    def test_per_view_reference_capture_is_pinned_for_advance_and_history(self):
+        state = self._new_state()
+        self._record_next_views(state)
+        first_capture = next(
+            item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic"
+        )
+        reference_capture = self.root / "per-view-reference.png"
+        write_blob_png(reference_capture, variant=71)
+        first_capture["reference"] = {
+            "path": reference_capture.relative_to(self.root).as_posix(),
+            "status": "recorded",
+            "readySignal": True,
+            "consoleErrors": [],
+            "screenshotSha256": sha256(reference_capture),
+            "image": probe(reference_capture),
+        }
+        write_manifest(self.manifest_path, self.manifest)
+        request = build_critic_request(state, self.manifest_path)
+        bound_view = next(
+            item for item in request["views"] if item["viewId"] == first_capture["id"]
+        )
+        self.assertEqual(bound_view["referenceCaptureSha256"], sha256(reference_capture))
+        ledger_entry = next(
+            item for item in state["evidenceLedger"] if item["viewId"] == first_capture["id"]
+        )
+        self.assertEqual(
+            ledger_entry["referenceCaptureSha256"], bound_view["referenceCaptureSha256"]
+        )
+        original_reference_bytes = reference_capture.read_bytes()
+        write_blob_png(reference_capture, variant=72)
+        with self.assertRaisesRegex(ValueError, "reference capture hash changed"):
+            advance_state(copy.deepcopy(state), request, self._response(request))
+
+        reference_capture.write_bytes(original_reference_bytes)
+        advanced = advance_state(state, request, self._response(request))
+        write_blob_png(reference_capture, variant=73)
+        before_failed_history = copy.deepcopy(advanced)
+        with self.assertRaisesRegex(ValueError, "reference capture hash changed"):
+            build_critic_request(advanced, self.manifest_path)
+        self.assertEqual(advanced, before_failed_history)
+
+    def test_reference_source_file_is_rehashed_at_request_and_advance(self):
+        state = self._new_state()
+        self._record_next_views(state)
+        before_request = copy.deepcopy(state)
+        request = build_critic_request(state, self.manifest_path)
+        original_reference_bytes = self.reference.read_bytes()
+        write_blob_png(self.reference, variant=88)
+        with self.assertRaisesRegex(ValueError, "reference source file hash"):
+            build_critic_request(before_request, self.manifest_path)
+        with self.assertRaisesRegex(ValueError, "reference source file hash"):
+            advance_state(copy.deepcopy(state), request, self._response(request))
+        self.reference.write_bytes(original_reference_bytes)
+
+    def test_glb_session_requires_a_recorded_reference_for_every_adaptive_view(self):
+        self.manifest["reference"]["kind"] = "glb"
+        write_manifest(self.manifest_path, self.manifest)
+        state = self._new_state()
+        self._record_next_views(state)
+        with self.assertRaisesRegex(ValueError, "no recorded browser reference capture"):
+            build_critic_request(state, self.manifest_path)
+        downgraded = copy.deepcopy(state)
+        downgraded["scene"]["referenceKind"] = "image"
+        with self.assertRaisesRegex(ValueError, "reference kind changed"):
+            build_critic_request(downgraded, self.manifest_path)
+
+    def test_browser_document_url_allows_origin_slash_but_rejects_redirect(self):
+        self.manifest["runtime"]["url"] = "http://127.0.0.1:5173"
+        write_manifest(self.manifest_path, self.manifest)
+        state = self._new_state()
+        schedule_adaptive_views(self.manifest, state)
+        captures = [item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic"]
+        first_path = self.root / "origin-normalized.png"
+        second_path = self.root / "redirected.png"
+        write_blob_png(first_path, variant=91)
+        write_blob_png(second_path, variant=92)
+        result = record_capture(
+            self.manifest_path,
+            self.manifest,
+            captures[0]["id"],
+            first_path,
+            ready_signal=True,
+            browser_receipt=self._browser_receipt(
+                captures[0], first_path, document_url="http://127.0.0.1:5173/"
+            ),
+        )
+        self.assertEqual(result["status"], "recorded")
+        with self.assertRaisesRegex(ValueError, "runtime URL"):
+            record_capture(
+                self.manifest_path,
+                self.manifest,
+                captures[1]["id"],
+                second_path,
+                ready_signal=True,
+                browser_receipt=self._browser_receipt(
+                    captures[1],
+                    second_path,
+                    document_url="http://127.0.0.1:5173/redirected",
+                ),
+            )
+
+    def test_hand_validator_rejects_schema_forbidden_response_fields(self):
+        state = self._new_state()
+        request = self._capture_next_views(state)
+        response = self._response(request)
+        response["critic"]["approved"] = True
+        with self.assertRaisesRegex(ValueError, "schema-forbidden"):
+            advance_state(state, request, response)
+
+    def test_critical_finding_cannot_be_averaged_away_and_creates_next_views(self):
+        state = self._complete_clean_root_round(self._new_state())
+        request = self._capture_next_views(state)
+        target = request["views"][0]["viewId"]
+        response = self._response(
+            request,
+            {target: [{"defectKey": "through-skull", "severity": "critical"}]},
+        )
+        result = advance_state(state, request, response)
+        self.assertNotEqual(result["status"], "passed")
+        self.assertEqual(result["status"], "needs-render")
+        self.assertEqual(len(result["nextViews"]), 4)
+        self.assertEqual(result["refinementMode"], "defect-directed")
+        self.assertEqual(result["rounds"][1]["criticalCount"], 1)
+        self.assertFalse(result["rounds"][1]["criticalRulePassed"])
+
+    def test_same_defect_in_child_round_converges_repeated_defect(self):
+        state = self._complete_clean_root_round(self._new_state())
+        request0 = self._capture_next_views(state)
+        target0 = request0["views"][0]["viewId"]
+        state = advance_state(
+            state,
+            request0,
+            self._response(request0, {target0: [{"defectKey": "floating-hat", "severity": "major"}]}),
+        )
+        request1 = self._capture_next_views(state)
+        target1 = request1["views"][0]["viewId"]
+        state = advance_state(
+            state,
+            request1,
+            self._response(request1, {target1: [{"defectKey": "floating-hat", "severity": "major"}]}),
+        )
+        self.assertEqual(state["status"], "blocked")
+        self.assertEqual(state["stopReason"], "repeated-defect")
+        self.assertEqual(state["action"], "refine-code")
+
+    def test_plateau_with_renamed_but_unimproved_defect_stops(self):
+        state = self._complete_clean_root_round(self._new_state(plateau_rounds=1))
+        request0 = self._capture_next_views(state)
+        target0 = request0["views"][0]["viewId"]
+        state = advance_state(
+            state,
+            request0,
+            self._response(request0, {target0: [{"defectKey": "bad-a", "severity": "major"}]}),
+        )
+        request1 = self._capture_next_views(state)
+        target1 = request1["views"][0]["viewId"]
+        state = advance_state(
+            state,
+            request1,
+            self._response(request1, {target1: [{"defectKey": "bad-b", "severity": "major"}]}),
+        )
+        self.assertEqual(state["status"], "blocked")
+        self.assertEqual(state["stopReason"], "plateau")
+
+    def test_max_view_budget_below_uniform_floor_blocks_clean_root(self):
+        state = self._new_state(max_views=29)
+        request = self._capture_next_views(state)
+        result = advance_state(
+            state,
+            request,
+            self._response(request),
+        )
+        self.assertEqual(result["status"], "blocked")
+        self.assertEqual(result["stopReason"], "max-views-before-minimum-coverage")
+        self.assertEqual(result["nextViews"], [])
+
+    def test_missing_view_review_and_mutated_capture_fail_closed(self):
+        state = self._new_state()
+        request = self._capture_next_views(state)
+        response = self._response(request)
+        response["views"].pop()
+        with self.assertRaisesRegex(ValueError, "review every requested view"):
+            advance_state(copy.deepcopy(state), request, response)
+
+        response = self._response(request)
+        Path(request["views"][0]["capturePath"]).write_bytes(b"mutated")
+        with self.assertRaisesRegex(ValueError, "hash changed"):
+            advance_state(copy.deepcopy(state), request, response)
+
+    def test_render_bridge_reimport_is_idempotent_and_rejects_direction_collision(self):
+        state = self._new_state()
+        first = schedule_adaptive_views(self.manifest, state)
+        second = schedule_adaptive_views(self.manifest, state)
+        self.assertEqual(len(first["scheduled"]), 6)
+        self.assertEqual(len(second["alreadyPresent"]), 6)
+        self.assertEqual(len([item for item in self.manifest["captures"] if item.get("role") == "adaptive-critic"]), 6)
+        self.assertEqual(len(self.manifest["evidence"]["adaptiveCriticPlans"]), 1)
+
+        collision_id = state["nextViews"][0]["id"]
+        collision_capture = next(
+            item for item in self.manifest["captures"] if item.get("id") == collision_id
+        )
+        collision_capture["adaptiveCritic"]["direction"] = [1.0, 0.0, 0.0]
+        with self.assertRaisesRegex(ValueError, "collision"):
+            schedule_adaptive_views(self.manifest, state)
+
+    def test_schedule_rejects_path_escape_and_contains_all_generated_evidence(self):
+        state = self._new_state()
+        before = copy.deepcopy(self.manifest)
+        malicious = copy.deepcopy(state)
+        malicious["nextViews"][0]["id"] = (
+            f"{state['sessionId']}-harsh-/../../../../../../escaped"
+        )
+        with self.assertRaises(ValueError):
+            schedule_adaptive_views(
+                self.manifest,
+                malicious,
+                manifest_path=self.manifest_path,
+            )
+        self.assertEqual(self.manifest, before)
+
+        for unsafe_output in (
+            "../escaped",
+            "/absolute/escaped",
+            "C:/escaped",
+            "captures\\..\\escaped",
+        ):
+            with self.subTest(output_dir=unsafe_output):
+                with self.assertRaises(ValueError):
+                    schedule_adaptive_views(
+                        self.manifest,
+                        state,
+                        manifest_path=self.manifest_path,
+                        output_dir=unsafe_output,
+                    )
+                self.assertEqual(self.manifest, before)
+
+        plan_path = self.root / "safe-plan-unsafe-output.json"
+        plan_path.write_text(json.dumps(state), encoding="utf-8")
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            exit_code = render_bridge_main(
+                [
+                    "schedule-adaptive",
+                    "--manifest",
+                    str(self.manifest_path),
+                    "--plan",
+                    str(plan_path),
+                    "--output-dir",
+                    "../escaped",
+                ]
+            )
+        self.assertEqual(exit_code, 2)
+        self.assertIn("unsafe relative path component", stderr.getvalue())
+        self.assertEqual(read_manifest(self.manifest_path), before)
+
+        glb_manifest = copy.deepcopy(self.manifest)
+        glb_manifest["reference"]["kind"] = "glb"
+        glb_state = copy.deepcopy(state)
+        glb_state["scene"]["referenceKind"] = "glb"
+        result = schedule_adaptive_views(
+            glb_manifest,
+            glb_state,
+            manifest_path=self.manifest_path,
+        )
+        self.assertEqual(len(result["scheduled"]), 6)
+        evidence_root = self.manifest_path.parent.resolve()
+        for capture in (
+            item for item in glb_manifest["captures"]
+            if item.get("role") == "adaptive-critic"
+        ):
+            paths = [capture["path"]]
+            paths.extend(record["path"] for record in capture["passes"].values())
+            paths.append(capture["reference"]["path"])
+            paths.extend(
+                record["path"] for record in capture["reference"]["passes"].values()
+            )
+            for path_value in paths:
+                resolved = (evidence_root / Path(path_value)).resolve()
+                self.assertTrue(resolved.is_relative_to(evidence_root))
+                self.assertNotIn("..", Path(path_value).parts)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/grimoire/build/python_threejs_render_bridge.md
+++ b/grimoire/build/python_threejs_render_bridge.md
@@ -149,14 +149,78 @@ window.__IMG2THREEJS_CAPTURE__ = {
   async setCamera({ azimuthDegrees, elevationDegrees, target, near, far }) {
     // Apply the camera and controls to the real Three.js scene, then resolve.
   },
+  async getEvidenceSnapshot({ captureId, sessionNonce }) {
+    // Required for adaptive hard-gate captures. Read these values from the
+    // live scene/camera after setCamera has settled; do not echo the plan.
+    return {
+      captureId,
+      sessionNonce,
+      sceneBuildSha256: computeStableSceneBuildSha256(),
+      objectCount: scene.children.length,
+      camera: {
+        direction: actualCameraDirectionFromTarget(),
+        matrixWorld: camera.matrixWorld.toArray(),
+        projectionMatrix: camera.projectionMatrix.toArray(),
+      },
+    };
+  },
   async capturePass({ passId, mode }) {
     // Select beauty/diagnostic render target, settle, and return { ok: true, selector: 'canvas' }.
   },
 };
 ```
 
-If the ready signal, capture contract, canvas, screenshot, or hash check fails, the adapter stops.
+For an adaptive capture the ready value must be strict boolean `true`; the adapter injects an
+unpredictable browser-session nonce before navigation and requires `getEvidenceSnapshot` to echo it
+with the capture ID. It captures the actual WebGL `canvas`, records document/scene/camera/browser
+provenance, and hashes both PNG bytes and decoded RGBA pixels. If the ready signal, capture contract,
+canvas, screenshot, provenance, or hash check fails, the adapter stops.
+The receipt is a trusted local Playwright-runner attestation, not cryptographic or remote
+attestation. The generic `render_bridge.py record` CLI cannot mint it from a hand-written PNG.
+Viewport, browser DPR, canvas CSS/backing size, WebGL drawing buffer, and screenshot dimensions must
+form one consistent chain.
 It does not fall back to a Python/Blender image and does not claim that a render happened.
+
+## Adaptive hostile camera loop
+
+The fixed camera batch is the minimum evidence set. For models that must hold up from arbitrary
+angles, `adaptive_harsh_critic.py` adds a bounded adaptive layer without replacing that baseline:
+
+```text
+six cube-map root nextViews
+  -> render_bridge.py schedule-adaptive
+  -> browser setCamera + real scene PNG
+  -> adaptive_harsh_critic.py request (re-hash pixels + fixed turntable gate)
+  -> separate critic agent (critic.id != creator.id)
+  -> adaptive_harsh_critic.py advance
+  -> mandatory uniform split to level 1 (24 more views)
+  -> then defective cells split into four nextViews
+  -> repeat until pass or bounded stop
+```
+
+`schedule-adaptive` only creates pending capture records. The existing browser adapter can capture
+the generated IDs because they use the same `azimuthDegrees`, `elevationDegrees`, target, near and
+far camera contract as static views. For these IDs, the generic `render_bridge.py record` command is
+not an evidence path: only `scripts/capture_threejs_playwright.py` can mint the required browser
+receipt. Scheduling rejects non-canonical session/view/cell geometry and unsafe output paths; every
+capture/reference/pass path must resolve beneath the manifest evidence root, and the manifest update
+is transactional. Different directions with the same decoded pixels or camera matrix fail closed. Every
+critique and finding is bound to the resulting PNG hash, decoded-pixel hash, browser-receipt hash and
+exact direction. Never hand an agent only the state JSON and call that visual review.
+One-pixel and global/structured ±1/2/3-LSB perturbations are also rejected by alpha-composited
+low-frequency visible RGB plus demeaned-luma structure; pHash and mean visible color constrain the
+wider structural envelope. Chroma is retained so visibly
+different isoluminant colors remain admissible, while hidden RGB under alpha=0 cannot fake a new
+frame. Random session-scoped IDs and paths prevent a fresh init from reusing stale capture names.
+The first `sceneBuildSha256`, the current source reference hash, optional per-view reference hashes,
+and all prior round evidence remain in the state ledger and are revalidated before every request and
+advance. GLB adaptive views require their paired browser-rendered reference capture.
+The default clean floor is 30 captures (6 roots + 24 level-1 cells); a max-view cap below that blocks.
+All rounds in one adaptive session observe one immutable scene build. After a code correction,
+create a new manifest and critic state and recapture the fixed baseline as well as adaptive views;
+never append corrected-build pixels to the previous session's evidence.
+
+Full critic and convergence contract: `grimoire/review/adaptive_harsh_critic.md`.
 
 ## Prohibited shortcuts
 

--- a/grimoire/review/adaptive_harsh_critic.md
+++ b/grimoire/review/adaptive_harsh_critic.md
@@ -1,0 +1,258 @@
+# Adaptive harsh critic
+
+Use this gate after the fixed turntable gate when a model must survive hostile off-axis review, not
+just look plausible from a presentation camera. It inspects the **real browser Three.js scene**. It
+does not review a slide, a scene-description JSON, generated prose, or a Python substitute render.
+
+## Division of labour
+
+- `adaptive_harsh_critic.py` is a deterministic controller. It creates view cells, hashes captures,
+  validates critic identity/evidence, subdivides defective directions, and enforces stop policies.
+- `render_bridge.py` schedules those views into the existing browser manifest. Chrome DevTools MCP,
+  the optional Playwright adapter, or another contract-compatible browser path captures the pixels.
+  Adaptive hard-gate evidence currently requires the bundled Playwright adapter receipt; the generic
+  `render_bridge.py record` command is intentionally unable to mint one.
+- A **separate host agent** is the critic. The controller never calls an external model. The host
+  creates the critic agent and gives it the emitted request plus readable capture images.
+- The scene creator applies corrections **between sessions**. One adaptive session is an immutable
+  observation of one scene build; changing code or the build digest mid-session is rejected. Start
+  a new render manifest + critic state after a correction. The critic must never be the creator
+  under a renamed role: `critic.id == creator.id` is a validation error.
+
+Each `init` creates a random `ahc-<20 hex>` session. Serialized view IDs and capture paths include
+that session, so an identical manifest/creator/policy invocation cannot reuse names from an old run.
+
+## View sphere
+
+Round 0 is a six-cell cube map: front, right, rear, left, top, bottom. Those face centres are only the
+root of the sphere, not enough evidence to pass. The default `minimumUniformLevel=1` subdivides **all
+six** roots and requires another 24 real captures, even when every root centre was clean. Therefore a
+default clean run needs at least 6 + 24 = 30 independently reviewed views before it can pass. This
+fail-closed floor catches defects near cube-face edges/corners that six centre cameras miss.
+
+Front/right/rear/left also have to pass `turntable_gate.py`; adaptive review is an escalation above
+that fixed baseline, not a replacement for it.
+
+Every view is a cube-map cell with `[uMin,uMax] × [vMin,vMax]`. Until `minimumUniformLevel` is met,
+every frontier cell is split uniformly. After that floor, only cells with observable defects split
+into four children and emit their centre directions as `nextViews`. Repeating defect-directed splits
+has no fixed angular-resolution ceiling: a direction can be refined again and again. Actual runs are
+deliberately finite.
+
+## Bounded termination
+
+The first applicable stop wins:
+
+1. no findings after the complete current frontier reaches `minimumUniformLevel`: `passed`;
+2. the same stable `defectKey` survives the configured consecutive rounds: `repeated-defect`;
+3. worst severity and finding count fail to improve for the configured window: `plateau`;
+4. completing another round would exceed `maxRounds`: `max-rounds`;
+5. scheduling a complete four-child subdivision would exceed `maxViews`: `max-views`.
+
+If either cap prevents the required uniform floor, the more explicit stop is
+`max-rounds-before-minimum-coverage` or `max-views-before-minimum-coverage`. A cap is never treated as
+permission to pass with incomplete coverage.
+
+The max-view gate refuses a biased partial subdivision. It does not inspect the first two children
+and pretend the other two directions never existed. An unreadable capture is `unreviewable-evidence`
+and routes to `request-input`.
+
+## Critical means AND, never average
+
+The response has no global acceptance score. Every finding is `minor`, `major`, or `critical`; any
+finding prevents a pass, and one `critical` finding is a blocking failure for the whole round. A
+critical rear defect cannot be diluted by five clean sides, a high beauty score, or a large number of
+minor passes. The round record persists `criticalCount` and `criticalRulePassed` explicitly.
+
+## Pixel binding
+
+The `request` command only succeeds after every `nextView` is recorded by the browser bridge. It
+re-opens each PNG and verifies the manifest hash. The critic must echo these fields on every review:
+
+- `viewId`
+- `captureSha256`
+- exact unit `direction: [x,y,z]`
+
+Every individual finding must repeat the same three fields. The `advance` command re-opens and hashes
+the PNG again. A review of JSON prose with no real capture, a stale screenshot, a swapped camera, or a
+finding detached from its pixels is rejected.
+
+The machine-readable state/request/response schema is
+`docs/specs/adaptive-harsh-critic.v1.schema.json`.
+
+### Browser provenance and collapse rejection
+
+An adaptive capture is not `recorded` merely because a PNG exists. The Playwright adapter must load
+the manifest's exact runtime URL and observe all of the following in the live page:
+
+- `window.__IMG2THREEJS_READY__ === true` as a strict boolean;
+- a non-zero WebGL canvas captured directly with the `canvas` locator;
+- `window.__IMG2THREEJS_CAPTURE__.setCamera(...)`;
+- `window.__IMG2THREEJS_CAPTURE__.getEvidenceSnapshot({captureId, sessionNonce})`.
+
+`getEvidenceSnapshot` must return the same `captureId` and unpredictable adapter `sessionNonce`, a
+stable 64-hex `sceneBuildSha256`, positive `objectCount`, and the actual camera `direction`,
+`matrixWorld`, and `projectionMatrix`. The controller checks that the matrixWorld camera back axis
+encodes the scheduled direction. The adapter also records browser/version/headless state, exact
+document URL and SHA-256, ready/capture-contract results, canvas/drawing-buffer dimensions, encoded
+PNG SHA-256, and a decoded-RGBA pixel SHA-256. This canonical receipt is itself hashed.
+
+The receipt is a **trusted local-runner attestation**, not a cryptographic proof or remote
+attestation. Its security boundary assumes the bundled Playwright adapter and runtime contract are
+the trusted evidence-producing path. A caller that can replace the adapter/runtime/code or rewrite
+all state can forge the world it reports. The ordinary `render_bridge.py record` CLI still cannot
+mint this receipt from a PNG or a self-reported ready string.
+
+Different directions in one adaptive session may not reuse the same decoded pixels, a perceptually
+near-identical frame, or the same camera matrix. The near-collapse gate combines alpha-composited
+low-frequency visible RGB with pHash, mean visible color, and brightness-shift-invariant demeaned
+luma structure. The RGB/color guards preserve genuine isoluminant color changes while ignoring
+hidden RGB under fully transparent pixels. Re-encoding one PNG, changing one pixel, or adding a
+global or structured ±1/2/3-LSB noise veil does not help. A perfectly
+symmetrical subject that genuinely produces near-identical pixels therefore blocks for human input
+rather than silently passing; visibly different views, including substantial global color changes,
+remain outside the visible-RGB collapse envelope.
+
+### Immutable issued request
+
+`request` canonicalizes the **complete** request except the self-referential `requestId` and
+`requestDigest`, computes SHA-256, derives `requestId` from that digest, and atomically pins the
+digest, manifest hash, round, and ordered view IDs in `state.pendingRequest`. It also writes the
+updated state file. `advance` recomputes the digest before reading the response. Changing any scene,
+baseline, capture path/hash/pixels/provenance, direction, cell, round, policy contract, or view order
+is rejected even when the response is changed to agree with the forged request. Only a successful
+advance consumes and clears `pendingRequest`; invalid responses leave it pending for a corrected
+retry, and a second request cannot be issued over it.
+
+The first accepted capture set also pins `sceneBuildSha256` in `state.scene`. Every later round must
+match it. `state.evidenceLedger` and each completed round retain every scheduled view's capture path,
+encoded/decoded hash, browser-receipt hash, scene-build hash, round, direction, and optional per-view
+reference capture path/hash. Before issuing a new request the controller re-opens the full historical
+ledger and rejects missing or changed evidence; adding new captures to the manifest does not erase
+the previous proof trail. The original reference image/GLB file is also re-opened and checked against
+the pinned `reference.sha256` at request and advance. For a GLB session, every adaptive procedural
+view must have a clean, recorded browser reference capture; reference evidence is not optional.
+
+Request construction is transactional for direct Python callers: scene/ledger/pending changes are
+committed to the supplied state only after the fixed baseline and every history gate succeeds.
+
+## End-to-end commands
+
+Initialize after `render_bridge.py init` has created a scene manifest:
+
+```bash
+python3 forge/stage4_review/adaptive_harsh_critic.py init \
+  --manifest work/render-manifest.json \
+  --creator-id builder-agent \
+  --minimum-uniform-level 1 \
+  --out work/harsh-critic-state.json
+```
+
+Schedule the current `nextViews` into the real scene and capture only those pending IDs (the generic
+Playwright adapter already iterates arbitrary manifest captures; a Chrome MCP adapter uses the same
+camera records):
+
+```bash
+python3 forge/stage4_review/render_bridge.py schedule-adaptive \
+  --manifest work/render-manifest.json \
+  --plan work/harsh-critic-state.json
+
+python3 scripts/capture_threejs_playwright.py \
+  --manifest work/render-manifest.json \
+  --capture-id ahc-<session>-harsh-front-root \
+  --capture-id ahc-<session>-harsh-right-root
+```
+
+Read the complete generated IDs from `state.nextViews`; do not strip the session prefix. Omitting
+`--capture-id` captures every pending manifest entry.
+
+Scheduling first validates the complete state and canonical cube-cell grammar: the random session,
+view ID, face/path/level/round, bounds, direction, angles, radius, and parent must all agree.
+`--output-dir` must be a canonical relative path. Every generated capture, reference, and diagnostic
+pass path is resolved and proven to remain below the render manifest's evidence root before the
+manifest is atomically updated; absolute paths, drives, backslashes, empty/dot components, and `..`
+are rejected.
+
+After the first clean response, `nextViews` contains 24 level-1 IDs. Schedule and capture all of
+them; six clean root views alone must not produce `passed`.
+
+Package immutable evidence for an independent agent:
+
+```bash
+python3 forge/stage4_review/adaptive_harsh_critic.py request \
+  --state work/harsh-critic-state.json \
+  --out work/critic-request-r0.json
+```
+
+This command updates both files: the request is created and its canonical digest is pinned into the
+existing state. Do not restore an older state after issuing the request.
+
+The host creates a separate critic and has it inspect every image in `views[]` at native resolution.
+Its response follows this shape; every finding repeats the real pixel and direction binding:
+
+```json
+{
+  "kind": "img2threejs.adaptive-harsh-critic-response",
+  "schemaVersion": 1,
+  "requestId": "ahcr-...",
+  "critic": {
+    "id": "critic-agent",
+    "role": "independent-harsh-critic",
+    "acknowledgements": {
+      "inspectedPixels": true,
+      "noScoreAveraging": true,
+      "criticalDefectsAreBlocking": true
+    }
+  },
+  "views": [
+    {
+      "viewId": "ahc-<session>-harsh-rear-root",
+      "captureSha256": "<copied from request>",
+      "direction": [0, 0, -1],
+      "verdict": "defect",
+      "findings": [
+        {
+          "defectKey": "rear-skull-through-hole",
+          "severity": "critical",
+          "category": "geometry",
+          "description": "Background is visible through the rear skull volume.",
+          "viewId": "ahc-<session>-harsh-rear-root",
+          "captureSha256": "<same capture hash>",
+          "direction": [0, 0, -1]
+        }
+      ]
+    }
+  ]
+}
+```
+
+The actual response must contain one review for **every** requested view. Advance exactly one round:
+
+```bash
+python3 forge/stage4_review/adaptive_harsh_critic.py advance \
+  --state work/harsh-critic-state.json \
+  --request work/critic-request-r0.json \
+  --reviews work/critic-response-r0.json \
+  --in-place
+```
+
+`advance` intentionally supports only `--in-place`. There is one canonical state transition and no
+second `--out` target whose write could fail after the request was already consumed. Copy a completed
+state only after the command succeeds if an archival snapshot is needed.
+
+If status is `needs-render`, keep the same scene build and repeat schedule → browser capture →
+request → independent critique → advance. If status is `blocked`, preserve that manifest as
+evidence, correct the scene, and initialize a new manifest + critic state; do not mix old and new
+scene builds or weaken the critic policy.
+
+## What the gate proves and does not prove
+
+It enforces that the declared creator/critic identities differ, the issued request did not change after
+the state pinned it, reviewed pixels carry the trusted local Playwright/WebGL runner attestation and
+are hash-bound to captured camera matrices/directions, repeated pixels did not collapse distinct
+scheduled views, the fixed turntable baseline ran, defects cannot be averaged away, and recursive
+work terminates. The receipt is not cryptographic proof. It cannot cryptographically prove that two
+IDs are two humans or models, nor defend
+against an attacker who can rewrite both code and every state/manifest file. It does not infer hidden
+ground truth that no reference shows. Host orchestration must actually create a fresh agent context,
+and hidden-side claims must remain labelled as self-consistency checks or inference.

--- a/grimoire/review/gates_reference.md
+++ b/grimoire/review/gates_reference.md
@@ -19,6 +19,18 @@ only the executable order and one-line summary; this file defines the mandatory 
   `forge/stage4_review/diagnose_render_multi_angle.py` flags `degenerate-view` when an orbited
   silhouette collapses (a flat plane faking a volume). Orbit angles use reference-free
   self-consistency — never scored against a reference angle the photo doesn't cover.
+- **Adaptive harsh critic**: after the fixed turntable baseline, optional hostile review starts from
+  six cube-map cells, then uniformly subdivides all roots once by default (6+24 real reviews) before
+  a clean pass is possible. After that it recursively subdivides every direction with a finding. New `nextViews` must
+  be scheduled through `render_bridge.py` and captured by the Playwright adapter with strict ready,
+  WebGL, runtime document, scene-build, actual-camera-matrix and encoded/decoded-pixel evidence. The
+  generic record CLI, duplicate pixels/matrices across directions, and a prose/JSON-only review are
+  invalid. Each complete critic request is canonical-digest pinned in state until successful
+  consumption. The critic ID must
+  differ from the creator ID, and every review plus every finding must bind the actual PNG hash and
+  exact direction. Any critical finding blocks the entire run with no averaging. Repeated-defect,
+  plateau, max-view, and max-round policies terminate the refinement. Full contract:
+  `grimoire/review/adaptive_harsh_critic.md`.
 - **CS2 knife review contract**: `forge/stage4_review/cs2_review.py` consumes the manifest and
   versioned scene fixture, then blocks wrong family identity, missing projection coverage,
   painted-region mismatch, critical identity-detail failure, finish/material response failure,

--- a/grimoire/review/self_correction.md
+++ b/grimoire/review/self_correction.md
@@ -34,6 +34,15 @@ Use this reference when a model construction pass has just finished.
 
 For visual passes, `continue` requires a rendered screenshot, a comparison image, a global AI vision score at or above threshold, and every critical feature at or above its own threshold. Without them, the review is not evidence-backed enough. Pixel comparison code is never the acceptance authority.
 
+When adaptive hostile review is enabled, it is an additional AND gate. Use a fresh critic agent
+whose ID differs from the scene creator, and give it the real hash-bound captures emitted by
+`adaptive_harsh_critic.py request`. A clean hero comparison cannot override a critical finding from
+any adaptive side. Keep the scene build immutable while one adaptive session refines its sampling;
+do not edit code between that session's rounds. After it passes or blocks, apply corrections and
+start a new render manifest + critic state so the fixed baseline and every adaptive side are
+recaptured from the corrected build. Stop on repeated-defect, plateau, max-views, or max-rounds; do
+not weaken the policy to obtain `continue`. Full contract: `adaptive_harsh_critic.md`.
+
 ## Root Cause Guide
 
 Use `refine-spec` when:

--- a/grimoire/scripts.md
+++ b/grimoire/scripts.md
@@ -293,6 +293,66 @@ region left unreached is enclosed by the object. A hole through a model barely c
 AREA, so the collapse check cannot see it; this can. Use `--allow-holes` for a subject that genuinely
 has a through-hole at that angle — the hole is still reported, only the verdict changes.
 
+### stage4_review/adaptive_harsh_critic.py
+
+Deterministic controller for independent, pixel-bound scene criticism. It does not call a model or
+render pixels. Round 0 starts with six cube-map cells, then default `minimumUniformLevel=1` forces
+all six roots to split and requires 24 more real captures even when their centres are clean. Only
+after that 6+24 floor does a finding selectively split its cell into four `nextViews`. Angular
+coverage can refine without a fixed side count while repeated-defect/plateau/max-round/max-view
+policies still terminate every run.
+
+```bash
+python3 forge/stage4_review/adaptive_harsh_critic.py init \
+  --manifest render-manifest.json --creator-id builder-agent \
+  --minimum-uniform-level 1 --out critic-state.json
+python3 forge/stage4_review/render_bridge.py schedule-adaptive \
+  --manifest render-manifest.json --plan critic-state.json
+# Browser-capture every new manifest ID here. The generic render_bridge.py
+# record command cannot mint adaptive evidence.
+python3 scripts/capture_threejs_playwright.py \
+  --manifest render-manifest.json --capture-id ahc-<session>-harsh-front-root
+python3 forge/stage4_review/adaptive_harsh_critic.py request \
+  --state critic-state.json --out critic-request.json
+# A separate critic agent inspects every request.views[] PNG and writes critic-response.json.
+python3 forge/stage4_review/adaptive_harsh_critic.py advance \
+  --state critic-state.json --request critic-request.json \
+  --reviews critic-response.json --in-place
+```
+
+`request` first re-runs the fixed front/right/rear/left turntable baseline. It refuses pending,
+missing, changed, provenance-free, duplicate-pixel, duplicate-camera, or direction-mismatched
+captures. It derives `requestId` from the complete canonical request and writes the digest to
+`state.pendingRequest`; therefore the command intentionally updates the state as well as creating
+the request. A second request is refused until `advance` successfully consumes the first. `advance`
+recomputes that digest and rejects any request mutation before reading the review. It also requires
+`critic.id != creator.id`,
+one response per requested view, and the actual capture SHA-256 + exact direction on both the view
+review and every finding. There is no aggregate pass score: one critical finding blocks the run.
+If max rounds/views cannot complete the required uniform level, the state blocks rather than
+granting a partial-coverage pass.
+Schema and full host-agent contract: `docs/specs/adaptive-harsh-critic.v1.schema.json` and
+`grimoire/review/adaptive_harsh_critic.md`.
+
+`render_bridge.py schedule-adaptive --manifest M --plan STATE [--output-dir DIR]` appends the
+state's `nextViews` as pending `adaptive-critic` captures. Re-importing an identical plan is
+idempotent; reusing a view ID with another direction/session fails. The command validates the full
+state plus canonical session/view/cell/round geometry. `DIR` must be canonical and relative, and all
+capture/reference/pass paths are resolved beneath `M`'s evidence root before a transactional manifest
+update; traversal, absolute, drive-qualified, backslash, and dot-component paths fail closed.
+Adaptive records require the
+Playwright receipt (`strict ready → exact runtime document → WebGL canvas → scene build digest →
+actual camera matrices → encoded and decoded-pixel hashes`). `render_bridge.py record` rejects them,
+including a caller-supplied ready-signal string.
+The receipt is trusted local-runner attestation, not cryptographic proof; the generic record CLI
+cannot mint it. Each init gets a random session-scoped view/path namespace. Exact and near-identical
+pixels (alpha-composited visible RGB + demeaned-luma structure, with pHash/mean-color guards) collapse fail closed without
+mistaking isoluminant but visibly different colors for the same frame. The first scene build digest,
+source reference hash, per-view GLB references, and every round's evidence ledger stay pinned and are
+re-opened. Keep the scene build immutable through one adaptive state. A correction starts a new
+render manifest and critic state so the fixed turntable and all adaptive captures are from the
+corrected build. `advance` only accepts `--in-place`; it has no branch-like `--out` mode.
+
 ### stage4_review/attachment_anchor.py
 `stage4_review/attachment_anchor.py spec.json [--measured measured.json] [--json]`
 Relates a worn or held item to the thing it is worn on or held by. `ANCHOR_DECLARED`,

--- a/scripts/capture_threejs_playwright.py
+++ b/scripts/capture_threejs_playwright.py
@@ -13,7 +13,9 @@ replacement scene in Python and fails closed when the runtime contract is absent
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import secrets
 import sys
 from pathlib import Path
 
@@ -27,8 +29,13 @@ from forge.stage4_review.render_bridge import (  # noqa: E402
     record_capture_pass,
     record_reference_capture,
     PASS_IDS,
+    ADAPTIVE_BROWSER_RECEIPT_KIND,
+    ADAPTIVE_BROWSER_RECEIPT_VERSION,
+    decoded_pixel_sha256,
+    sha256,
     write_manifest,
 )
+from forge.stage1_intake.probe_image import probe  # noqa: E402
 
 
 def capture(manifest_path_value: Path, capture_ids: list[str], headed: bool, timeout_ms: int, mode: str) -> dict:
@@ -60,20 +67,32 @@ def capture(manifest_path_value: Path, capture_ids: list[str], headed: bool, tim
     console_errors: list[str] = []
     page_errors: list[str] = []
     browser_info: dict = {}
+    session_nonce = secrets.token_hex(16)
 
     try:
         with sync_playwright() as playwright:
             browser = playwright.chromium.launch(headless=not headed)
-            browser_info = {"adapter": "playwright", "browser": "chromium", "headless": not headed}
+            browser_info = {
+                "adapter": "playwright",
+                "adapterVersion": ADAPTIVE_BROWSER_RECEIPT_VERSION,
+                "browser": "chromium",
+                "browserVersion": browser.version,
+                "headless": not headed,
+                "sessionNonce": session_nonce,
+            }
             context = browser.new_context(
                 viewport={"width": int(viewport[0]), "height": int(viewport[1])},
                 device_scale_factor=dpr,
+            )
+            context.add_init_script(
+                "Object.defineProperty(window, '__IMG2THREEJS_ADAPTER_SESSION__', "
+                f"{{value: '{session_nonce}', writable: false, configurable: false}});"
             )
             page = context.new_page()
             page.on("pageerror", lambda error: page_errors.append(str(error)))
             page.on("console", lambda message: console_errors.append(message.text) if message.type == "error" else None)
             page.goto(url, wait_until="domcontentloaded", timeout=timeout_ms)
-            page.wait_for_function("() => Boolean(window.__IMG2THREEJS_READY__)", timeout=timeout_ms)
+            page.wait_for_function("() => window.__IMG2THREEJS_READY__ === true", timeout=timeout_ms)
 
             if fidelity_v2:
                 pass_contract = page.evaluate(
@@ -104,6 +123,7 @@ def capture(manifest_path_value: Path, capture_ids: list[str], headed: bool, tim
 
             for capture_id in selected:
                 capture_spec = find_capture(manifest, capture_id)
+                adaptive = capture_spec.get("role") == "adaptive-critic"
                 result = page.evaluate(
                     """
                     async (camera) => {
@@ -133,12 +153,67 @@ def capture(manifest_path_value: Path, capture_ids: list[str], headed: bool, tim
                     """
                     () => {
                       const canvas = document.querySelector('canvas');
-                      return canvas ? {width: canvas.width, height: canvas.height} : null;
+                      if (!canvas) return null;
+                      const gl = canvas.getContext('webgl2') || canvas.getContext('webgl') || canvas.getContext('experimental-webgl');
+                      const rect = canvas.getBoundingClientRect();
+                      return {
+                        cssWidth: Math.round(rect.width),
+                        cssHeight: Math.round(rect.height),
+                        width: canvas.width,
+                        height: canvas.height,
+                        drawingBufferWidth: gl?.drawingBufferWidth || 0,
+                        drawingBufferHeight: gl?.drawingBufferHeight || 0,
+                        devicePixelRatio: window.devicePixelRatio,
+                        webgl: Boolean(gl),
+                      };
                     }
                     """
                 )
-                if not canvas or canvas["width"] <= 0 or canvas["height"] <= 0:
-                    raise RuntimeError("Three.js canvas has zero dimensions")
+                if (
+                    not canvas
+                    or canvas["cssWidth"] <= 0
+                    or canvas["cssHeight"] <= 0
+                    or canvas["width"] <= 0
+                    or canvas["height"] <= 0
+                    or canvas["drawingBufferWidth"] <= 0
+                    or canvas["drawingBufferHeight"] <= 0
+                    or canvas.get("webgl") is not True
+                ):
+                    raise RuntimeError("Three.js WebGL canvas is missing or has zero dimensions")
+                evidence_snapshot = None
+                # A GLB reference capture uses the same scheduled camera but
+                # does not mint procedural adaptive evidence; requiring the
+                # procedural getEvidenceSnapshot contract here would reject a
+                # valid reference-only route for data that is never consumed.
+                if adaptive and mode != "reference":
+                    evidence_snapshot = page.evaluate(
+                        """
+                        async ({captureId, sessionNonce}) => {
+                          const api = window.__IMG2THREEJS_CAPTURE__;
+                          if (!api || typeof api.setCamera !== 'function') {
+                            return {ok: false, reason: 'window.__IMG2THREEJS_CAPTURE__.setCamera is missing'};
+                          }
+                          if (typeof api.getEvidenceSnapshot !== 'function') {
+                            return {ok: false, reason: 'window.__IMG2THREEJS_CAPTURE__.getEvidenceSnapshot is missing'};
+                          }
+                          if (window.__IMG2THREEJS_READY__ !== true) {
+                            return {ok: false, reason: 'window.__IMG2THREEJS_READY__ is not strict boolean true'};
+                          }
+                          const snapshot = await api.getEvidenceSnapshot({captureId, sessionNonce});
+                          return {ok: true, snapshot};
+                        }
+                        """,
+                        {"captureId": capture_id, "sessionNonce": session_nonce},
+                    )
+                    if evidence_snapshot.get("ok") is not True:
+                        raise RuntimeError(str(evidence_snapshot.get("reason", "adaptive evidence snapshot failed")))
+                    evidence_snapshot = evidence_snapshot.get("snapshot")
+                    if not isinstance(evidence_snapshot, dict):
+                        raise RuntimeError("adaptive getEvidenceSnapshot returned no object")
+                    if evidence_snapshot.get("captureId") != capture_id:
+                        raise RuntimeError("adaptive evidence snapshot captureId mismatch")
+                    if evidence_snapshot.get("sessionNonce") != session_nonce:
+                        raise RuntimeError("adaptive evidence snapshot session nonce mismatch")
                 if mode == "reference":
                     reference_spec = capture_spec.get("reference")
                     if not isinstance(reference_spec, dict) or not reference_spec.get("path"):
@@ -147,7 +222,9 @@ def capture(manifest_path_value: Path, capture_ids: list[str], headed: bool, tim
                 else:
                     screenshot = manifest_path(manifest_path_value, str(capture_spec["path"]))
                 screenshot.parent.mkdir(parents=True, exist_ok=True)
-                if fidelity_v2:
+                if adaptive and mode != "reference":
+                    page.locator("canvas").screenshot(path=str(screenshot))
+                elif fidelity_v2:
                     # The capture contract may return a selector when the route has a
                     # dedicated pass canvas; default to the target Three.js canvas.
                     pass_result = page.evaluate(
@@ -177,6 +254,55 @@ def capture(manifest_path_value: Path, capture_ids: list[str], headed: bool, tim
                         console_errors=console_errors + page_errors,
                     )
                 else:
+                    browser_receipt = None
+                    if adaptive:
+                        assert isinstance(evidence_snapshot, dict)
+                        image = probe(screenshot)
+                        document_sha256 = hashlib.sha256(page.content().encode("utf-8")).hexdigest()
+                        browser_receipt = {
+                            "kind": ADAPTIVE_BROWSER_RECEIPT_KIND,
+                            "schemaVersion": ADAPTIVE_BROWSER_RECEIPT_VERSION,
+                            "adapter": {
+                                "name": "capture_threejs_playwright",
+                                "version": ADAPTIVE_BROWSER_RECEIPT_VERSION,
+                            },
+                            "sessionNonce": session_nonce,
+                            "captureId": capture_id,
+                            "runtime": {
+                                "requestedUrl": url,
+                                "documentUrl": page.url,
+                                "documentSha256": document_sha256,
+                                "readySignal": {
+                                    "expression": runtime.get("readySignal"),
+                                    "value": ready_value,
+                                    "valueType": "boolean" if isinstance(ready_value, bool) else type(ready_value).__name__,
+                                },
+                                "captureContract": {
+                                    "name": runtime.get("captureContract"),
+                                    "setCamera": True,
+                                    "getEvidenceSnapshot": True,
+                                },
+                                "snapshotEcho": {
+                                    "captureId": evidence_snapshot.get("captureId"),
+                                    "sessionNonce": evidence_snapshot.get("sessionNonce"),
+                                },
+                                "sceneBuildSha256": evidence_snapshot.get("sceneBuildSha256"),
+                                "objectCount": evidence_snapshot.get("objectCount"),
+                            },
+                            "browser": {
+                                "name": "chromium",
+                                "version": browser.version,
+                                "headless": not headed,
+                            },
+                            "camera": evidence_snapshot.get("camera"),
+                            "canvas": {"selector": "canvas", **canvas},
+                            "screenshot": {
+                                "sha256": sha256(screenshot),
+                                "pixelSha256": decoded_pixel_sha256(screenshot),
+                                "width": image.get("width"),
+                                "height": image.get("height"),
+                            },
+                        }
                     record_capture(
                         manifest_path_value,
                         manifest,
@@ -185,6 +311,7 @@ def capture(manifest_path_value: Path, capture_ids: list[str], headed: bool, tim
                         ready_signal=ready_value,
                         console_errors=console_errors + page_errors,
                         browser_snapshot={"canvas": canvas},
+                        browser_receipt=browser_receipt,
                     )
 
                 if fidelity_v2:


### PR DESCRIPTION
## Summary

- add a model-free adaptive harsh-critic controller for real Three.js scene captures
- start from six cube-map faces, enforce one uniform subdivision pass (30 minimum views), and recursively subdivide defective cells with bounded fail-closed stop policies
- require an independent critic, immutable scene/capture evidence, browser-runner receipts, exact view directions, and critical-defect hard blocking
- harden the render bridge against path traversal, duplicate/near-duplicate fake views, stale evidence, scene-build drift, partial manifest writes, and state/request mutation
- document the trusted-local-runner boundary, CLI workflow, state schema, and correction loop

## Why

A fixed turntable can miss narrow defects, while a score average can hide a critical failure. This adds evidence-bound adaptive coverage: broad real-scene coverage first, then deeper review only where defects remain. Runtime is finite through maximum-round/view, plateau, and repeated-defect guards.

## Tests

- `py -3 -B -m unittest forge.tests.test_adaptive_harsh_critic -v` -- 35/35 passed
- `py -3 -B -m unittest forge.tests.test_render_bridge forge.tests.test_glb_reference forge.tests.test_turntable_gate forge.tests.test_correction_loop -v` -- 37/37 passed
- `$env:PYTHONUTF8='1'; py -3 -B -m unittest forge.tests.test_pipeline -v` -- 62/62 passed
- independent black-box replay covered malicious output paths, manifest transaction rollback, global/structured +/-1/2/3 LSB near-duplicate frames, schema mutation, canonical in-place state advance, and the normal 6+24 view flow
- `git diff --check` -- passed (Windows CRLF notices only)

## Environment notes

- Browser evidence is intentionally restricted to the trusted local Playwright runner; receipts are provenance attestations, not cryptographic proof.
- Playwright was not installed in this Windows environment, so the browser adapter was contract-tested without a live Chromium/Three.js integration run.
- A broad 696-test discovery run also exercised the new tests; 11 unrelated Windows-only failures/errors were caused by child-process GBK/UTF-8 output and unavailable symlink privileges.