### PR TITLE
Scene profile (img2threejsScene): solved cameras and reprojection gates for built spaces, plus box-object self-calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Box-object self-calibration** (`forge/stage1_intake/box_calibration.py`) — the scene
+  mathematics applied to box-dominant objects (tanks, cabinets, containers, buildings), whose
+  own edges provide the orthogonal families a lone object lacks. Solves f (+ principal point
+  with 3 families, gated on pairwise-f agreement), fits the box to tagged corner pixels by
+  Gauss-Newton (stdlib), and returns MEASURED dimension ratios with per-corner residuals and
+  the uniform-vs-local diagnosis — so ObjectSculptSpec proportions can be measured instead of
+  eyeballed. Refuses single-family subjects with routing advice. Guide:
+  `grimoire/intake/box_calibration.md`.
 - **img2threejsScene** — a `scene` profile for interiors and built spaces, which the object
   rubric rejects by design. A scene is its own calibration target: `scene_camera.py` solves
   focal length, principal point, orientation and height from two orthogonal floor line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to **img2threejs** are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **img2threejsScene** — a `scene` profile for interiors and built spaces, which the object
+  rubric rejects by design. A scene is its own calibration target: `scene_camera.py` solves
+  focal length, principal point, orientation and height from two orthogonal floor line
+  families (2-VP horizon route, with a 3-VP route that is gated on leave-one-out stability of
+  the derived focal length — sub-pixel noise at shallow pitch can otherwise collapse f by 3x);
+  `scene_backproject.py` places props from floor-contact pixels with per-landmark depth
+  sensitivity and decomposes reprojection error into a uniform (camera) component and local
+  (placement) residuals; `scene_unit_gate.py` tests a proposed metres-per-repeat against
+  architectural height bands conjunctively. Contracts in `grimoire/scene/reconstruction.md`,
+  failure catalogue in `grimoire/scene/traps.md`, profile steps in `forge/state.py --profile
+  scene`. Motivated by a film-still interior reconstruction (median landmark reprojection
+  4-6px; floor contacts 0.5px).
+
 ## [1.4.4-beta.2]
 
 ### Added

--- a/SKILL.md
+++ b/SKILL.md
@@ -31,6 +31,15 @@ The user attaches/points to an object image and wants a procedural Three.js mode
 reconstruction/animation/destruction plan, a sculpt spec, or code. Also for material studies,
 action-ready props, game objects, botanical/mechanical parts, and stylized reconstructions.
 
+For a photo of an INTERIOR OR BUILT SPACE (a room, a street, a stage set), use the `scene`
+profile (img2threejsScene): `python3 forge/state.py init --profile scene ...`. Scenes fail the
+object rubric on purpose and are routed, not rejected — a built space carries its own camera
+calibration (orthogonal architectural lines + a repeated floor pattern), so the scene track
+solves the camera (`forge/stage1_intake/scene_camera.py`), back-projects every prop's floor
+contact with a confidence tier (`scene_backproject.py`), gates absolute scale against
+architectural bands (`scene_unit_gate.py`), and verifies by reprojection instead of by eye.
+Contracts: `grimoire/scene/reconstruction.md`; failure catalogue: `grimoire/scene/traps.md`.
+
 ## Core Promise
 
 Sculpt from a photo, in order — never one-shot a mesh:

--- a/SKILL.md
+++ b/SKILL.md
@@ -40,6 +40,12 @@ contact with a confidence tier (`scene_backproject.py`), gates absolute scale ag
 architectural bands (`scene_unit_gate.py`), and verifies by reprojection instead of by eye.
 Contracts: `grimoire/scene/reconstruction.md`; failure catalogue: `grimoire/scene/traps.md`.
 
+The same mathematics spills over to BOX-DOMINANT OBJECTS (tank hulls, cabinets, containers,
+buildings): their own edges provide the orthogonal line families a lone object normally lacks,
+so before eyeballing width/height/depth into a spec, run
+`forge/stage1_intake/box_calibration.py` and copy its measured dimension ratios instead.
+Guide: `grimoire/intake/box_calibration.md`.
+
 ## Core Promise
 
 Sculpt from a photo, in order — never one-shot a mesh:

--- a/forge/_shared/workflow_state.py
+++ b/forge/_shared/workflow_state.py
@@ -49,6 +49,29 @@ CHARACTER_STEPS: Final = (
     ),
 )
 
+SCENE_STEPS: Final = (
+    (
+        "scene-contract-read",
+        "Read grimoire/scene/reconstruction.md and grimoire/scene/traps.md completely",
+    ),
+    (
+        "scene-line-harvest",
+        "Collect two orthogonal floor line families (and vertical edges if any) as pixel segments into scene-lines.json",
+    ),
+    (
+        "scene-camera-solve",
+        "python3 forge/stage1_intake/scene_camera.py scene-lines.json --out scene-camera.json (verdict must not be fail)",
+    ),
+    (
+        "scene-backprojection",
+        "python3 forge/stage1_intake/scene_backproject.py scene-camera.json scene-landmarks.json --out scene-plan.json",
+    ),
+    (
+        "scene-unit-sanity",
+        "python3 forge/stage1_intake/scene_unit_gate.py scene-heights.json --unit <metres-per-repeat> (>= 3 banded samples in-band)",
+    ),
+)
+
 CS2_STEPS: Final = (
     ("cs2-contract-read", "Read grimoire/intake/cs2_intake_contract.md completely"),
     ("cs2-authoritative-classification", "Obtain an authoritative CS2 family/subtype classification record"),
@@ -102,8 +125,8 @@ def new_state(
     max_per_pass: int = 3,
     max_total: int = 6,
 ) -> dict[str, Any]:
-    if profile not in {"generic", "cs2", "character"}:
-        raise WorkflowStateError("profile must be generic, cs2, or character")
+    if profile not in {"generic", "cs2", "character", "scene"}:
+        raise WorkflowStateError("profile must be generic, cs2, character, or scene")
     if max_per_pass < 1 or max_total < 1 or max_per_pass > max_total:
         raise WorkflowStateError("loop limits require 1 <= max-per-pass <= max-total")
     setup = [_step(*item, scope="setup") for item in SETUP_STEPS]
@@ -112,6 +135,8 @@ def new_state(
         setup[insertion:insertion] = [_step(*item, scope="setup") for item in CS2_STEPS]
     elif profile == "character":
         setup[insertion:insertion] = [_step(*item, scope="setup") for item in CHARACTER_STEPS]
+    elif profile == "scene":
+        setup[insertion:insertion] = [_step(*item, scope="setup") for item in SCENE_STEPS]
     pass_steps = list(PASS_STEPS)
     if profile == "cs2":
         review_index = next(index for index, item in enumerate(pass_steps) if item[0] == "ai-review-recorded")
@@ -146,7 +171,7 @@ def validate_state(state: Any) -> dict[str, Any]:
         raise WorkflowStateError("state must be a JSON object")
     if state.get("schemaVersion") != SCHEMA_VERSION:
         raise WorkflowStateError(f"unsupported state schemaVersion: {state.get('schemaVersion')!r}")
-    if state.get("profile") not in {"generic", "cs2", "character"}:
+    if state.get("profile") not in {"generic", "cs2", "character", "scene"}:
         raise WorkflowStateError("state profile is invalid")
     checklist = state.get("checklist")
     if not isinstance(checklist, list) or not checklist:

--- a/forge/stage1_intake/box_calibration.py
+++ b/forge/stage1_intake/box_calibration.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Self-calibration from a box-dominant OBJECT's own edges (img2threejsScene spillover).
+
+`solve_camera_pose.py` is honest that a lone object cannot fix the camera from
+one image — but a BOX-DOMINANT object (tank hull, cabinet, container, building)
+is the exception: its edges form two or three mutually orthogonal parallel
+families, which is the same calibration target a scene's architecture provides.
+This module reuses the scene solver's mathematics with the object's OWN axes as
+the world frame, and its deliverable is aimed at the object pipeline's weakest
+point: instead of eyeballing proportions into an ObjectSculptSpec, it returns
+**measured dimension ratios** with per-corner reprojection residuals.
+
+What it can and cannot do, stated up front:
+- Needs >= 2 clean parallel edges per family on >= 2 axes. A 2001-monolith-like
+  slab seen mostly face-on has one usable family and CANNOT self-calibrate —
+  that case stays with the floor-grid scene route or the eyeball route.
+- Absolute scale is not recoverable. The gauge is "the x dimension = 1"; pass
+  `scale` with a known dimension (e.g. a tank's published hull length) or a
+  known repeat (track-link pitch) to get metres.
+- With only 2 families, the third axis is ASSUMED parallel to the image plane
+  (same constraint as the scene solver's horizon route) and the output says so.
+
+Input JSON:
+    {"image": {"width": W, "height": H},
+     "edgeFamilies": {"x": [[x1,y1,x2,y2], ...], "y": [...], "z": [...]},
+     "corners": {"name": {"px": [u, v], "at": [i, j, k]}, ...},   # lattice coords, 0..1 (fractions ok)
+     "scale": {"axis": "x", "metres": 6.3}}                        # optional
+
+Axis convention: "y" is the object's up. Pure Python stdlib.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scene_camera import (  # noqa: E402
+    Segment, Vec2, Vec3, _cross, _dot, _orthocentre, _unit,
+    vanishing_point, VP_RESIDUAL_WARN_PX, VP_RESIDUAL_FAIL_PX,
+)
+
+F_PAIRWISE_SPREAD_WARN = 0.06   # the three pairwise f estimates of a 3-VP solve must agree
+F_PAIRWISE_SPREAD_FAIL = 0.20
+CORNER_RESIDUAL_WARN_PX = 6.0
+GN_ITERATIONS = 120
+GN_INIT_DISTANCES = (3.0, 6.0, 12.0, 24.0)   # in gauge units; multi-start, deterministic
+
+
+# --- calibration ------------------------------------------------------------
+def calibrate(families: dict[str, list[Segment]], image: tuple[int, int]
+              ) -> dict[str, Any]:
+    """f, principal point and the box axes (camera frame) from 2-3 edge families."""
+    w, h = image
+    vps: dict[str, tuple[Vec2, float, int]] = {}
+    for axis, segs in families.items():
+        if axis not in ("x", "y", "z"):
+            raise ValueError(f"unknown axis '{axis}' (use x, y, z; y = object's up)")
+        if len(segs) >= 2:
+            vps[axis] = vanishing_point([tuple(map(float, s)) for s in segs])
+    if len(vps) < 2:
+        raise ValueError("need >= 2 edge families with >= 2 segments each; "
+                         "a single-family subject cannot self-calibrate — "
+                         "use the scene route (floor grid) or solve_camera_pose.py")
+
+    notes: list[str] = []
+    axes = sorted(vps)
+    if len(vps) == 3:
+        v1, v2, v3 = (vps[a][0] for a in axes)
+        p = _orthocentre(v1, v2, v3)
+        f2s = [-((a[0] - p[0]) * (b[0] - p[0]) + (a[1] - p[1]) * (b[1] - p[1]))
+               for a, b in ((v1, v2), (v1, v3), (v2, v3))]
+        if min(f2s) <= 0:
+            raise ValueError("edge families are not mutually orthogonal in this view "
+                             "(a pairwise f^2 <= 0) — check the axis tagging")
+        fs = [math.sqrt(v) for v in f2s]
+        spread = (max(fs) - min(fs)) / (sum(fs) / 3)
+        f = sum(fs) / 3
+        route = "three-family orthocentre"
+    else:
+        (a1, a2) = axes
+        v1, v2 = vps[a1][0], vps[a2][0]
+        px = w / 2.0
+        if abs(v2[0] - v1[0]) < 1e-9:
+            py = (v1[1] + v2[1]) / 2
+        else:
+            py = v1[1] + (v2[1] - v1[1]) * (px - v1[0]) / (v2[0] - v1[0])
+        p = (px, py)
+        f2 = -((v1[0] - p[0]) * (v2[0] - p[0]) + (v1[1] - p[1]) * (v2[1] - p[1]))
+        if f2 <= 0:
+            raise ValueError("the two edge families are not orthogonal in this view — "
+                             "check the axis tagging")
+        f = math.sqrt(f2)
+        spread = None
+        missing = ({"x", "y", "z"} - set(axes)).pop()
+        route = "two-family (principal point on the vanishing line)"
+        notes.append(f"axis '{missing}' unobserved and ASSUMED parallel to the image "
+                     f"plane; principal point x assumed at the frame centre")
+
+    # box axes in the camera frame (each VP direction points forward: z > 0)
+    e: dict[str, Vec3] = {}
+    for axis in axes:
+        v = vps[axis][0]
+        e[axis] = _unit(((v[0] - p[0]) / f, (v[1] - p[1]) / f, 1.0))  # type: ignore[assignment]
+    missing = {"x", "y", "z"} - set(axes)
+    if missing:
+        m = missing.pop()
+        others = [a for a in ("x", "y", "z") if a != m]
+        d = _unit(_cross(e[others[0]], e[others[1]]))
+        e[m] = d  # type: ignore[assignment]
+    if e["y"][1] > 0:            # camera y points down; the object's up must not
+        e["y"] = tuple(-c for c in e["y"])  # type: ignore[assignment]
+    # right-handed x, y, z; re-orthogonalise around the two measured axes
+    if _dot(_cross(e["x"], e["y"]), e["z"]) < 0:
+        e["x"] = tuple(-c for c in e["x"])  # type: ignore[assignment]
+    e["z"] = _unit(_cross(e["x"], e["y"]))          # type: ignore[assignment]
+    e["x"] = _unit(_cross(e["y"], e["z"]))          # type: ignore[assignment]
+
+    resid = {a: round(vps[a][1], 2) for a in axes}
+    worst = max(resid.values())
+    verdict = "pass"
+    if worst > VP_RESIDUAL_FAIL_PX or (spread is not None and spread > F_PAIRWISE_SPREAD_FAIL):
+        verdict = "fail"
+    elif worst > VP_RESIDUAL_WARN_PX or (spread is not None and spread > F_PAIRWISE_SPREAD_WARN):
+        verdict = "warn"
+    return {"focalPx": f, "principalPoint": p, "axesCameraFrame": e,
+            "route": route, "vpResidualPx": resid,
+            "fPairwiseSpread": round(spread, 4) if spread is not None else None,
+            "verdict": verdict, "notes": notes}
+
+
+# --- box fit (Gauss-Newton, stdlib) -----------------------------------------
+def _solve_lin(A: list[list[float]], b: list[float]) -> list[float]:
+    n = len(b)
+    M = [row[:] + [b[i]] for i, row in enumerate(A)]
+    for c in range(n):
+        piv = max(range(c, n), key=lambda r: abs(M[r][c]))
+        if abs(M[piv][c]) < 1e-12:
+            raise ValueError("singular normal equations (corners underconstrain the box)")
+        M[c], M[piv] = M[piv], M[c]
+        for r in range(n):
+            if r != c:
+                k = M[r][c] / M[c][c]
+                for cc in range(c, n + 1):
+                    M[r][cc] -= k * M[c][cc]
+    return [M[r][n] / M[r][r] for r in range(n)]
+
+
+def fit_box(cal: dict[str, Any], corners: dict[str, Any]) -> dict[str, Any]:
+    """Fit origin (camera frame) + dimensions (gauge: dim_x = 1) to corner pixels."""
+    f, (px, py) = cal["focalPx"], cal["principalPoint"]
+    e = cal["axesCameraFrame"]
+    names = sorted(corners)
+    obs = [(corners[n]["px"], corners[n]["at"]) for n in names]
+    if len(obs) < 4:
+        raise ValueError("need >= 4 tagged corners to constrain the box")
+
+    def residuals(th: Sequence[float]) -> list[float]:
+        ox, oy, oz, dy, dz = th
+        r = []
+        for (u, v), (i, j, k) in obs:
+            c = [ox + i * e["x"][0] + j * dy * e["y"][0] + k * dz * e["z"][0],
+                 oy + i * e["x"][1] + j * dy * e["y"][1] + k * dz * e["z"][1],
+                 oz + i * e["x"][2] + j * dy * e["y"][2] + k * dz * e["z"][2]]
+            if c[2] < 1e-6:
+                return [1e4] * (2 * len(obs))
+            r += [px + f * c[0] / c[2] - u, py + f * c[1] / c[2] - v]
+        return r
+
+    best: tuple[float, list[float]] | None = None
+    mean_u = sum(o[0][0] for o in obs) / len(obs)
+    mean_v = sum(o[0][1] for o in obs) / len(obs)
+    look = _unit(((mean_u - px) / f, (mean_v - py) / f, 1.0))
+    for dist in GN_INIT_DISTANCES:
+        th = [look[0] * dist - 0.5, look[1] * dist - 0.5, look[2] * dist, 1.0, 1.0]
+        for _ in range(GN_ITERATIONS):
+            r0 = residuals(th)
+            J = []
+            for pi in range(5):
+                tp = th[:]
+                step = 1e-5 * max(1.0, abs(th[pi]))
+                tp[pi] += step
+                rp = residuals(tp)
+                J.append([(a - b) / step for a, b in zip(rp, r0)])
+            A = [[sum(J[a][k] * J[b][k] for k in range(len(r0))) + (1e-9 if a == b else 0)
+                  for b in range(5)] for a in range(5)]
+            g = [-sum(J[a][k] * r0[k] for k in range(len(r0))) for a in range(5)]
+            try:
+                delta = _solve_lin(A, g)
+            except ValueError:
+                break
+            cost0 = sum(x * x for x in r0)
+            scale = 1.0
+            for _ in range(12):                     # step-halving line search
+                cand = [t + scale * d for t, d in zip(th, delta)]
+                if sum(x * x for x in residuals(cand)) < cost0:
+                    th = cand
+                    break
+                scale *= 0.5
+            else:
+                break
+            if max(abs(d) * scale for d in delta) < 1e-10:
+                break
+        cost = sum(x * x for x in residuals(th))
+        if best is None or cost < best[0]:
+            best = (cost, th)
+    assert best is not None
+    th = best[1]
+    r = residuals(th)
+    per = [math.hypot(r[2 * i], r[2 * i + 1]) for i in range(len(obs))]
+    mdx = sum(r[2 * i] for i in range(len(obs))) / len(obs)
+    mdy = sum(r[2 * i + 1] for i in range(len(obs))) / len(obs)
+    local = [{"corner": n, "residualPx": round(math.hypot(r[2 * i] - mdx, r[2 * i + 1] - mdy), 2)}
+             for i, n in enumerate(names)]
+    dims = {"x": 1.0, "y": abs(th[3]), "z": abs(th[4])}
+    flipped = [a for a, v in (("y", th[3]), ("z", th[4])) if v < 0]
+    worst = max(local, key=lambda d: d["residualPx"])
+    diagnosis = []
+    if math.hypot(mdx, mdy) > CORNER_RESIDUAL_WARN_PX:
+        diagnosis.append(f"uniform shift {math.hypot(mdx, mdy):.1f}px — suspect the "
+                         f"calibration (principal point), not the corner readings")
+    if worst["residualPx"] > CORNER_RESIDUAL_WARN_PX:
+        diagnosis.append(f"corner '{worst['corner']}' is off by {worst['residualPx']}px — "
+                         f"re-read that pixel or its lattice tag")
+    return {"gauge": "dimension along x = 1",
+            "dimensions": {a: round(v, 4) for a, v in dims.items()},
+            "originCameraFrame": [round(v, 4) for v in th[:3]],
+            "axesFlippedDuringFit": flipped,
+            "meanCornerResidualPx": round(sum(per) / len(per), 2),
+            "uniformShiftPx": round(math.hypot(mdx, mdy), 2),
+            "perCorner": sorted(local, key=lambda d: -d["residualPx"]),
+            "diagnosis": diagnosis or ["corner reprojection is clean"]}
+
+
+def apply_scale(box: dict[str, Any], scale: dict[str, Any]) -> dict[str, Any]:
+    axis, metres = scale["axis"], float(scale["metres"])
+    per_unit = metres / box["dimensions"][axis]
+    return {"metresPerGaugeUnit": round(per_unit, 4),
+            "dimensionsMetres": {a: round(v * per_unit, 3)
+                                 for a, v in box["dimensions"].items()},
+            "source": f"user-supplied: dimension '{axis}' = {metres} m"}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("measurements")
+    ap.add_argument("--out", default="box-calibration.json")
+    args = ap.parse_args(argv)
+    m = json.loads(Path(args.measurements).read_text())
+    img = (int(m["image"]["width"]), int(m["image"]["height"]))
+    cal = calibrate({a: s for a, s in m["edgeFamilies"].items()}, img)
+    out: dict[str, Any] = {
+        "calibration": {k: (round(v, 2) if isinstance(v, float) else v)
+                        for k, v in cal.items() if k != "axesCameraFrame"},
+        "axesCameraFrame": {a: [round(c, 6) for c in v]
+                            for a, v in cal["axesCameraFrame"].items()},
+    }
+    if m.get("corners"):
+        out["box"] = fit_box(cal, m["corners"])
+        if m.get("scale"):
+            out["scale"] = apply_scale(out["box"], m["scale"])
+        else:
+            out["calibration"]["notes"] = cal["notes"] + [
+                "no scale reference: dimensions are ratios (x = 1), not lengths"]
+    Path(args.out).write_text(json.dumps(out, indent=2) + "\n")
+    json.dump(out, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0 if cal["verdict"] != "fail" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/forge/stage1_intake/scene_backproject.py
+++ b/forge/stage1_intake/scene_backproject.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Back-project scene landmarks to the floor plan, with honesty gates (stage 1).
+
+Input: `scene-camera.json` from `scene_camera.py` plus a landmark file:
+
+    {"contacts":  {"bedFootLeft": [415, 583], ...},          # pixel of a floor contact
+     "heights":   {"doorwayTop": {"px": [1070, 320], "foot": "doorwayThreshold"}, ...},
+     "expected":  {"bedFootLeft": [x, z], ...}}              # optional, for re-projection checks
+
+Output per contact: the floor point (x, z) in pattern units, AND the two numbers
+that say whether to believe it:
+
+- **depthSensitivityUnitsPerPx** — floor units of depth error per pixel of
+  reading error at that pixel. Near the horizon this explodes; a contact with
+  sensitivity 0.2 units/px is not a measurement, and silently placing furniture
+  from it puts a cabinet three times too far away. Confidence tiers come from
+  this number, not from wishing.
+- **reprojection decomposition** (when `expected` is given) — the mean error
+  vector is split into a UNIFORM component and per-landmark RESIDUALS. This is
+  the diagnostic that matters: a uniform shift means ONE cause (almost always
+  the camera — a principal-point offset looks exactly like this), while local
+  residuals mean individual placements. Chasing furniture positions to fix a
+  uniform error wastes a whole correction cycle; today's reference frame had a
+  90px uniform shift that was entirely the principal point.
+
+Pure Python stdlib.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from scene_camera import SceneCamera, load_camera  # noqa: E402
+
+# confidence tiers on depth sensitivity (units of floor depth per px of reading error)
+SENSITIVITY_MEASURED = 0.03    # below this: a 2px reading error moves the point < 0.06 units
+SENSITIVITY_APPROX = 0.12     # below this: usable with care
+# above SENSITIVITY_APPROX: "horizon-limited" — record, do not trust
+
+UNIFORM_SHIFT_SUSPICIOUS_PX = 15.0   # a uniform reprojection shift above this smells of camera
+
+
+def confidence(sens: float) -> str:
+    if sens <= SENSITIVITY_MEASURED:
+        return "measured"
+    if sens <= SENSITIVITY_APPROX:
+        return "approximate"
+    return "horizon-limited"
+
+
+def backproject(cam: SceneCamera, landmarks: dict[str, Any]) -> dict[str, Any]:
+    plan: dict[str, Any] = {}
+    for name, (u, v) in landmarks.get("contacts", {}).items():
+        pt = cam.floor(float(u), float(v))
+        sens = cam.depth_sensitivity(float(u), float(v))
+        if pt is None:
+            plan[name] = {"pixel": [u, v], "floor": None,
+                          "reason": "ray does not hit the floor (above the horizon?)"}
+            continue
+        plan[name] = {
+            "pixel": [u, v],
+            "floor": [round(pt[0], 3), round(pt[1], 3)],
+            "distanceUnits": round(math.hypot(*pt), 3),
+            "depthSensitivityUnitsPerPx": round(sens, 4),
+            "confidence": confidence(sens),
+        }
+
+    heights: dict[str, Any] = {}
+    for name, spec in landmarks.get("heights", {}).items():
+        u, v = map(float, spec["px"])
+        foot_name = spec["foot"]
+        foot = plan.get(foot_name, {}).get("floor")
+        if not foot:
+            heights[name] = {"reason": f"foot contact '{foot_name}' unavailable"}
+            continue
+        try:
+            h = cam.height_at(u, v, tuple(foot))
+        except ValueError as e:
+            heights[name] = {"reason": str(e)}
+            continue
+        heights[name] = {"pixel": [u, v], "foot": foot_name,
+                         "heightUnits": round(h, 3),
+                         "confidence": plan[foot_name]["confidence"]}
+    return {"floorPlan": plan, "heights": heights}
+
+
+def reprojection_check(cam: SceneCamera, landmarks: dict[str, Any],
+                       result: dict[str, Any]) -> dict[str, Any] | None:
+    expected = landmarks.get("expected")
+    if not expected:
+        return None
+    rows = []
+    for name, (x, z) in expected.items():
+        entry = result["floorPlan"].get(name)
+        if not entry or not entry.get("pixel"):
+            continue
+        q = cam.project((float(x), 0.0, float(z)))
+        if q is None:
+            continue
+        u, v = entry["pixel"]
+        rows.append({"landmark": name, "dx": q[0] - float(u), "dy": q[1] - float(v)})
+    if not rows:
+        return None
+    mx = sum(r["dx"] for r in rows) / len(rows)
+    my = sum(r["dy"] for r in rows) / len(rows)
+    uniform = math.hypot(mx, my)
+    residuals = [{"landmark": r["landmark"],
+                  "residualPx": round(math.hypot(r["dx"] - mx, r["dy"] - my), 2)}
+                 for r in rows]
+    worst = max(residuals, key=lambda r: r["residualPx"])
+    diagnosis = []
+    if uniform > UNIFORM_SHIFT_SUSPICIOUS_PX:
+        diagnosis.append(
+            f"uniform shift of {uniform:.1f}px across all landmarks — one cause, almost "
+            f"certainly the camera (check the principal point / view offset), NOT the "
+            f"individual placements")
+    if worst["residualPx"] > UNIFORM_SHIFT_SUSPICIOUS_PX:
+        diagnosis.append(f"local residual on '{worst['landmark']}' "
+                         f"({worst['residualPx']}px) — that placement is wrong")
+    return {"uniformShiftPx": [round(mx, 2), round(my, 2)],
+            "uniformShiftMagnitudePx": round(uniform, 2),
+            "residuals": sorted(residuals, key=lambda r: -r["residualPx"]),
+            "diagnosis": diagnosis or ["reprojection is clean"]}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("camera", help="scene-camera.json from scene_camera.py")
+    ap.add_argument("landmarks", help="JSON with contacts / heights / expected")
+    ap.add_argument("--out", default="scene-plan.json")
+    args = ap.parse_args(argv)
+    cam = load_camera(Path(args.camera))
+    landmarks = json.loads(Path(args.landmarks).read_text())
+    result = backproject(cam, landmarks)
+    check = reprojection_check(cam, landmarks, result)
+    if check:
+        result["reprojectionCheck"] = check
+    Path(args.out).write_text(json.dumps(result, indent=2) + "\n")
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/forge/stage1_intake/scene_camera.py
+++ b/forge/stage1_intake/scene_camera.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""Solve the camera from a scene's own architecture (img2threejsScene, stage 1).
+
+For a single OBJECT, the camera is not recoverable from one image — the existing
+`solve_camera_pose.py` says so and emits agent-fill placeholders. A SCENE is the
+opposite case: an interior (or a street, or any built space) contains long
+straight edges in two or three mutually orthogonal directions, and that is a
+calibration target. So the usual order inverts:
+
+    object : decomposition easy, measurement impossible  -> fit by eye
+    scene  : decomposition hard, measurement possible    -> fit by arithmetic
+
+Three closures make it work, in this order:
+
+1. **Two orthogonal floor directions** give two vanishing points v1, v2. The line
+   through them is the HORIZON of the floor plane.
+2. **The vertical direction** decides where the principal point p is:
+   - if the verticals converge (a finite v3), p is the ORTHOCENTRE of the
+     triangle v1v2v3 and f follows from any orthogonal pair;
+   - if the verticals are parallel in the image (v3 at infinity — the usual case
+     for an architectural shot, and testable, see `vertical_vp`), then the image
+     plane contains the vertical axis, so **p lies on the horizon** and the
+     classic two-point formula closes it: f = sqrt(|p-v1| * |p-v2|).
+   Either way, p is generally NOT the centre of the frame. Film stills and crops
+   move it. See `grimoire/scene/traps.md` — assuming p = centre is the single
+   most expensive mistake in this pipeline.
+3. **A repeated floor pattern** (tiles, boards, paving, joists) fixes the scale.
+   The unit of length is one repeat; absolute length is not recoverable from one
+   image and is not invented here. `scene_unit_gate.py` tests a proposed metre
+   value against architectural priors instead.
+
+This module does no computer vision. Line segments come from the agent, which
+can see; the script does the arithmetic and the gating, which the agent cannot do
+reliably. That is the same division of labour as the rest of the pipeline.
+
+Pure Python stdlib. No numpy, no PIL, no OpenCV.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+Vec2 = tuple[float, float]
+Vec3 = tuple[float, float, float]
+Mat3 = tuple[Vec3, Vec3, Vec3]
+Segment = tuple[float, float, float, float]
+
+# --- gate thresholds -------------------------------------------------------
+MIN_SEGMENTS_PER_FAMILY = 2
+VP_RESIDUAL_WARN_PX = 4.0          # mean point-line distance at the vanishing point
+VP_RESIDUAL_FAIL_PX = 12.0
+PITCH_DISAGREEMENT_WARN = 0.10     # the two floor families must report the same pitch
+PITCH_DISAGREEMENT_FAIL = 0.35
+TRIM_FRACTION = 0.25               # drop this worst share of segments and refit once
+VERTICAL_SPREAD_AT_INFINITY = 0.5  # leave-one-out relative spread of 1/|v3| above this = parallel
+PRINCIPAL_POINT_MAX_OFFSET = 0.5   # reject a 3-VP principal point further than this * diagonal
+F_LOO_SPREAD_MAX = 0.10            # 3-VP focal length must be stable to 10% under leave-one-out
+
+
+# --- small linear algebra (stdlib only) ------------------------------------
+def _dot(a: Sequence[float], b: Sequence[float]) -> float:
+    return sum(x * y for x, y in zip(a, b))
+
+
+def _cross(a: Vec3, b: Vec3) -> Vec3:
+    return (a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0])
+
+
+def _norm(a: Sequence[float]) -> float:
+    return math.sqrt(_dot(a, a))
+
+
+def _unit(a: Sequence[float]) -> tuple[float, ...]:
+    n = _norm(a)
+    if n < 1e-12:
+        raise ValueError("cannot normalise a zero vector")
+    return tuple(x / n for x in a)
+
+
+def _solve2(m: tuple[float, float, float, float], rhs: Vec2) -> Vec2:
+    a, b, c, d = m
+    det = a * d - b * c
+    if abs(det) < 1e-12:
+        raise ValueError("degenerate 2x2 system (are the lines parallel?)")
+    return ((rhs[0] * d - b * rhs[1]) / det, (a * rhs[1] - rhs[0] * c) / det)
+
+
+def _det3(m: Mat3) -> float:
+    return (m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+            - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+            + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]))
+
+
+def _matvec(m: Mat3, v: Vec3) -> Vec3:
+    return tuple(_dot(row, v) for row in m)  # type: ignore[return-value]
+
+
+def _transpose(m: Mat3) -> Mat3:
+    return tuple(tuple(m[r][c] for r in range(3)) for c in range(3))  # type: ignore[return-value]
+
+
+# --- lines and vanishing points --------------------------------------------
+def line_of(seg: Segment) -> tuple[float, float, float]:
+    """Segment -> normalised line (A, B, C) with A*x + B*y + C = 0, A^2+B^2 = 1.
+
+    The general form is used on purpose: the `x = a*y + b` form blows up on
+    horizontal lines, and a scene has plenty of those.
+    """
+    x1, y1, x2, y2 = seg
+    dx, dy = x2 - x1, y2 - y1
+    n = math.hypot(dx, dy)
+    if n < 1e-9:
+        raise ValueError(f"degenerate segment {seg}")
+    a, b = -dy / n, dx / n
+    return (a, b, -(a * x1 + b * y1))
+
+
+def vanishing_point(segments: Sequence[Segment], *, trim: float = TRIM_FRACTION
+                    ) -> tuple[Vec2, float, int]:
+    """Least-squares intersection of a bundle of lines, with one trimming refit.
+
+    Minimises the sum of squared point-line distances, which is well conditioned
+    even when the point is far outside the frame (it usually is).
+    Returns (point, mean residual px, segments kept).
+    """
+    lines = [line_of(s) for s in segments]
+    if len(lines) < MIN_SEGMENTS_PER_FAMILY:
+        raise ValueError(f"need >= {MIN_SEGMENTS_PER_FAMILY} segments, got {len(lines)}")
+
+    def fit(ls: Sequence[tuple[float, float, float]]) -> Vec2:
+        saa = sum(l[0] * l[0] for l in ls)
+        sab = sum(l[0] * l[1] for l in ls)
+        sbb = sum(l[1] * l[1] for l in ls)
+        sac = sum(l[0] * l[2] for l in ls)
+        sbc = sum(l[1] * l[2] for l in ls)
+        return _solve2((saa, sab, sab, sbb), (-sac, -sbc))
+
+    point = fit(lines)
+    if len(lines) >= 4 and trim > 0:
+        resid = sorted(lines, key=lambda l: abs(l[0] * point[0] + l[1] * point[1] + l[2]))
+        keep = resid[: max(MIN_SEGMENTS_PER_FAMILY, int(round(len(lines) * (1 - trim))))]
+        point = fit(keep)
+        lines = keep
+    mean_res = sum(abs(l[0] * point[0] + l[1] * point[1] + l[2]) for l in lines) / len(lines)
+    return point, mean_res, len(lines)
+
+
+def vertical_vp(segments: Sequence[Segment], diag: float) -> dict[str, Any]:
+    """Do the verticals converge, or are they parallel *within their own noise*?
+
+    This is a judgement the arithmetic can make and the eye cannot. Two nearly
+    vertical edges 40px apart always "converge somewhere", but if the implied
+    convergence moves around when you drop any one segment, it means nothing.
+    So the test is leave-one-out: refit without each segment and look at the
+    spread of 1/|v3 - centre| (the reciprocal, because that is the quantity
+    proportional to tan(pitch); |v3| itself is unbounded and useless as a scale).
+
+    Getting this wrong is expensive in both directions: calling a real
+    convergence "parallel" silently folds the camera's pitch into the principal
+    point, and calling noise a convergence puts the principal point anywhere.
+    """
+    if len(segments) < MIN_SEGMENTS_PER_FAMILY:
+        return {"available": False, "reason": "fewer than 2 vertical segments supplied"}
+    try:
+        point, res, kept = vanishing_point(segments, trim=0.0)
+    except ValueError:
+        # exactly parallel lines — the strongest possible "at infinity"
+        return {"available": True, "point": None, "meanResidualPx": 0.0,
+                "segments": len(segments), "leaveOneOutSpread": None, "atInfinity": True,
+                "reason": "verticals are exactly parallel -> principal point constrained to the horizon"}
+    centre = (0.0, 0.0)
+    inv = []
+    if len(segments) >= 3:
+        for i in range(len(segments)):
+            subset = [s for j, s in enumerate(segments) if j != i]
+            try:
+                q, _, _ = vanishing_point(subset, trim=0.0)
+            except ValueError:
+                continue
+            d = math.hypot(q[0] - centre[0], q[1] - centre[1])
+            inv.append(1.0 / d if d > 1e-9 else float("inf"))
+    base = math.hypot(point[0], point[1])
+    base_inv = 1.0 / base if base > 1e-9 else float("inf")
+    if len(inv) >= 2 and base_inv > 0:
+        mean = sum(inv) / len(inv)
+        var = sum((x - mean) ** 2 for x in inv) / (len(inv) - 1)
+        spread = math.sqrt(var) / abs(mean) if mean else float("inf")
+    else:
+        spread = None
+    at_infinity = (base > 200.0 * diag) or (spread is not None and spread > VERTICAL_SPREAD_AT_INFINITY)
+    return {"available": True, "point": [round(point[0], 1), round(point[1], 1)],
+            "meanResidualPx": round(res, 3), "segments": kept,
+            "leaveOneOutSpread": round(spread, 3) if spread is not None else None,
+            "atInfinity": at_infinity,
+            "reason": ("verticals are parallel within the fit noise -> the principal point is "
+                       "constrained to the horizon and any real camera pitch is absorbed into it"
+                       if at_infinity else
+                       "verticals converge with a stable vanishing point -> full 3-VP calibration")}
+
+
+# --- camera ----------------------------------------------------------------
+class SceneCamera:
+    """Pinhole camera for a scene, expressed in the floor grid's own frame.
+
+    World frame: origin at the camera's foot on the floor, +Y up, +X and +Z along
+    the two measured floor directions. One unit = one floor-pattern repeat.
+    """
+
+    def __init__(self, focal: float, principal: Vec2, rotation: Mat3, height: float,
+                 image: tuple[int, int], meta: dict[str, Any] | None = None):
+        self.f = focal
+        self.p = principal
+        # rotation maps world -> camera.  **The world axes go in the COLUMNS.**
+        # Putting them in the rows silently mixes the two frames: near points stay
+        # almost right and far points stretch, so a room comes out too long and it
+        # reads as a modelling error. See grimoire/scene/traps.md.
+        self.R = rotation
+        self.Rt = _transpose(rotation)
+        self.h = height
+        self.image = image
+        self.meta = meta or {}
+
+    def ray(self, u: float, v: float) -> Vec3:
+        d = ((u - self.p[0]) / self.f, (v - self.p[1]) / self.f, 1.0)
+        return _unit(_matvec(self.Rt, d))  # type: ignore[return-value]
+
+    def floor(self, u: float, v: float) -> Vec2 | None:
+        """Pixel -> point on the floor plane y = 0, or None if the ray misses it."""
+        d = self.ray(u, v)
+        if d[1] >= -1e-9:
+            return None
+        t = self.h / -d[1]
+        return (d[0] * t, d[2] * t)
+
+    def height_at(self, u: float, v: float, foot: Vec2) -> float:
+        """Height of the pixel (u, v) on a vertical line standing at floor point `foot`."""
+        d = self.ray(u, v)
+        horiz = math.hypot(d[0], d[2])
+        if horiz < 1e-9:
+            raise ValueError("ray is vertical; cannot resolve a height this way")
+        t = math.hypot(foot[0], foot[1]) / horiz
+        return self.h + d[1] * t
+
+    def project(self, point: Vec3) -> Vec2 | None:
+        c = _matvec(self.R, (point[0], point[1] - self.h, point[2]))
+        if c[2] <= 1e-6:
+            return None
+        return (self.p[0] + self.f * c[0] / c[2], self.p[1] + self.f * c[1] / c[2])
+
+    def horizon_y(self, x: float) -> float:
+        v1, v2 = self.meta["vp1"], self.meta["vp2"]
+        if abs(v2[0] - v1[0]) < 1e-9:
+            return v1[1]
+        return v1[1] + (v2[1] - v1[1]) * (x - v1[0]) / (v2[0] - v1[0])
+
+    def depth_sensitivity(self, u: float, v: float) -> float:
+        """Floor units of depth error per pixel of reading error, at this pixel.
+
+        A contact point near the horizon is not a measurement. Reporting this
+        number is what stops the pipeline from silently placing a cabinet three
+        times too far away.
+        """
+        dy = abs(v - self.horizon_y(u))
+        if dy < 1e-6:
+            return float("inf")
+        return self.h * self.f / (dy * dy)
+
+    def to_dict(self) -> dict[str, Any]:
+        w, hgt = self.image
+        return {
+            "focalPx": round(self.f, 2),
+            "principalPoint": [round(self.p[0], 2), round(self.p[1], 2)],
+            "principalPointOffsetFromCentrePx": [round(self.p[0] - w / 2, 2),
+                                                 round(self.p[1] - hgt / 2, 2)],
+            "fovHorizontalDeg": round(math.degrees(2 * math.atan(w / 2 / self.f)), 3),
+            "fovVerticalDeg": round(math.degrees(2 * math.atan(hgt / 2 / self.f)), 3),
+            "rotationWorldToCameraRowMajor": [round(x, 6) for row in self.R for x in row],
+            "cameraHeightInUnits": round(self.h, 4),
+            "image": {"width": w, "height": hgt},
+            **self.meta,
+        }
+
+
+def _floor_basis(f: float, p: Vec2, v1: Vec2, v2: Vec2) -> Mat3:
+    """World->camera rotation whose X and Z axes are the two measured floor directions."""
+    d1 = _unit(((v1[0] - p[0]) / f, (v1[1] - p[1]) / f, 1.0))
+    d2 = _unit(((v2[0] - p[0]) / f, (v2[1] - p[1]) / f, 1.0))
+    up = list(_unit(_cross(d2, d1)))
+    if up[1] > 0:                      # camera +Y points down, so world up has y < 0
+        up = [-x for x in up]
+    # re-orthogonalise: the measured directions are only approximately orthogonal
+    d2o = _unit(_cross(tuple(up), d1))          # type: ignore[arg-type]
+    cols = (d2o, tuple(up), d1)
+    R: Mat3 = tuple(tuple(cols[c][r] for c in range(3)) for r in range(3))  # type: ignore[assignment]
+    if _det3(R) < 0:
+        cols = (tuple(-x for x in d2o), tuple(up), d1)
+        R = tuple(tuple(cols[c][r] for c in range(3)) for r in range(3))    # type: ignore[assignment]
+    return R
+
+
+def _pitch_from_families(cam: SceneCamera, families: Sequence[Sequence[Segment]],
+                         rows: Vec2) -> list[dict[str, Any]]:
+    """Spacing of each floor family, measured on the floor plane itself.
+
+    Every line of one family becomes a single number — its signed offset along the
+    family normal — so the spacing shows up as clusters, and the gap between
+    cluster centres is the repeat. Squares mean both families must agree; when
+    they do not, that disagreement IS the scale uncertainty and is reported.
+    """
+    out: list[dict[str, Any]] = []
+    y0, y1 = rows
+    for fam in families:
+        offsets: list[float] = []
+        for seg in fam:
+            a, b, c = line_of(seg)
+            pts = []
+            for y in (y0, y1):
+                if abs(a) < 1e-9:
+                    pts = []
+                    break
+                pts.append(cam.floor(-(b * y + c) / a, y))
+            if len(pts) != 2 or pts[0] is None or pts[1] is None:
+                continue
+            p0, p1 = pts
+            d = _unit((p1[0] - p0[0], p1[1] - p0[1]))
+            offsets.append(-d[1] * p0[0] + d[0] * p0[1])
+        offsets.sort()
+        clusters: list[list[float]] = []
+        for o in offsets:
+            if clusters and o - clusters[-1][-1] < 0.30:
+                clusters[-1].append(o)
+            else:
+                clusters.append([o])
+        centres = [sum(c) / len(c) for c in clusters]
+        gaps = [b - a for a, b in zip(centres, centres[1:])]
+        pitch = sorted(gaps)[len(gaps) // 2] if gaps else None
+        out.append({"lines": len(offsets), "clusters": len(centres),
+                    "pitch": round(pitch, 4) if pitch else None})
+    return out
+
+
+def solve(measurements: dict[str, Any]) -> SceneCamera:
+    img = measurements["image"]
+    w, h = int(img["width"]), int(img["height"])
+    diag = math.hypot(w, h)
+    fams = measurements["floorFamilies"]
+    if len(fams) != 2:
+        raise ValueError("exactly two orthogonal floor families are required")
+    segs = [[tuple(map(float, s)) for s in fam["segments"]] for fam in fams]
+
+    v1, r1, n1 = vanishing_point(segs[0])
+    v2, r2, n2 = vanishing_point(segs[1])
+    vert = vertical_vp([tuple(map(float, s)) for s in measurements.get("verticalSegments", [])],
+                       diag)
+
+    notes: list[str] = []
+    p = None
+    route = ""
+    f2 = 0.0
+    if vert.get("available") and not vert.get("atInfinity"):
+        # Full three-point calibration: p is the orthocentre of v1 v2 v3.
+        # Guarded twice, because the triangle degenerates exactly when the
+        # verticals are nearly parallel — which is the COMMON case, not an
+        # exotic one. The stability test is leave-one-out **on the derived
+        # focal length**, not on v3: with near-parallel verticals v3 wanders by
+        # thousands of pixels under sub-pixel endpoint noise, and an
+        # innocent-looking v3 can still produce f wrong by 3x. (Measured on the
+        # synthetic fixture: 0.8px of endpoint noise at 3 deg of pitch collapsed
+        # f from 772 to 259 before this gate existed.)
+        vsegs = [tuple(map(float, s_)) for s_ in measurements.get("verticalSegments", [])]
+
+        def f_from_verts(subset: Sequence[Segment]) -> tuple[Vec2, float] | None:
+            try:
+                v3s, _, _ = vanishing_point(subset, trim=0.0)
+                cand = _orthocentre(v1, v2, v3s)
+                cf2 = -((v1[0] - cand[0]) * (v2[0] - cand[0])
+                        + (v1[1] - cand[1]) * (v2[1] - cand[1]))
+                if cf2 <= 0:
+                    return None
+                return cand, math.sqrt(cf2)
+            except ValueError:
+                return None
+
+        full = f_from_verts(vsegs)
+        loo_f = [r[1] for i in range(len(vsegs))
+                 if len(vsegs) > 2 and (r := f_from_verts([s_ for j, s_ in enumerate(vsegs) if j != i]))]
+        stable = (full is not None and len(loo_f) >= 2
+                  and (max(loo_f) - min(loo_f)) / full[1] <= F_LOO_SPREAD_MAX)
+        if stable:
+            cand, f_cand = full
+            off = math.hypot(cand[0] - w / 2, cand[1] - h / 2)
+            if off < PRINCIPAL_POINT_MAX_OFFSET * diag:
+                p, f2, route = cand, f_cand * f_cand, "three-vanishing-point"
+                vert["fLeaveOneOutSpread"] = round((max(loo_f) - min(loo_f)) / f_cand, 4)
+            else:
+                notes.append("3-VP principal point implausibly far from the frame; "
+                             "fell back to the horizon constraint")
+        else:
+            spread_txt = (round((max(loo_f) - min(loo_f)) / full[1], 3)
+                          if full and len(loo_f) >= 2 else None)
+            notes.append(f"3-VP focal length unstable under leave-one-out "
+                         f"(spread={spread_txt}); fell back to the horizon constraint")
+    if p is None:
+        px = float(measurements.get("principalPointX", w / 2))  # not measurable from one plane
+        if abs(v2[0] - v1[0]) < 1e-9:
+            py = (v1[1] + v2[1]) / 2
+        else:
+            py = v1[1] + (v2[1] - v1[1]) * (px - v1[0]) / (v2[0] - v1[0])
+        p = (px, py)
+        f2 = -((v1[0] - p[0]) * (v2[0] - p[0]) + (v1[1] - p[1]) * (v2[1] - p[1]))
+        route = "two-vanishing-point (principal point on the horizon)"
+        notes.append("principal point x assumed at the frame centre; only its y is measured")
+    if f2 <= 0:
+        raise ValueError("the two floor families are not orthogonal in this view "
+                         "(f^2 <= 0) — check that the segments really are two "
+                         "perpendicular directions of the same plane")
+    f = math.sqrt(f2)
+
+    R = _floor_basis(f, p, v1, v2)
+    cam = SceneCamera(f, p, R, 1.0, (w, h))
+    cam.meta = {"vp1": [round(v1[0], 1), round(v1[1], 1)],
+                "vp2": [round(v2[0], 1), round(v2[1], 1)]}
+
+    rows = measurements.get("pitchRows") or [h * 0.87, h * 0.96]
+    pitches = _pitch_from_families(cam, segs, (float(rows[0]), float(rows[1])))
+    vals = [p_["pitch"] for p_ in pitches if p_["pitch"]]
+    if vals:
+        pitch = sum(vals) / len(vals)
+        disagree = (max(vals) - min(vals)) / pitch if len(vals) > 1 else 0.0
+        cam.h = 1.0 / pitch
+    else:
+        pitch, disagree = None, None
+        notes.append("no floor repeat could be measured; length unit = camera height")
+
+    verdict = "pass"
+    if max(r1, r2) > VP_RESIDUAL_FAIL_PX:
+        verdict = "fail"
+    elif max(r1, r2) > VP_RESIDUAL_WARN_PX:
+        verdict = "warn"
+    if disagree is not None:
+        if disagree > PITCH_DISAGREEMENT_FAIL:
+            verdict = "fail"
+        elif disagree > PITCH_DISAGREEMENT_WARN and verdict == "pass":
+            verdict = "warn"
+
+    cam.meta.update({
+        "route": route,
+        "verticalCheck": vert,
+        "calibration": {
+            "vp1ResidualPx": round(r1, 2), "vp1Segments": n1,
+            "vp2ResidualPx": round(r2, 2), "vp2Segments": n2,
+            "floorPitchPerFamily": pitches,
+            "pitchDisagreement": round(disagree, 4) if disagree is not None else None,
+            "verdict": verdict,
+        },
+        "lengthUnit": "one floor-pattern repeat" if vals else "camera height",
+        "notes": notes,
+    })
+    return cam
+
+
+def _orthocentre(a: Vec2, b: Vec2, c: Vec2) -> Vec2:
+    """Orthocentre of a triangle — the principal point of a 3-VP calibration."""
+    # altitude from a is perpendicular to bc, etc.  Solve the 2x2 system.
+    m = ((c[0] - b[0], c[1] - b[1]), (c[0] - a[0], c[1] - a[1]))
+    rhs = (m[0][0] * a[0] + m[0][1] * a[1], m[1][0] * b[0] + m[1][1] * b[1])
+    return _solve2((m[0][0], m[0][1], m[1][0], m[1][1]), rhs)
+
+
+def load_camera(path: Path) -> SceneCamera:
+    d = json.loads(Path(path).read_text())
+    r = d["rotationWorldToCameraRowMajor"]
+    R: Mat3 = ((r[0], r[1], r[2]), (r[3], r[4], r[5]), (r[6], r[7], r[8]))
+    cam = SceneCamera(d["focalPx"], tuple(d["principalPoint"]), R,
+                      d["cameraHeightInUnits"],
+                      (d["image"]["width"], d["image"]["height"]))
+    cam.meta = {k: v for k, v in d.items() if k in ("vp1", "vp2", "route", "calibration")}
+    return cam
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("measurements", help="JSON with image size and two floor line families")
+    ap.add_argument("--out", default="scene-camera.json")
+    args = ap.parse_args(argv)
+    cam = solve(json.loads(Path(args.measurements).read_text()))
+    payload = cam.to_dict()
+    Path(args.out).write_text(json.dumps(payload, indent=2) + "\n")
+    json.dump(payload, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0 if payload["calibration"]["verdict"] != "fail" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/forge/stage1_intake/scene_camera.py
+++ b/forge/stage1_intake/scene_camera.py
@@ -152,7 +152,8 @@ def vanishing_point(segments: Sequence[Segment], *, trim: float = TRIM_FRACTION
     return point, mean_res, len(lines)
 
 
-def vertical_vp(segments: Sequence[Segment], diag: float) -> dict[str, Any]:
+def vertical_vp(segments: Sequence[Segment], diag: float,
+                centre: Vec2 = (0.0, 0.0)) -> dict[str, Any]:
     """Do the verticals converge, or are they parallel *within their own noise*?
 
     This is a judgement the arithmetic can make and the eye cannot. Two nearly
@@ -186,7 +187,7 @@ def vertical_vp(segments: Sequence[Segment], diag: float) -> dict[str, Any]:
                 continue
             d = math.hypot(q[0] - centre[0], q[1] - centre[1])
             inv.append(1.0 / d if d > 1e-9 else float("inf"))
-    base = math.hypot(point[0], point[1])
+    base = math.hypot(point[0] - centre[0], point[1] - centre[1])
     base_inv = 1.0 / base if base > 1e-9 else float("inf")
     if len(inv) >= 2 and base_inv > 0:
         mean = sum(inv) / len(inv)
@@ -255,10 +256,19 @@ class SceneCamera:
         return (self.p[0] + self.f * c[0] / c[2], self.p[1] + self.f * c[1] / c[2])
 
     def horizon_y(self, x: float) -> float:
-        v1, v2 = self.meta["vp1"], self.meta["vp2"]
-        if abs(v2[0] - v1[0]) < 1e-9:
-            return v1[1]
-        return v1[1] + (v2[1] - v1[1]) * (x - v1[0]) / (v2[0] - v1[0])
+        """Image y of the floor plane's vanishing line at column x.
+
+        Derived from K and R, not from stored vanishing points: a ray (u, v) lies
+        on the horizon iff its world direction has no vertical component, i.e.
+        R[0][1]*(u-px)/f + R[1][1]*(v-py)/f + R[2][1] = 0  (the middle column of
+        R is the world up-axis in camera coordinates). Works on any SceneCamera,
+        including hand-built fixtures with no meta.
+        """
+        a = self.R[0][1] * (x - self.p[0]) / self.f + self.R[2][1]
+        b = self.R[1][1] / self.f
+        if abs(b) < 1e-12:
+            raise ValueError("degenerate orientation: horizon is not a function of x")
+        return self.p[1] - a / b
 
     def depth_sensitivity(self, u: float, v: float) -> float:
         """Floor units of depth error per pixel of reading error, at this pixel.
@@ -274,7 +284,22 @@ class SceneCamera:
 
     def to_dict(self) -> dict[str, Any]:
         w, hgt = self.image
+        # Off-axis frustum for Three.js. A plain PerspectiveCamera cannot express
+        # an off-centre principal point (traps.md #1), so hand over the numbers
+        # for camera.setViewOffset(fullW, fullH, offX, offY, w, h) directly:
+        # a virtual frame centred ON the principal point, with the real frame
+        # cut out of it.
+        full_w = 2 * max(self.p[0], w - self.p[0])
+        full_h = 2 * max(self.p[1], hgt - self.p[1])
+        three = {
+            "fovFullDeg": round(math.degrees(2 * math.atan(full_h / 2 / self.f)), 3),
+            "fullWidth": round(full_w, 2), "fullHeight": round(full_h, 2),
+            "offsetX": round(full_w / 2 - self.p[0], 2),
+            "offsetY": round(full_h / 2 - self.p[1], 2),
+            "width": w, "height": hgt,
+        }
         return {
+            "threejsViewOffset": three,
             "focalPx": round(self.f, 2),
             "principalPoint": [round(self.p[0], 2), round(self.p[1], 2)],
             "principalPointOffsetFromCentrePx": [round(self.p[0] - w / 2, 2),
@@ -309,10 +334,22 @@ def _pitch_from_families(cam: SceneCamera, families: Sequence[Sequence[Segment]]
                          rows: Vec2) -> list[dict[str, Any]]:
     """Spacing of each floor family, measured on the floor plane itself.
 
-    Every line of one family becomes a single number — its signed offset along the
-    family normal — so the spacing shows up as clusters, and the gap between
+    Every line of one family becomes a single number — its signed offset along
+    the family normal — so the spacing shows up as clusters, and the gap between
     cluster centres is the repeat. Squares mean both families must agree; when
     they do not, that disagreement IS the scale uncertainty and is reported.
+
+    Two robustness points, both learned the hard way:
+    - A line is sampled along its DOMINANT image axis. Parametrising by y alone
+      throws away every near-horizontal line, which is the entire second family
+      of a one-point-perspective floor.
+    - The clustering threshold is scale-free. The gap distribution is BIMODAL:
+      several detected segments per physical grout give tiny gaps, neighbouring
+      grouts give repeat-sized ones. So the split point is the largest
+      multiplicative jump in the sorted gaps — not the median (dragged into the
+      duplicate mode) and not a fixed absolute value (merges everything when
+      the camera is high and the repeat is small in camera-height units; both
+      were tried and both failed on real or synthetic data).
     """
     out: list[dict[str, Any]] = []
     y0, y1 = rows
@@ -320,26 +357,38 @@ def _pitch_from_families(cam: SceneCamera, families: Sequence[Sequence[Segment]]
         offsets: list[float] = []
         for seg in fam:
             a, b, c = line_of(seg)
-            pts = []
-            for y in (y0, y1):
+            if abs(a) >= abs(b):                       # steep in the image: sample two rows
                 if abs(a) < 1e-9:
-                    pts = []
-                    break
-                pts.append(cam.floor(-(b * y + c) / a, y))
-            if len(pts) != 2 or pts[0] is None or pts[1] is None:
+                    continue
+                px_pts = [(-(b * y + c) / a, y) for y in (y0, y1)]
+            else:                                      # shallow: sample two columns
+                x0, x1 = seg[0], seg[2]
+                if abs(x1 - x0) < 1e-6:
+                    x0, x1 = x0 - 40.0, x0 + 40.0
+                px_pts = [(x, -(a * x + c) / b) for x in (x0, x1)]
+            pts = [cam.floor(u, v) for u, v in px_pts]
+            if any(p_ is None for p_ in pts):
                 continue
             p0, p1 = pts
             d = _unit((p1[0] - p0[0], p1[1] - p0[1]))
             offsets.append(-d[1] * p0[0] + d[0] * p0[1])
         offsets.sort()
+        gaps_all = sorted(g for g in (b2 - a2 for a2, b2 in zip(offsets, offsets[1:]))
+                          if g > 1e-9)
+        merge_below = 0.0
+        if len(gaps_all) >= 2:
+            jumps = [(gaps_all[i + 1] / gaps_all[i], i) for i in range(len(gaps_all) - 1)]
+            ratio, at = max(jumps)
+            if ratio >= 3.0:                     # clear duplicate/repeat separation
+                merge_below = math.sqrt(gaps_all[at] * gaps_all[at + 1])
         clusters: list[list[float]] = []
         for o in offsets:
-            if clusters and o - clusters[-1][-1] < 0.30:
+            if clusters and o - clusters[-1][-1] < merge_below:
                 clusters[-1].append(o)
             else:
                 clusters.append([o])
         centres = [sum(c) / len(c) for c in clusters]
-        gaps = [b - a for a, b in zip(centres, centres[1:])]
+        gaps = [b2 - a2 for a2, b2 in zip(centres, centres[1:])]
         pitch = sorted(gaps)[len(gaps) // 2] if gaps else None
         out.append({"lines": len(offsets), "clusters": len(centres),
                     "pitch": round(pitch, 4) if pitch else None})
@@ -358,7 +407,7 @@ def solve(measurements: dict[str, Any]) -> SceneCamera:
     v1, r1, n1 = vanishing_point(segs[0])
     v2, r2, n2 = vanishing_point(segs[1])
     vert = vertical_vp([tuple(map(float, s)) for s in measurements.get("verticalSegments", [])],
-                       diag)
+                       diag, centre=(w / 2, h / 2))
 
     notes: list[str] = []
     p = None

--- a/forge/stage1_intake/scene_unit_gate.py
+++ b/forge/stage1_intake/scene_unit_gate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Scene unit-sanity gate: does ONE metre value make ALL the architecture plausible?
+
+The floor pattern fixes relative scale, but no single image reveals absolute
+length — a photograph of a room tiled at 0.5 m looks identical to one tiled at
+1.0 m with everything doubled. What breaks the tie is that buildings are built
+for bodies: door heads, worktop heights, cornices and seats live in narrow,
+well-documented bands. So instead of guessing, propose a metre-per-unit value
+and test EVERY independently measured height against its band at once.
+
+The strength of the gate is the conjunction. Any one fit is weak (a door head
+alone tolerates 1.9-2.5 m), but a doorway AND a worktop AND a cornice AND the
+camera height all landing in-band pins the unit tightly — and a single hard
+failure kills the proposal. Report which.
+
+Bands are architectural, deliberately generous, and centre on residential /
+formal interiors. They are priors, not laws: the output is `plausible` /
+`implausible` with named reasons, never a silent rescale.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+# (kind, low_m, high_m) — generous residential/formal-interior bands
+BANDS: dict[str, tuple[float, float]] = {
+    "doorHead": (1.85, 3.60),          # top of a door / archway (formal interiors run tall)
+    "worktop": (0.70, 1.20),           # commode / dresser / counter top
+    "seat": (0.35, 0.55),              # chair or bench seat
+    "cornice": (2.30, 6.00),           # underside of the cornice / ceiling band
+    "ceiling": (2.20, 7.00),
+    "dado": (0.60, 1.20),              # chair rail
+    "cameraEyeLevel": (0.90, 1.90),    # handheld to tripod; below 0.9 is a floor rig
+    "tableTop": (0.65, 0.80),
+    "wallSconce": (1.50, 2.20),
+}
+
+
+def evaluate(unit_m: float, samples: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    rows, fails = [], []
+    for name, spec in samples.items():
+        kind = spec["kind"]
+        if kind not in BANDS:
+            rows.append({"sample": name, "kind": kind, "verdict": "unknown-kind"})
+            continue
+        lo, hi = BANDS[kind]
+        metres = float(spec["units"]) * unit_m
+        ok = lo <= metres <= hi
+        rows.append({"sample": name, "kind": kind, "units": spec["units"],
+                     "metres": round(metres, 3), "band": [lo, hi],
+                     "verdict": "in-band" if ok else "OUT-OF-BAND"})
+        if not ok:
+            fails.append(f"{name} ({kind}): {metres:.2f} m outside [{lo}, {hi}]")
+    tested = [r for r in rows if "band" in r]
+    verdict = "implausible" if fails else ("plausible" if len(tested) >= 3 else
+                                          "insufficient (need >= 3 banded samples)")
+    return {"metresPerUnit": unit_m, "samples": rows, "verdict": verdict,
+            "failures": fails,
+            "note": "conjunction gate: one hard failure kills the proposal; "
+                    "fewer than 3 banded samples cannot support it"}
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("samples", help='JSON {"name": {"kind": "doorHead", "units": 2.98}, ...}')
+    ap.add_argument("--unit", type=float, required=True, help="proposed metres per pattern unit")
+    ap.add_argument("--out", default="scene-unit.json")
+    args = ap.parse_args(argv)
+    result = evaluate(args.unit, json.loads(Path(args.samples).read_text()))
+    Path(args.out).write_text(json.dumps(result, indent=2) + "\n")
+    json.dump(result, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0 if result["verdict"] == "plausible" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/forge/state.py
+++ b/forge/state.py
@@ -26,7 +26,7 @@ def build_parser() -> argparse.ArgumentParser:
     init = commands.add_parser("init")
     init.add_argument("--state", type=Path, default=Path(".img2threejs/state.json"))
     init.add_argument("--reference", required=True)
-    init.add_argument("--profile", choices=("generic", "cs2", "character"), default="generic")
+    init.add_argument("--profile", choices=("generic", "cs2", "character", "scene"), default="generic")
     init.add_argument("--spec", default="")
     init.add_argument("--max-per-pass", type=int, default=3)
     init.add_argument("--max-total", type=int, default=6)

--- a/forge/tests/test_box_calibration.py
+++ b/forge/tests/test_box_calibration.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Contract tests for box-object self-calibration.
+
+Fixture: a tank-proportioned box (hull 6.3 x 2.9 x 3.7 -> gauge ratios
+1 : 0.4603 : 0.5873) rendered through a known camera in the solver's pixel
+convention. Every expected value is exact by construction.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from forge.stage1_intake import box_calibration as bc  # noqa: E402
+
+W, H = 1536, 691
+F_TRUE, P_TRUE = 900.0, (760.0, 410.0)
+DIMS = (6.3, 2.9, 3.7)          # x (hull length), y (height), z (width)
+
+
+def make_fixture(yaw_deg=34.0, pitch_deg=-6.0, *, noise=0.0, seed=3,
+                 drop_family=None, distance=16.0):
+    rng = random.Random(seed)
+    jit = lambda v: v + rng.uniform(-noise, noise)  # noqa: E731
+    yaw, pitch = math.radians(yaw_deg), math.radians(pitch_deg)
+
+    def unit(v):
+        n = math.sqrt(sum(x * x for x in v))
+        return tuple(x / n for x in v)
+
+    def cross(a, b):
+        return (a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2],
+                a[0] * b[1] - a[1] * b[0])
+
+    look = (math.sin(yaw) * math.cos(pitch), math.sin(pitch), math.cos(yaw) * math.cos(pitch))
+    right = unit(cross(look, (0, 1, 0)))
+    down = cross(look, right)
+    R = (right, down, look)              # world -> camera (rows)
+
+    centre_cam = (0.0, 0.0, distance)
+
+    def corner_cam(i, j, k):
+        wpt = ((i - 0.5) * DIMS[0], (j - 0.5) * DIMS[1], (k - 0.5) * DIMS[2])
+        c = tuple(sum(R[r][m] * wpt[m] for m in range(3)) for r in range(3))
+        return tuple(c[r] + centre_cam[r] for r in range(3))
+
+    def project(c):
+        return (P_TRUE[0] + F_TRUE * c[0] / c[2], P_TRUE[1] + F_TRUE * c[1] / c[2])
+
+    fams = {"x": [], "y": [], "z": []}
+    for axis, idx in (("x", 0), ("y", 1), ("z", 2)):
+        for j in (0, 1):
+            for k in (0, 1):
+                lat0, lat1 = [0, j, k], [0, j, k]
+                lat0[idx], lat1[idx] = 0, 1
+                a = project(corner_cam(*lat0))
+                b = project(corner_cam(*lat1))
+                fams[axis].append([jit(a[0]), jit(a[1]), jit(b[0]), jit(b[1])])
+    if drop_family:
+        del fams[drop_family]
+
+    corners = {}
+    for i in (0, 1):
+        for j in (0, 1):
+            for k in (0, 1):
+                if i + j + k == 0:          # hide one corner, like a real photo
+                    continue
+                q = project(corner_cam(i, j, k))
+                corners[f"c{i}{j}{k}"] = {"px": [jit(q[0]), jit(q[1])], "at": [i, j, k]}
+    return {"image": {"width": W, "height": H}, "edgeFamilies": fams, "corners": corners}
+
+
+class ThreeFamilyCalibration(unittest.TestCase):
+    def test_recovers_focal_and_principal_point(self):
+        m = make_fixture()
+        cal = bc.calibrate(m["edgeFamilies"], (W, H))
+        self.assertEqual(cal["route"], "three-family orthocentre")
+        self.assertLess(abs(cal["focalPx"] - F_TRUE) / F_TRUE, 0.01)
+        self.assertLess(abs(cal["principalPoint"][0] - P_TRUE[0]), 3.0)
+        self.assertLess(abs(cal["principalPoint"][1] - P_TRUE[1]), 3.0)
+        self.assertEqual(cal["verdict"], "pass")
+
+    def test_dimension_ratios_from_corners(self):
+        m = make_fixture()
+        cal = bc.calibrate(m["edgeFamilies"], (W, H))
+        box = bc.fit_box(cal, m["corners"])
+        self.assertLess(abs(box["dimensions"]["y"] - DIMS[1] / DIMS[0]), 0.01)
+        self.assertLess(abs(box["dimensions"]["z"] - DIMS[2] / DIMS[0]), 0.01)
+        self.assertLess(box["meanCornerResidualPx"], 1.0)
+
+    def test_survives_pixel_noise(self):
+        m = make_fixture(noise=0.7)
+        cal = bc.calibrate(m["edgeFamilies"], (W, H))
+        box = bc.fit_box(cal, m["corners"])
+        self.assertLess(abs(box["dimensions"]["y"] - DIMS[1] / DIMS[0]), 0.05)
+        self.assertLess(abs(box["dimensions"]["z"] - DIMS[2] / DIMS[0]), 0.05)
+
+    def test_known_dimension_gives_metres(self):
+        m = make_fixture()
+        cal = bc.calibrate(m["edgeFamilies"], (W, H))
+        box = bc.fit_box(cal, m["corners"])
+        scale = bc.apply_scale(box, {"axis": "x", "metres": 6.3})
+        self.assertLess(abs(scale["dimensionsMetres"]["y"] - 2.9), 0.05)
+        self.assertLess(abs(scale["dimensionsMetres"]["z"] - 3.7), 0.05)
+
+
+class TwoFamilyCalibration(unittest.TestCase):
+    def test_level_camera_without_vertical_family(self):
+        # pitch 0 -> the y family is image-parallel; drop it entirely and the
+        # two-family route must still recover f and the ratios.
+        m = make_fixture(pitch_deg=0.0, drop_family="y")
+        cal = bc.calibrate(m["edgeFamilies"], (W, H))
+        self.assertTrue(cal["route"].startswith("two-family"))
+        self.assertTrue(any("ASSUMED" in n for n in cal["notes"]))
+        self.assertLess(abs(cal["focalPx"] - F_TRUE) / F_TRUE, 0.02)
+        box = bc.fit_box(cal, m["corners"])
+        self.assertLess(abs(box["dimensions"]["y"] - DIMS[1] / DIMS[0]), 0.03)
+
+    def test_single_family_is_refused_with_routing_advice(self):
+        m = make_fixture(drop_family="y")
+        del m["edgeFamilies"]["z"]
+        with self.assertRaises(ValueError) as ctx:
+            bc.calibrate(m["edgeFamilies"], (W, H))
+        self.assertIn("cannot self-calibrate", str(ctx.exception))
+
+
+class CornerGates(unittest.TestCase):
+    def test_bad_corner_is_named(self):
+        m = make_fixture()
+        cal = bc.calibrate(m["edgeFamilies"], (W, H))
+        m["corners"]["c111"]["px"][0] += 25.0
+        box = bc.fit_box(cal, m["corners"])
+        self.assertEqual(box["perCorner"][0]["corner"], "c111")
+        self.assertTrue(any("'c111'" in d for d in box["diagnosis"]))
+
+    def test_underconstrained_corners_are_refused(self):
+        m = make_fixture()
+        cal = bc.calibrate(m["edgeFamilies"], (W, H))
+        few = dict(list(m["corners"].items())[:3])
+        with self.assertRaises(ValueError):
+            bc.fit_box(cal, few)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/forge/tests/test_scene_camera.py
+++ b/forge/tests/test_scene_camera.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Contract tests for the scene camera solver and its honesty gates.
+
+The fixture is a synthetic camera in the same pixel convention as the solver
+(x right, y down, z forward), so every expected value is exact by construction.
+Two regression cases are lifted from the reconstruction that motivated this
+profile (a film-still interior, 1536x691): the 90px uniform reprojection shift
+caused by an off-centre principal point, and the 3-VP focal collapse under
+sub-pixel noise.
+"""
+
+from __future__ import annotations
+
+import math
+import random
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from forge.stage1_intake import scene_camera as sc  # noqa: E402
+from forge.stage1_intake import scene_backproject as sb  # noqa: E402
+from forge.stage1_intake import scene_unit_gate as su  # noqa: E402
+
+W, H = 1536, 691
+F_TRUE, P_TRUE, H_TRUE = 772.0, (760.0, 430.0), 1.25
+
+
+def camera_looking(yaw_deg: float, pitch_deg: float) -> sc.SceneCamera:
+    """Ground-truth camera in the OpenCV pixel convention: rows = [right; down; look]."""
+    yaw, pitch = math.radians(yaw_deg), math.radians(pitch_deg)
+    look = (math.sin(yaw) * math.cos(pitch), math.sin(pitch), math.cos(yaw) * math.cos(pitch))
+
+    def unit(v):
+        n = math.sqrt(sum(x * x for x in v))
+        return tuple(x / n for x in v)
+
+    def cross(a, b):
+        return (a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0])
+
+    right = unit(cross(look, (0, 1, 0)))
+    down = cross(look, right)
+    return sc.SceneCamera(F_TRUE, P_TRUE, (right, down, look), H_TRUE, (W, H))
+
+
+def synthetic_measurements(ct: sc.SceneCamera, *, noise: float = 0.0,
+                           verticals: int = 0, seed: int = 7) -> dict:
+    rng = random.Random(seed)
+    jit = lambda v: v + rng.uniform(-noise, noise)  # noqa: E731
+
+    def clipped(fn):
+        inside = []
+        for i in range(500):
+            t = -16 + 32 * i / 499
+            q = ct.project(fn(t))
+            if q and 0 <= q[0] < W and 0 <= q[1] < H:
+                inside.append(q)
+        if len(inside) < 40:
+            return None
+        a, b = inside[0], inside[-1]
+        if math.hypot(b[0] - a[0], b[1] - a[1]) < 60:
+            return None
+        return [jit(a[0]), jit(a[1]), jit(b[0]), jit(b[1])]
+
+    fam_a = [s for k in range(-16, 17) if (s := clipped(lambda t, k=k: (k * 1.0, 0.0, t)))]
+    fam_b = [s for k in range(-16, 17) if (s := clipped(lambda t, k=k: (t, 0.0, k * 1.0)))]
+    m = {"image": {"width": W, "height": H},
+         "floorFamilies": [{"name": "A", "segments": fam_a},
+                           {"name": "B", "segments": fam_b}],
+         "pitchRows": [H * 0.80, H * 0.94]}
+    if verticals:
+        v = []
+        for x in range(-8, 9):
+            for z in (3, 5, 7, 9, 12):
+                a = ct.project((x, 0.1, z))
+                b = ct.project((x, 2.6, z))
+                if a and b and all(0 <= q[0] < W and 0 <= q[1] < H for q in (a, b)):
+                    v.append([jit(a[0]), jit(a[1]), jit(b[0]), jit(b[1])])
+            if len(v) >= verticals:
+                break
+        m["verticalSegments"] = v[:verticals]
+    return m
+
+
+def floor_error(ct: sc.SceneCamera, cam: sc.SceneCamera) -> float:
+    errs = []
+    for v in range(470, H, 10):
+        for u in range(30, W, 50):
+            t = ct.floor(u, v)
+            b = cam.floor(u, v)
+            if t and b:
+                errs.append(math.hypot(b[0] - t[0], b[1] - t[1]) / max(1.0, math.hypot(*t)))
+    return max(errs)
+
+
+class TwoVanishingPointRoute(unittest.TestCase):
+    def test_recovers_camera_when_horizontal(self):
+        ct = camera_looking(38, 0.0)
+        cam = sc.solve(synthetic_measurements(ct))
+        d = cam.to_dict()
+        self.assertLess(abs(d["focalPx"] - F_TRUE) / F_TRUE, 0.01)
+        self.assertLess(abs(d["cameraHeightInUnits"] - H_TRUE) / H_TRUE, 0.01)
+        self.assertLess(floor_error(ct, cam), 0.01)
+        self.assertEqual(d["calibration"]["verdict"], "pass")
+
+    def test_pitch_absorbed_into_principal_point_stays_usable(self):
+        # With verticals unavailable the camera's pitch folds into the principal
+        # point; the back-projection must still be metrically close.
+        ct = camera_looking(38, -3.0)
+        cam = sc.solve(synthetic_measurements(ct))
+        self.assertLess(floor_error(ct, cam), 0.03)
+
+    def test_non_orthogonal_families_are_refused(self):
+        ct = camera_looking(38, 0.0)
+        m = synthetic_measurements(ct)
+        m["floorFamilies"][1] = m["floorFamilies"][0]  # same direction twice
+        with self.assertRaises(ValueError):
+            sc.solve(m)
+
+
+class ThreeVanishingPointRoute(unittest.TestCase):
+    def test_exact_with_clean_verticals(self):
+        ct = camera_looking(38, -3.0)
+        cam = sc.solve(synthetic_measurements(ct, verticals=8))
+        d = cam.to_dict()
+        self.assertEqual(d["route"], "three-vanishing-point")
+        self.assertLess(abs(d["focalPx"] - F_TRUE), 0.5)
+        self.assertLess(abs(d["principalPoint"][0] - P_TRUE[0]), 0.5)
+        self.assertLess(floor_error(ct, cam), 1e-6)
+
+    def test_focal_collapse_under_noise_is_gated(self):
+        # Regression: before the leave-one-out gate on f, 0.8px of endpoint noise
+        # at 3 degrees of pitch collapsed f from 772 to 259. Whatever route is
+        # chosen now, the back-projection must stay metrically sane.
+        ct = camera_looking(38, -3.0)
+        cam = sc.solve(synthetic_measurements(ct, verticals=8, noise=0.8))
+        self.assertLess(floor_error(ct, cam), 0.05)
+
+    def test_two_verticals_cannot_claim_stability(self):
+        ct = camera_looking(38, -3.0)
+        m = synthetic_measurements(ct, verticals=8)
+        m["verticalSegments"] = m["verticalSegments"][:2]
+        cam = sc.solve(m)
+        self.assertTrue(cam.to_dict()["route"].startswith("two-vanishing-point"))
+
+
+class PitchAgreementGate(unittest.TestCase):
+    def test_disagreeing_families_downgrade_the_verdict(self):
+        ct = camera_looking(38, 0.0)
+        m = synthetic_measurements(ct)
+        # stretch one family's spacing by 25%: squares no longer agree
+        fam = m["floorFamilies"][0]["segments"]
+        m["floorFamilies"][0]["segments"] = fam[::2] + fam[1::2][:2]
+        cam = sc.solve(synthetic_measurements(ct))
+        base = cam.to_dict()["calibration"]["pitchDisagreement"]
+        self.assertIsNotNone(base)
+        self.assertLess(base, sc.PITCH_DISAGREEMENT_WARN)
+
+
+class BackprojectionGates(unittest.TestCase):
+    def setUp(self):
+        self.ct = camera_looking(38, 0.0)
+        self.cam = sc.solve(synthetic_measurements(self.ct))
+
+    def test_depth_sensitivity_grows_toward_horizon(self):
+        low = self.cam.depth_sensitivity(W / 2, H - 20)
+        high = self.cam.depth_sensitivity(W / 2, self.cam.horizon_y(W / 2) + 25)
+        self.assertLess(low, high / 10)
+
+    def test_uniform_shift_is_named_as_one_cause(self):
+        # Regression: an off-centre principal point produced a 90px uniform shift
+        # that looked like every piece of furniture being misplaced at once.
+        contacts, expected = {}, {}
+        for i, (x, z) in enumerate([(-2, 4), (1, 5), (-4, 7), (3, 8), (0, 3)]):
+            q = self.ct.project((x, 0.0, z))
+            contacts[f"p{i}"] = [q[0], q[1] + 90.0]     # reading shifted uniformly
+            expected[f"p{i}"] = [x, z]
+        landmarks = {"contacts": contacts, "expected": expected}
+        result = sb.backproject(self.cam, landmarks)
+        check = sb.reprojection_check(self.cam, landmarks, result)
+        self.assertGreater(check["uniformShiftMagnitudePx"], 60)
+        self.assertTrue(any("principal point" in d for d in check["diagnosis"]))
+
+    def test_local_residual_names_the_landmark(self):
+        contacts, expected = {}, {}
+        for i, (x, z) in enumerate([(-2, 4), (1, 5), (-4, 7), (3, 8)]):
+            q = self.ct.project((x, 0.0, z))
+            contacts[f"p{i}"] = [q[0], q[1]]
+            expected[f"p{i}"] = [x, z]
+        expected["p2"] = [-5.5, 8.5]                     # one wrong placement
+        landmarks = {"contacts": contacts, "expected": expected}
+        result = sb.backproject(self.cam, landmarks)
+        check = sb.reprojection_check(self.cam, landmarks, result)
+        self.assertEqual(check["residuals"][0]["landmark"], "p2")
+        self.assertTrue(any("'p2'" in d for d in check["diagnosis"]))
+
+    def test_horizon_contact_is_flagged_not_trusted(self):
+        y_h = self.cam.horizon_y(W / 2)
+        result = sb.backproject(self.cam, {"contacts": {"far": [W / 2, y_h + 18]}})
+        entry = result["floorPlan"]["far"]
+        self.assertEqual(entry["confidence"], "horizon-limited")
+
+
+class UnitSanityGate(unittest.TestCase):
+    # Values measured from the motivating interior (in floor-pattern units).
+    SAMPLES = {
+        "doorway": {"kind": "doorHead", "units": 2.98},
+        "commodeTop": {"kind": "worktop", "units": 1.15},
+        "cornice": {"kind": "cornice", "units": 3.50},
+        "camera": {"kind": "cameraEyeLevel", "units": 1.21},
+    }
+
+    def test_one_metre_per_tile_is_plausible(self):
+        self.assertEqual(su.evaluate(1.0, self.SAMPLES)["verdict"], "plausible")
+
+    def test_half_metre_tile_fails_conjunctively(self):
+        out = su.evaluate(0.5, self.SAMPLES)
+        self.assertEqual(out["verdict"], "implausible")
+        self.assertTrue(out["failures"])
+
+    def test_two_samples_cannot_support_a_verdict(self):
+        few = {k: self.SAMPLES[k] for k in ("commodeTop", "camera")}   # both in-band
+        self.assertIn("insufficient", su.evaluate(1.0, few)["verdict"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/forge/tests/test_scene_camera.py
+++ b/forge/tests/test_scene_camera.py
@@ -147,22 +147,53 @@ class ThreeVanishingPointRoute(unittest.TestCase):
 
 
 class PitchAgreementGate(unittest.TestCase):
-    def test_disagreeing_families_downgrade_the_verdict(self):
-        ct = camera_looking(38, 0.0)
-        m = synthetic_measurements(ct)
-        # stretch one family's spacing by 25%: squares no longer agree
-        fam = m["floorFamilies"][0]["segments"]
-        m["floorFamilies"][0]["segments"] = fam[::2] + fam[1::2][:2]
-        cam = sc.solve(synthetic_measurements(ct))
+    def test_square_grid_agrees(self):
+        cam = sc.solve(synthetic_measurements(camera_looking(38, 0.0)))
         base = cam.to_dict()["calibration"]["pitchDisagreement"]
         self.assertIsNotNone(base)
         self.assertLess(base, sc.PITCH_DISAGREEMENT_WARN)
+
+    def test_disagreeing_families_fail_the_verdict(self):
+        # Keep only every second line of one family: its measured repeat doubles,
+        # so the two families disagree by ~2x and the verdict must be "fail".
+        # (The first version of this test built the modified measurements and
+        # then solved the CLEAN ones — a dead assertion. Kept as a reminder that
+        # a gate without a failing-input test is not known to fire.)
+        m = synthetic_measurements(camera_looking(38, 0.0))
+        m["floorFamilies"][0]["segments"] = m["floorFamilies"][0]["segments"][::2]
+        cam = sc.solve(m)
+        cal = cam.to_dict()["calibration"]
+        self.assertGreater(cal["pitchDisagreement"], sc.PITCH_DISAGREEMENT_FAIL)
+        self.assertEqual(cal["verdict"], "fail")
+
+    def test_shallow_family_still_measured(self):
+        # Near-one-point perspective: at 8 deg of yaw one family is almost
+        # horizontal in the image. Sampling lines only by image row used to drop
+        # that entire family (pitch None -> unit silently degraded).
+        cam = sc.solve(synthetic_measurements(camera_looking(8, 0.0)))
+        fams = cam.to_dict()["calibration"]["floorPitchPerFamily"]
+        self.assertTrue(all(f["pitch"] is not None for f in fams), fams)
 
 
 class BackprojectionGates(unittest.TestCase):
     def setUp(self):
         self.ct = camera_looking(38, 0.0)
         self.cam = sc.solve(synthetic_measurements(self.ct))
+
+    def test_horizon_y_matches_ground_truth_camera(self):
+        # horizon_y is derived from K and R, so it must work on the hand-built
+        # fixture too, and agree with where floor() stops returning points.
+        y_h = self.ct.horizon_y(W / 2)
+        self.assertIsNone(self.ct.floor(W / 2, y_h - 2))
+        self.assertIsNotNone(self.ct.floor(W / 2, y_h + 8))
+
+    def test_threejs_view_offset_recentres_principal_point(self):
+        d = sc.solve(synthetic_measurements(camera_looking(38, -3.0))).to_dict()
+        t = d["threejsViewOffset"]
+        # cutting (offsetX, offsetY, w, h) out of the full frame puts the
+        # principal point back at the stored pixel position
+        self.assertAlmostEqual(t["fullWidth"] / 2 - t["offsetX"], d["principalPoint"][0], places=1)
+        self.assertAlmostEqual(t["fullHeight"] / 2 - t["offsetY"], d["principalPoint"][1], places=1)
 
     def test_depth_sensitivity_grows_toward_horizon(self):
         low = self.cam.depth_sensitivity(W / 2, H - 20)

--- a/grimoire/intake/box_calibration.md
+++ b/grimoire/intake/box_calibration.md
@@ -1,0 +1,57 @@
+# Box-object self-calibration — measured proportions for the object pipeline
+
+`forge/stage1_intake/box_calibration.py`. The scene profile's central
+observation — orthogonal straight-line families calibrate the camera — spills
+over to one class of OBJECT: box-dominant subjects (tank hulls, cabinets,
+containers, buildings, machine housings). Their own edges provide the two or
+three orthogonal families that a lone organic object cannot, so the camera
+becomes solvable and the payoff lands exactly on the object pipeline's weakest
+step: **proportions stop being eyeballed into the spec and become measured
+ratios with reprojection residuals.**
+
+## When to reach for it
+
+- The subject's silhouette is dominated by straight, parallel edge pairs on at
+  least TWO of its principal axes (>= 2 clean edges per family).
+- You are about to write width/height/depth ratios into an ObjectSculptSpec by
+  eye. Don't — harvest the edges, run the solver, and copy the measured ratios.
+
+## When NOT to
+
+- One usable family only (a slab seen face-on, a mostly-organic subject with a
+  single straight feature). The solver refuses with routing advice rather than
+  guessing — that case stays with the floor-grid scene route (if a patterned
+  ground is visible) or the honest eyeball route (`solve_camera_pose.py`).
+- Curved-hull subjects (cars): the "edges" you can harvest are not straight
+  world lines; the residual gate will tell you, but don't fight it.
+
+## What you get
+
+```json
+{"calibration": {"route": "three-family orthocentre", "focalPx": ...,
+                 "fPairwiseSpread": ..., "verdict": "pass|warn|fail"},
+ "box": {"gauge": "dimension along x = 1",
+         "dimensions": {"x": 1.0, "y": 0.4603, "z": 0.5873},
+         "perCorner": [...], "uniformShiftPx": ..., "diagnosis": [...]},
+ "scale": {"dimensionsMetres": ...}}
+```
+
+- With 3 families: f AND the principal point are both solved (orthocentre).
+  The three pairwise f estimates must agree (`fPairwiseSpread` gate) — that is
+  the same honesty device as the scene solver's pitch-agreement gate.
+- With 2 families: the third axis is ASSUMED image-parallel and the output says
+  so (same constraint as the scene solver's horizon route).
+- Corner residuals are decomposed into a uniform shift (suspect the
+  calibration) and local residuals (that corner reading or lattice tag is
+  wrong) — the same one-cause-vs-local diagnosis as `scene_backproject.py`.
+- Absolute scale needs one known dimension (a published hull length, a track
+  pitch x link count). Without it, dimensions are ratios and are labelled so.
+
+## Relationship to the rest of intake
+
+This is an opt-in stage-1 measurement, not a new profile: run it during the
+object pipeline's intake (before spec authoring), and feed `box.dimensions`
+into the spec's component sizes. Contracts shared with the scene route live in
+`grimoire/scene/reconstruction.md` and the trap catalogue in
+`grimoire/scene/traps.md` (principal point, column-major rotation, stability
+tests — all apply verbatim).

--- a/grimoire/intake/validation_rubric.md
+++ b/grimoire/intake/validation_rubric.md
@@ -22,7 +22,7 @@ Use this reference when the suitability decision is unclear.
 ## Reject
 
 - target object is ambiguous
-- photo is a scene, not an object reference
+- photo is a scene, not an object reference — **route to the `scene` profile instead of rejecting** (`grimoire/scene/reconstruction.md`): interiors and built spaces carry their own calibration (orthogonal architectural lines + a repeated floor pattern), so they get a solved camera and reprojection gates rather than the object track
 - important shape is hidden, cropped, blurred, or transparent
 - request demands exact mesh extraction or manufacturing-grade dimensions
 - object relies primarily on smoke, liquid, glass caustics, or lace (no reconstruction path exists for these)

--- a/grimoire/scene/reconstruction.md
+++ b/grimoire/scene/reconstruction.md
@@ -1,0 +1,74 @@
+# Scene reconstruction (img2threejsScene profile)
+
+Rebuild an INTERIOR OR BUILT SPACE seen in one photograph as a procedural
+Three.js scene. This inverts the object pipeline's economics:
+
+|                | object                     | scene                                  |
+| -------------- | -------------------------- | -------------------------------------- |
+| decomposition  | easy — one part tree       | hard — shell + openings + fixtures + props + lights |
+| camera         | NOT recoverable → fit by eye | recoverable → solved by arithmetic   |
+| verification   | side-by-side sheet, agent vision | REPROJECTION — pixels, not opinions |
+
+The whole profile follows from one observation: **a built space is its own
+calibration target.** Floors, walls and openings supply bundles of straight
+lines in two or three mutually orthogonal directions, and a repeated floor
+pattern (tiles, boards, paving) supplies scale. So "fit the camera until it
+looks right" — the only option for a lone object — is replaced by "solve the
+camera, then never argue with it".
+
+## Order of work
+
+1. **Line harvest** (agent vision). Collect pixel segments for the two floor
+   directions, and for vertical architectural edges if any are crisp. The agent
+   sees; the scripts do arithmetic. Segments from furniture silhouettes and
+   reflections are the main contamination — prefer grout lines, skirting, and
+   wall/floor junctions.
+2. **Camera solve** — `forge/stage1_intake/scene_camera.py`. Two orthogonal
+   floor vanishing points give the horizon; the vertical direction decides
+   whether the principal point is the 3-VP orthocentre or is constrained to the
+   horizon (see `traps.md` on which route you are actually in). Scale comes from
+   the floor repeat. The solve carries its own gates: VP residuals, the
+   **pitch-agreement gate** (square tiles must report the same repeat in both
+   directions — a disagreement IS your scale uncertainty, report it, do not
+   average it away silently), and a leave-one-out stability gate on the 3-VP
+   focal length.
+3. **Back-projection** — `scene_backproject.py`. Every prop is placed by its
+   FLOOR CONTACT pixel, back-projected to the plan. Heights come from vertical
+   lines standing on those contacts. Each placement carries a
+   **depth-sensitivity** number (floor units per pixel of reading error) and a
+   confidence tier; near the horizon the tier says `horizon-limited` and the
+   placement is a recorded guess, not a measurement.
+4. **Unit sanity** — `scene_unit_gate.py`. Absolute scale is NOT recoverable
+   from one image. Propose metres-per-repeat and test every independently
+   measured height against architectural bands **conjunctively** (door head AND
+   worktop AND cornice AND camera height). One hard failure kills the proposal.
+5. **Build** the shell (floor, walls with the mouldings toolkit, ceiling), the
+   openings, then props at the measured plan positions.
+6. **Verify by reprojection.** Project the built geometry through the solved
+   camera back into reference pixels. The reprojection check decomposes error
+   into a UNIFORM shift (one cause — almost always the camera) and per-landmark
+   residuals (that placement is wrong). Do not eyeball a comparison sheet for
+   placement; pixels decide.
+
+## What a scene spec needs that ObjectSculptSpec lacks
+
+- `shell` — floor polygon, wall bands (plinth / dado / panel field / frieze /
+  cornice heights), ceiling treatment.
+- `openings` — doorways and windows: which wall, position along it, head
+  height, and what lies beyond (a glowing cell reads better than a void).
+- `fixtures` — things attached to walls (panelling, paintings, sconces).
+- `props` — free-standing furniture: floor contact (x, z), yaw, and overall
+  height, each with the confidence tier from back-projection.
+- `lights` — with EVIDENCE. Interior light placement is an identity feature:
+  state which surfaces are bright (undersides bright = the floor is the
+  emitter) rather than importing a studio rig.
+
+## Honesty requirements
+
+- The camera solve is measured; SAY SO, and keep the solved values apart from
+  assumed ones (principal-point x, the room behind the camera, hidden faces).
+- Everything behind the camera is invention. Record the assumed plan shape.
+- Absolute scale is a proposal that passed a plausibility gate, not a fact.
+- Do not reproduce identifiable artwork (paintings, posters) from the
+  reference; place procedural stand-ins with the same compositional statistics
+  and say that is what they are.

--- a/grimoire/scene/traps.md
+++ b/grimoire/scene/traps.md
@@ -1,0 +1,81 @@
+# Scene traps — each one cost a correction cycle before it was named
+
+Every entry below was hit for real during the profile's motivating
+reconstruction (a 1536x691 film-still interior). They share a nasty property:
+**each looks like a modelling error and is not one.**
+
+## 1. The principal point is not the centre of the frame
+
+Film stills, published screenshots, and social-media crops are almost never the
+full sensor frame. The motivating still carried its principal point 90px below
+centre. Two consequences:
+
+- Symptom: EVERY reprojected landmark is offset by the same vector. The reflex
+  is to move the furniture; the cause is one number. The reprojection check in
+  `scene_backproject.py` names this ("uniform shift") precisely so nobody spends
+  a cycle chasing placements.
+- Three.js cannot express it with a plain `PerspectiveCamera`: build the camera
+  with the FOV of a larger virtual frame whose centre IS the principal point,
+  then cut the real frame out of it with `camera.setViewOffset(fullW, fullH,
+  offsetX, offsetY, viewW, viewH)`.
+
+## 2. World axes go in the COLUMNS of world-to-camera
+
+Building R with the world basis vectors as rows silently transposes the frame.
+The evil part is the error signature: near-field points stay almost correct and
+far points stretch (~1.7x in the motivating case), so the room "comes out too
+long" and it reads as a proportion mistake. If distances measured on the floor
+grow with depth, check the rotation layout before touching any geometry.
+
+## 3. "The verticals converge" is a claim that needs a stability test
+
+Two nearly vertical edges always intersect SOMEWHERE. Whether that intersection
+means anything is a noise question, and the eye cannot answer it. Measured on a
+synthetic fixture: with 3 degrees of camera pitch and 0.8px of endpoint noise,
+the 3-VP orthocentre collapsed the focal length from 772 to 259 — a 3x error
+from sub-pixel noise. The solver therefore gates the 3-VP route on a
+leave-one-out spread of the DERIVED FOCAL LENGTH (not of the vanishing point,
+whose distance is unbounded and meaningless as a scale) and falls back to the
+horizon-constrained route when unstable. The fallback absorbs true pitch into
+the principal point — fine for back-projection, but it means the reported
+"pitch" is not the physical camera pitch; do not quote it as one.
+
+## 4. Wall orientation must come from the interior normal
+
+Deriving a wall's rotation from its edge direction alone flips half the walls
+of any non-convex or many-sided plan; with backface culling they vanish into
+black. Compute the normal, dot it with (room centre - wall midpoint), and
+negate if needed. The symptom (black wall) misleads toward lighting/material
+debugging.
+
+## 5. Frames and door surrounds need real holes
+
+A frame drawn as a solid slab in front of a canvas/doorway reads as a blank
+plate from any oblique angle. Extrude a ring (outer shape with the inner shape
+as a `THREE.Path` hole). Same rule for archway surrounds.
+
+## 6. The light source may BE the scene
+
+Interior identity often lives in nonstandard lighting — the motivating room is
+lit by its own floor. The evidence is directional: undersides of furniture
+bright, cornice shadow soft and upward. Importing a default studio rig destroys
+the likeness even when every measurement is right. State the light hypothesis
+in the spec with its evidence, and light the model that way (emissive floor +
+upward area light, in that case).
+
+## 7. Contacts near the horizon are not measurements
+
+Depth sensitivity scales like the SQUARE of the inverse distance to the
+horizon line: at the motivating frame's resolution, a reading 60px under the
+horizon moved ~0.2 floor units per pixel. The gate tiers these as
+`horizon-limited` — record them, model from them if nothing better exists, but
+never report them as measured, and never "fix" a 30px reprojection error there
+by dragging furniture.
+
+## 8. A scene fails the object rubric — route it, don't force it
+
+`grimoire/intake/validation_rubric.md` rejects "photo is a scene, not an
+object reference" for the OBJECT pipeline, and that stays correct. The scene
+profile is the routing answer: shell/openings/fixtures/props decomposition,
+solved camera, reprojection gates. Do not push a scene through the object
+spec; do not reject it either.


### PR DESCRIPTION
## Summary

The object rubric rejects "photo is a scene, not an object reference" by design, and that stays correct for the object track. This PR adds the routing answer instead of the rejection: a `scene` profile whose premise is that **a built space is its own calibration target**. Interiors and streets carry orthogonal architectural line families plus a repeated floor pattern, so the camera becomes *solvable* — and "fit by eye" is replaced end-to-end by "solve, back-project, verify by reprojection". The same mathematics then spills over to box-dominant objects (tanks, cabinets, containers, buildings), whose own edges provide the families a lone object lacks, turning ObjectSculptSpec proportions from eyeballed guesses into measured ratios.

The profile was developed against a real reconstruction (a 1536x691 film-still interior): floor contacts reprojected to 0.5px, monolith corners to 4-6px, and every gate in this PR exists because its failure mode was actually hit there.

All scripts are pure Python 3.10+ stdlib (no pip, no PIL/numpy), per CONTRIBUTING. Scripts enforce, the model judges: line segments come from agent vision, arithmetic and gating are deterministic.

## Changes

- `forge/stage1_intake/scene_camera.py` — camera solve from two orthogonal floor line families. 2-VP horizon route (verticals parallel within their own noise -> principal point constrained to the horizon, `f = sqrt(|p-v1||p-v2|)`) and a 3-VP orthocentre route gated on **leave-one-out stability of the derived focal length** — measured on the synthetic fixture, 0.8px endpoint noise at 3 deg pitch collapsed f from 772 to 259 before that gate existed. Pitch-agreement gate: square floor repeats must agree between families; disagreement is reported as scale uncertainty (warn/fail), never silently averaged. Emits a `threejsViewOffset` block (off-centre principal points cannot be expressed by a plain `PerspectiveCamera`; `setViewOffset` numbers come from the tool).
- `forge/stage1_intake/scene_backproject.py` — props placed from floor-contact pixels with per-landmark depth sensitivity (tiers `measured` / `approximate` / `horizon-limited`); reprojection error decomposed into a uniform component (one cause — almost always the camera) vs local residuals (that placement is wrong), so a 90px uniform shift never again reads as "all the furniture is misplaced".
- `forge/stage1_intake/scene_unit_gate.py` — absolute scale is unrecoverable from one image; a proposed metres-per-repeat is tested conjunctively against architectural height bands (>= 3 in-band to pass, one hard failure kills).
- `forge/stage1_intake/box_calibration.py` — the spillover: 3 edge families -> orthocentre calibration (f and principal point, gated on pairwise-f agreement); 2 families -> horizon-line rule with the assumption stated; 1 family -> refused with routing advice. Box fit by stdlib Gauss-Newton over tagged corner pixels, gauge "x = 1", optional known dimension for metres.
- `grimoire/scene/reconstruction.md` + `grimoire/scene/traps.md` — contracts and the failure catalogue (off-centre principal point; world axes belong in the columns of world-to-camera; "the verticals converge" needs a stability test; interior wall normals; ring holes for frames; the light source may BE the scene; horizon-limited contacts). `grimoire/intake/box_calibration.md` for the object-side guide.
- `forge/_shared/workflow_state.py`, `forge/state.py` — `--profile scene` inserts line-harvest / camera-solve / backprojection / unit-sanity steps.
- `grimoire/intake/validation_rubric.md`, `SKILL.md` — the scene reject line now routes to the profile instead.
- `forge/tests/test_scene_camera.py` (18 tests), `forge/tests/test_box_calibration.py` (8 tests) — synthetic ground-truth cameras in the solver's own pixel convention; both motivating regressions are encoded, including a gate whose only test initially solved the clean measurements instead of the broken ones (kept as a comment: a gate without a failing-input test is not known to fire).

## Validation

- [x] `python3 forge/tests/test_pipeline.py` — 62 tests OK
- [x] `python3 -m unittest discover -s forge/tests -p 'test_*.py'` — full suite OK (skips are the showcase typecheck gates, no showcase checkout)
- [x] Real-data end-to-end on the motivating film-still interior: solver reproduces an independently derived calibration (f 775.2 vs 772.7, principal point identical, camera height 1.18 vs 1.21) and the pitch-agreement gate fires "warn" on the real data's 24% family disagreement — exactly the honesty it was built for.
- [x] Box route: tank-proportioned fixture (6.3 x 2.9 x 3.7) recovers dimension ratios to 1% clean / 5% at 0.7px noise, f to 1%; named bad-corner diagnosis verified.

## Contributor checklist

- [x] This PR keeps the code-only procedural reconstruction contract; it does not silently download meshes or art packs.
- [x] Existing object specs remain valid — the object track is untouched; the scene profile is additive, and `--profile` keeps its previous choices.
- [x] I added or updated tests for new gates, schema fields, or templates where applicable.
- [x] I updated documentation and roadmap status where applicable (SKILL.md, validation rubric, CHANGELOG under Unreleased, grimoire).
