### PR TITLE
fix: force UTF-8 output so the bilingual spec search runs off a UTF-8 console

### DIFF
--- a/forge/_shared/console.py
+++ b/forge/_shared/console.py
@@ -1,0 +1,52 @@
+"""Make a script's stdout/stderr able to carry the text this repo actually prints.
+
+WHY THIS EXISTS. The vocabulary packs under `docs/specs/vocabulary/` are bilingual --
+`core_3d.jsonl` and `cs2.jsonl` carry Vietnamese and Chinese recognition cues alongside the
+English ones -- and the scripts that surface them print with `ensure_ascii=False`, which is the
+right call: escaping every non-ASCII character to `\\uXXXX` would make the snippets unreadable
+for the reader they were written for.
+
+That combination is safe only when the sink can encode the text. `print()` encodes through
+`sys.stdout.encoding`, which Python takes from the environment, and on a default Windows console
+that is cp1252 -- a codec with no mapping for `ạ` (U+1EA1) or `ấ` (U+1EA5). The result is not a
+garbled line, it is `UnicodeEncodeError` raised mid-write, a non-zero exit, and a partially
+written stream. `search_specs.py` is the executable half of the mandatory local-spec-search step,
+so that crash stops the pipeline at stage 1 rather than degrading to a worse-but-working search.
+
+The same fault is reachable anywhere, not just on Windows: `PYTHONIOENCODING=cp1252` reproduces it
+on Linux and in CI, which is how the regression test for it is written.
+
+WHY RECONFIGURE RATHER THAN ESCAPE. Switching these scripts to `ensure_ascii=True` would fix the
+crash by deleting the information -- the bilingual cue becomes unreadable escapes for every
+reader, everywhere, to satisfy one legacy console. Forcing the stream to UTF-8 instead keeps the
+output correct and makes it identical on every platform, which is also what the deterministic
+fingerprints and cached artifacts elsewhere in `forge/` already assume.
+
+`errors="backslashreplace"` is a second belt: if a stream cannot be reconfigured at all (a wrapped
+or already-detached stdout), any character it still cannot represent degrades to a visible escape
+instead of killing the process. A gate should fail on its own findings, never on its own output.
+"""
+
+from __future__ import annotations
+
+import sys
+
+__all__ = ["enable_utf8_output"]
+
+
+def enable_utf8_output() -> None:
+    """Force UTF-8 on stdout/stderr for the current process.
+
+    Idempotent, never raises, and a no-op on streams that do not support reconfiguration
+    (`io.StringIO` under test capture, a detached stream, a non-text sink).
+    """
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="backslashreplace")
+        except (OSError, ValueError):
+            # A detached or already-closed stream cannot be reconfigured. Printing is then
+            # someone else's problem; refusing to start over it would be worse.
+            continue

--- a/forge/stage1_intake/search_specs.py
+++ b/forge/stage1_intake/search_specs.py
@@ -15,6 +15,7 @@ from typing import Final, TypeAlias, TypedDict
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
+from forge._shared.console import enable_utf8_output  # noqa: E402
 from forge._shared.spec_search import (  # noqa: E402
     CacheReadError,
     CacheValidationError,
@@ -174,6 +175,9 @@ def _emit_error(context: ErrorContext, failure: CliFailure) -> int:
 
 
 def main(argv: Sequence[str]) -> int:
+    # Before argparse, so `--help` (which the bilingual descriptions also reach) and every
+    # payload below leave this process as UTF-8 regardless of the console's own codec.
+    enable_utf8_output()
     json_requested = "--json" in argv
     try:
         options = _parse_options(argv)

--- a/forge/tests/test_pipeline.py
+++ b/forge/tests/test_pipeline.py
@@ -73,12 +73,12 @@ class PipelineTest(unittest.TestCase):
                 "--out", self.assessment)
         self.assertEqual(r.returncode, 0, r.stderr)
         self.assertTrue(self.assessment.exists())
-        self.assertIn("qualityContract", json.loads(self.assessment.read_text()))
+        self.assertIn("qualityContract", json.loads(self.assessment.read_text(encoding="utf-8")))
 
         r = run("stage2_spec/new_sculpt_spec.py", "Oak", "--assessment", self.assessment,
                 "--out", self.spec)
         self.assertEqual(r.returncode, 0, r.stderr)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         self.assertEqual(spec["schemaVersion"], "2.1")
         self.assertEqual(spec["targetName"], "Oak")
 
@@ -90,7 +90,7 @@ class PipelineTest(unittest.TestCase):
             self.assessment,
         )
         self.assertEqual(r.returncode, 0, r.stderr)
-        assessment = json.loads(self.assessment.read_text())
+        assessment = json.loads(self.assessment.read_text(encoding="utf-8"))
         search = assessment["localSpecSearch"]
         self.assertEqual(search["collection"], "cs2")
         self.assertEqual(search["query"], "Karambit Fade")
@@ -107,7 +107,7 @@ class PipelineTest(unittest.TestCase):
             self.spec,
         )
         self.assertEqual(r.returncode, 0, r.stderr)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         self.assertEqual(spec["localSpecSearch"]["collection"], "cs2")
         self.assertTrue(spec["localSpecSearch"]["matches"])
 
@@ -119,7 +119,7 @@ class PipelineTest(unittest.TestCase):
             self.assessment,
         )
         self.assertEqual(r.returncode, 0, r.stderr)
-        assessment = json.loads(self.assessment.read_text())
+        assessment = json.loads(self.assessment.read_text(encoding="utf-8"))
         self.assertEqual(assessment["localSpecSearch"]["collection"], "core_3d")
 
     def test_normal_validate_passes_strict_fails_on_shallow(self):
@@ -136,7 +136,7 @@ class PipelineTest(unittest.TestCase):
 
     def test_topology_rejects_missing_classification(self):
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         del spec["componentTree"][0]["topologyClass"]
         del spec["componentTree"][0]["topologyRationale"]
         self.spec.write_text(json.dumps(spec))
@@ -146,7 +146,7 @@ class PipelineTest(unittest.TestCase):
 
     def test_topology_rejects_restated_rationale(self):
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         spec["componentTree"][0]["topologyClass"] = "assembled-solid"
         spec["componentTree"][0]["topologyRationale"] = "Assembled Solid"
         self.spec.write_text(json.dumps(spec))
@@ -156,7 +156,7 @@ class PipelineTest(unittest.TestCase):
 
     def test_topology_rejects_disallowed_continuous_sculpt_pairing(self):
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         spec["componentTree"][0]["primitive"] = "box"
         spec["componentTree"][0]["topologyClass"] = "continuous-sculpt"
         spec["componentTree"][0]["topologyRationale"] = "Smooth organic bulge with no seams."
@@ -167,7 +167,7 @@ class PipelineTest(unittest.TestCase):
 
     def test_topology_rejects_disallowed_fiber_strand_pairing(self):
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         spec["componentTree"][0]["primitive"] = "plane-card"
         spec["componentTree"][0]["topologyClass"] = "fiber-strand"
         spec["componentTree"][0]["topologyRationale"] = "Thin repeated strand form."
@@ -178,7 +178,7 @@ class PipelineTest(unittest.TestCase):
 
     def test_topology_accepts_all_six_classes_with_allowed_primitives(self):
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         cases = [
             ("continuous-sculpt", "lathe"),
             ("assembled-solid", "box"),
@@ -210,7 +210,7 @@ class PipelineTest(unittest.TestCase):
         # as "1.0" (round(1.0, 3) -> the float 1.0, not the bare int 1). RGBA_PATTERN must
         # accept that exact format, or every real extracted recipe fails its own validator.
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         spec["componentTree"][0]["colorMaterialRecipe"] = {
             "dominantAlbedo": "rgba(21, 87, 78, 1.0)",
             "secondaryAlbedo": "rgba(34, 67, 67, 1.0)",
@@ -341,7 +341,7 @@ class PipelineTest(unittest.TestCase):
 
     def test_dense_component_enables_height_maps_when_shared_material_is_plain(self):
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         component = spec["componentTree"][0]
         component["geometryDensity"] = "dense"
         spec["materials"][0].pop("geometryDensity", None)
@@ -390,7 +390,7 @@ class PipelineTest(unittest.TestCase):
         # generic box. Confirms all three previously-unimplemented primitives now
         # produce real geometry-builder calls instead of raising or falling back.
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         spec["componentTree"][0]["primitive"] = "extrude"
         spec["componentTree"][0]["topologyClass"] = "continuous-sculpt"
         spec["componentTree"][0]["topologyRationale"] = "Blade tapering to a single sharp point."
@@ -422,7 +422,7 @@ class PipelineTest(unittest.TestCase):
         # unconditionally even when no component in the pass used lathe/tube. Only
         # the primitives actually present should get a helper function.
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         spec["componentTree"][0]["primitive"] = "extrude"
         spec["componentTree"][0]["topologyClass"] = "continuous-sculpt"
         spec["componentTree"][0]["topologyRationale"] = "Blade tapering to a single sharp point."
@@ -444,7 +444,7 @@ class PipelineTest(unittest.TestCase):
         # resolves to its base geometry (default box) so a component may declare it without
         # crashing. The instancing itself is applied by repetition systems (test below).
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         spec["componentTree"][0]["primitive"] = "instanced-cluster"
         self.spec.write_text(json.dumps(spec))
         out = self.dir / "createOakModel.ts"
@@ -456,7 +456,7 @@ class PipelineTest(unittest.TestCase):
         # Repeated parts (teeth/fasteners/spokes) must render as ONE THREE.InstancedMesh
         # (single draw call), not a per-instance Mesh clone loop (real-time perf principle).
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         first_mat = (spec.get("materials") or [{}])[0].get("id", "base")
         spec["repetitionSystems"] = [{
             "id": "teeth", "level": "macro", "parent": "root", "count": 8,
@@ -490,7 +490,7 @@ class PipelineTest(unittest.TestCase):
         # reads correctly from every angle (the karambit-blade fix). Must emit a real
         # extrudePath + CatmullRomCurve3, only when a component uses curve-sweep.
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         spec["componentTree"][0]["primitive"] = "curve-sweep"
         spec["componentTree"][0]["topologyClass"] = "continuous-sculpt"
         spec["componentTree"][0]["topologyRationale"] = "Hooked blade curving through space."
@@ -520,7 +520,7 @@ class PipelineTest(unittest.TestCase):
         # ±0.12. An off-origin blade (y~0.4) with the old formula clamped v→1 so every face sampled
         # the bright spine-rim row → white/washed tip facets. Corrected UV = (y - yMin) / yH.
         run("stage2_spec/new_sculpt_spec.py", "Blade", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         c = spec["componentTree"][0]
         c["primitive"] = "ground-blade"
         c["topologyClass"] = "continuous-sculpt"
@@ -542,7 +542,7 @@ class PipelineTest(unittest.TestCase):
         # a cutout (wire-cutter oval hole) is done via THREE.Shape.holes — dep-free, no
         # three-bvh-csg. The generator must emit hole-handling + oval-loop support on extrude.
         run("stage2_spec/new_sculpt_spec.py", "Blade", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         c = spec["componentTree"][0]
         c["primitive"] = "extrude"
         c["topologyClass"] = "continuous-sculpt"
@@ -566,7 +566,7 @@ class PipelineTest(unittest.TestCase):
         # THIN straight extrude (flat slab) must be flagged before render; the same form
         # with real thickness must not.
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         c = spec["componentTree"][0]
         c["primitive"] = "extrude"
         c["topologyClass"] = "continuous-sculpt"
@@ -588,7 +588,7 @@ class PipelineTest(unittest.TestCase):
 
     def test_generate_factory_emits_color_gradient_codegen(self):
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         spec["materials"][0]["colorGradient"] = {
             "type": "linear",
             "axis": [1.0, 0.0],
@@ -630,7 +630,7 @@ class PipelineTest(unittest.TestCase):
             "formDetail": 0.75, "materialSurface": 0.7, "lightingCamera": 0.8,
         })
         # every critical feature target of this pass needs an AI-vision review entry
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         targets = spec.get("selfCorrectLoop", {}).get("featureReviewTargets", [])
         reviews = [
             {"id": t.get("id"), "score": 0.8, "visible": True, "notes": "acceptable"}
@@ -647,7 +647,7 @@ class PipelineTest(unittest.TestCase):
                 "--feature-reviews-json", freviews,
                 "--camera-view", "front", "--in-place")
         self.assertEqual(r.returncode, 0, r.stderr)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         self.assertTrue(len(spec.get("reviewHistory", [])) >= 1)
 
     def test_pbr_extraction_runs(self):
@@ -666,7 +666,7 @@ class PipelineTest(unittest.TestCase):
             "--out", self.assessment)
         run("stage2_spec/new_sculpt_spec.py", "Widget", "--assessment", self.assessment,
             "--out", self.spec)
-        return json.loads(self.spec.read_text())
+        return json.loads(self.spec.read_text(encoding="utf-8"))
 
     def test_new_schema_fields_present(self):
         spec = self._fresh_spec("complex")
@@ -743,7 +743,7 @@ class PipelineTest(unittest.TestCase):
         self.assertIn("dominantAlbedo", recipe)
         self.assertTrue(recipe["dominantAlbedo"].startswith("rgba("))
         self.assertIn("materialClass", recipe)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         self.assertIn("colorMaterialRecipe", spec["componentTree"][0])
         self.assertEqual(spec["componentTree"][0]["colorMaterialRecipe"]["dominantAlbedo"], recipe["dominantAlbedo"])
 
@@ -771,7 +771,7 @@ class PipelineTest(unittest.TestCase):
         # include that person's specific traits (glasses/headphones/chest decal) unless the
         # caller opts in with --accessories. See new_sculpt_spec.py make_character_component_tree.
         run("stage2_spec/new_sculpt_spec.py", "Person", "--character", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         ids = {c["id"] for c in spec["componentTree"]}
         for part in (
             "root", "head", "abdomen", "chest", "neck", "hair",  # spine is two segments (US-001)
@@ -818,7 +818,7 @@ class PipelineTest(unittest.TestCase):
     def test_character_accessories_flag_restores_bust_traits(self):
         run("stage2_spec/new_sculpt_spec.py", "Person", "--character", "--accessories",
             "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         ids = {c["id"] for c in spec["componentTree"]}
         for accessory in ("glasses-frame-l", "hp-band", "shirt-decal"):
             self.assertIn(accessory, ids)
@@ -832,7 +832,7 @@ class PipelineTest(unittest.TestCase):
         without any flag, and the old mitten ids do not come back.
         """
         run("stage2_spec/new_sculpt_spec.py", "Person", "--character", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         ids = {c["id"] for c in spec["componentTree"]}
         for side in ("l", "r"):
             for digit in ("thumb", "index", "middle", "ring", "little"):
@@ -847,11 +847,11 @@ class PipelineTest(unittest.TestCase):
 
     def test_character_autodetect_from_domain(self):
         run("stage2_spec/new_pre_spec_assessment.py", "Person", "--complexity", "complex", "--out", self.assessment)
-        a = json.loads(self.assessment.read_text())
+        a = json.loads(self.assessment.read_text(encoding="utf-8"))
         a["preSpecAssessment"]["objectClass"]["primaryDomain"] = "character"
         self.assessment.write_text(json.dumps(a))
         run("stage2_spec/new_sculpt_spec.py", "Person", "--assessment", self.assessment, "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         self.assertIn("head", {c["id"] for c in spec["componentTree"]})
 
     def test_character_factory_generates(self):
@@ -867,7 +867,7 @@ class PipelineTest(unittest.TestCase):
         # Author a Doppler-style (anodized-multicolored) CS2 skin, image-first.
         run("stage2_spec/new_sculpt_spec.py", "Karambit Doppler", "--cs2",
             "--finish-style", "anodized-multicolored", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         finish = next(m for m in spec["materials"] if m["id"] == "skin-finish")
         # view-dependent PBR: high metalness, low roughness, strong environment
         self.assertGreaterEqual(finish["metalness"]["base"], 0.9)
@@ -887,13 +887,13 @@ class PipelineTest(unittest.TestCase):
 
     def test_cs2_track_skipped_for_objects(self):
         run("stage2_spec/new_sculpt_spec.py", "Crate", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         self.assertNotIn("skin-finish", {m["id"] for m in spec["materials"]})
 
     def test_cs2_intent_autodetected_from_target_name(self):
         r = run("stage2_spec/new_pre_spec_assessment.py", "Karambit | Doppler", "--out", self.assessment)
         self.assertEqual(r.returncode, 0, r.stderr)
-        payload = json.loads(self.assessment.read_text())
+        payload = json.loads(self.assessment.read_text(encoding="utf-8"))
         self.assertTrue(payload["preSpecAssessment"]["objectClass"]["cs2"])
 
     def test_cs2_defaults_to_ultra_complex(self):
@@ -901,25 +901,25 @@ class PipelineTest(unittest.TestCase):
         # ultra-complex (targetMinDetails 16) in both the assessment and the authored spec.
         r = run("stage2_spec/new_pre_spec_assessment.py", "Karambit | Doppler", "--out", self.assessment)
         self.assertEqual(r.returncode, 0, r.stderr)
-        pre = json.loads(self.assessment.read_text())["preSpecAssessment"]
+        pre = json.loads(self.assessment.read_text(encoding="utf-8"))["preSpecAssessment"]
         self.assertEqual(pre["complexity"]["tier"], "ultra-complex")
         self.assertEqual(pre["detailInventory"]["targetMinDetails"], 16)
         run("stage2_spec/new_sculpt_spec.py", "Karambit Doppler", "--cs2", "--out", self.spec)
-        spec_pre = json.loads(self.spec.read_text())["preSpecAssessment"]
+        spec_pre = json.loads(self.spec.read_text(encoding="utf-8"))["preSpecAssessment"]
         self.assertEqual(spec_pre["complexity"]["tier"], "ultra-complex")
         self.assertEqual(spec_pre["detailInventory"]["targetMinDetails"], 16)
         # an explicit lower --complexity still honors the 9 detail floor
         r2 = run("stage2_spec/new_pre_spec_assessment.py", "Bayonet skin", "--cs2",
                  "--complexity", "simple", "--out", self.assessment, "--force")
         self.assertEqual(r2.returncode, 0, r2.stderr)
-        low = json.loads(self.assessment.read_text())["preSpecAssessment"]
+        low = json.loads(self.assessment.read_text(encoding="utf-8"))["preSpecAssessment"]
         self.assertEqual(low["detailInventory"]["targetMinDetails"], 9)
 
     def test_cs2_identity_precedence_flags_conflict(self):
         # skin name implies anodized-multicolored (Doppler); vision disagrees with patina.
         run("stage2_spec/new_sculpt_spec.py", "Item", "--cs2", "--skin-name", "Karambit Doppler",
             "--vision-finish-style", "patina", "--vision-confidence", "0.9", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         self.assertEqual(spec["cs2Finish"]["finishStyle"], "anodized-multicolored")
         unknowns = spec["preSpecAssessment"]["unknownsToResolveBeforeImplementation"]
         self.assertTrue(any("conflict" in u.lower() for u in unknowns))
@@ -927,7 +927,7 @@ class PipelineTest(unittest.TestCase):
     def test_cs2_float_and_paint_seed_drive_wear_and_placement(self):
         run("stage2_spec/new_sculpt_spec.py", "Karambit", "--cs2", "--finish-style", "patina",
             "--float", "0.7", "--paint-seed", "12345", "--out", self.spec)
-        spec = json.loads(self.spec.read_text())
+        spec = json.loads(self.spec.read_text(encoding="utf-8"))
         finish = next(m for m in spec["materials"] if m["id"] == "skin-finish")
         self.assertFalse(finish["wear"]["approximated"])
         self.assertGreater(finish["wear"]["edgeWear"], 0.5)

--- a/forge/tests/test_search_specs.py
+++ b/forge/tests/test_search_specs.py
@@ -16,6 +16,7 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[2]
 SPEC_SEARCH_PATH = ROOT / "forge/_shared/spec_search.py"
+CONSOLE_PATH = ROOT / "forge/_shared/console.py"
 SEARCH_SPECS_CLI = ROOT / "forge/stage1_intake/search_specs.py"
 SPEC_SEARCH_SPEC = importlib.util.spec_from_file_location("spec_search", SPEC_SEARCH_PATH)
 assert SPEC_SEARCH_SPEC is not None and SPEC_SEARCH_SPEC.loader is not None
@@ -93,6 +94,23 @@ def make_record():
     }
 
 
+def require_symlinks(directory):
+    """Skip a test that needs a real symlink when this host will not create one.
+
+    These three tests assert that the ingester REFUSES symlinked sources and caches -- a
+    path-traversal guard. Creating the symlink is setup, not the assertion, and on Windows it
+    needs Developer Mode or an elevated shell (`OSError: [WinError 1314]`). Letting that surface
+    as an ERROR reports a missing OS privilege as a broken guard, which is the opposite of what
+    the run means: the guard is untested here, not failing.
+    """
+    probe = Path(directory) / ".symlink-probe"
+    try:
+        probe.symlink_to(directory, target_is_directory=True)
+    except (OSError, NotImplementedError) as error:
+        raise unittest.SkipTest(f"symlinks unavailable on this host: {error}") from error
+    probe.unlink()
+
+
 def write_jsonl(path, records):
     rows = (json.dumps(record, ensure_ascii=False, sort_keys=True) for record in records)
     path.write_text("\n".join(rows) + "\n", encoding="utf-8")
@@ -150,6 +168,9 @@ def write_cli_fixture(
     shared.mkdir(parents=True, exist_ok=True)
     intake.mkdir(parents=True, exist_ok=True)
     shutil.copyfile(SPEC_SEARCH_PATH, shared / "spec_search.py")
+    # search_specs.py imports this to force UTF-8 on its own stdout; without it in the fixture
+    # tree the CLI cannot start at all.
+    shutil.copyfile(CONSOLE_PATH, shared / "console.py")
     if SEARCH_SPECS_CLI.is_file():
         shutil.copyfile(SEARCH_SPECS_CLI, intake / "search_specs.py")
 
@@ -226,6 +247,7 @@ def run_cli_fixture(
     malformed_profile=False,
     include_raw_roots=True,
     cache_path=".cache/spec-search/cs2.json",
+    stdout_encoding=None,
 ):
     cli = write_cli_fixture(
         root,
@@ -235,12 +257,20 @@ def run_cli_fixture(
     )
     environment = os.environ.copy()
     environment["PYTHONDONTWRITEBYTECODE"] = "1"
+    if stdout_encoding is not None:
+        # Reproduces a legacy console on ANY host, so the encoding contract is testable on the
+        # Linux CI runner and not only on the Windows machine where it was first hit.
+        environment["PYTHONIOENCODING"] = stdout_encoding
     return subprocess.run(
         [sys.executable, str(cli), *arguments],
         cwd=root,
         env=environment,
         capture_output=True,
         text=True,
+        # The CLI forces its own stdout to UTF-8 (forge/_shared/console.py), so decode it as
+        # UTF-8 here too. `text=True` alone decodes with the PARENT's locale encoding, which
+        # turned the child's correct bilingual output into mojibake on a cp1252 host.
+        encoding="utf-8",
         check=False,
     )
 
@@ -506,6 +536,7 @@ class SourceIngestionTest(unittest.TestCase):
     def test_symlink_source_file_is_rejected_without_indexing_target(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
+            require_symlinks(root)
             source_root = root / "specs"
             source_root.mkdir()
             secret = root / "secret.md"
@@ -523,6 +554,7 @@ class SourceIngestionTest(unittest.TestCase):
     def test_symlink_source_root_is_rejected_without_indexing_target(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
+            require_symlinks(root)
             secret_root = root / "secret"
             secret_root.mkdir()
             (secret_root / "secret.md").write_text(
@@ -915,6 +947,7 @@ class CliOutputTest(unittest.TestCase):
     def test_symlinked_cache_parent_returns_structured_cache_failure(self):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
+            require_symlinks(root)
             cli = write_cli_fixture(root)
             outside = root.parent / f"{root.name}-outside"
             outside.mkdir()
@@ -927,6 +960,7 @@ class CliOutputTest(unittest.TestCase):
                 env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
                 check=False,
             )
 
@@ -1007,6 +1041,27 @@ class CliOutputTest(unittest.TestCase):
         self.assertEqual(repeated.returncode, 0, repeated.stderr)
         self.assertTrue(cached.stdout.strip())
         self.assertEqual(cached.stdout, repeated.stdout)
+
+    def test_bilingual_output_survives_a_legacy_console_encoding(self):
+        """The vocabulary is bilingual, so the CLI must not depend on the console's codec.
+
+        `search_specs.py` prints matches with `ensure_ascii=False`, and the fixture corpus (like
+        the shipped `core_3d`/`cs2` packs) carries Vietnamese. Encoding that through cp1252 raises
+        `UnicodeEncodeError` mid-write: the process dies with a partial stream and a non-zero exit.
+        Because `local-spec-search` is a mandatory checklist step, that is a stage-1 pipeline stop,
+        not a cosmetic glitch -- so it is asserted, for the human path and the JSON path alike.
+        """
+        for arguments in (("roughness", "độ", "nhám"), ("roughness", "độ", "nhám", "--json")):
+            with self.subTest(arguments=arguments):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    root = Path(temporary_directory)
+                    result = run_cli_fixture(root, *arguments, stdout_encoding="cp1252")
+
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertNotIn("UnicodeEncodeError", result.stderr)
+                # Not merely "did not crash": the bilingual text has to arrive intact, which is
+                # the whole reason ensure_ascii=False is used in the first place.
+                self.assertIn("nhám", result.stdout)
 
     def test_validation_and_profile_errors_have_documented_codes(self):
         scenarios = (


### PR DESCRIPTION
## What this changes

`search_specs.py` dies with `UnicodeEncodeError` on any console whose codec cannot encode the vocabulary packs, which blocks the mandatory `local-spec-search` step at stage 1. This forces the process's own stdout/stderr to UTF-8 instead.

Refs #107

## Why it happens

The vocabulary is bilingual by design — `docs/specs/vocabulary/core_3d.jsonl` and `cs2.jsonl` carry Vietnamese and Chinese recognition cues — and the CLI prints matches with `ensure_ascii=False` so those cues stay readable. `print()` encodes through `sys.stdout.encoding`, which Python takes from the environment. On a default Windows console that is cp1252, which has no mapping for `ạ` (U+1EA1), so the write raises mid-stream:

```
1. core.shader-mapping-torusgeometry-rings-loops  score=3.760685
   source: docs/raw/img2threejs-skill-dataset.json :: ...
UnicodeEncodeError: 'charmap' codec can't encode character '\u1ea1' in position 31
```

It is not Windows-only — `PYTHONIOENCODING=cp1252` reproduces it anywhere, which is why CI has never seen it.

## Why reconfigure rather than escape

Switching to `ensure_ascii=True` would fix the crash by deleting the information: the bilingual cue becomes unreadable `\uXXXX` escapes for every reader, everywhere, to satisfy one legacy console. Forcing the stream to UTF-8 keeps the output correct and makes it byte-identical across platforms — which the deterministic fingerprints and cached artifacts elsewhere in `forge/` already assume.

The helper lives in `forge/_shared/console.py` so other scripts can adopt it; it is stdlib-only, idempotent, and a no-op on streams that cannot be reconfigured.

## Also in this PR

- **The same fault in the other direction.** Assessment and spec artifacts are written as UTF-8 but read back with `Path.read_text()`, which decodes through the host locale. That raised `UnicodeDecodeError` on the one artifact embedding bilingual search results (`test_cs2_assessment_embeds_local_spec_search_results`). Those reads are now explicit, and the CLI subprocess helper decodes as UTF-8 to match what the CLI now guarantees.
- **Three symlink tests no longer error on hosts without symlink privilege.** They assert that the ingester *refuses* symlinked sources — a path-traversal guard. Creating the symlink is setup, not the assertion, so `OSError: [WinError 1314]` now skips rather than reporting a working guard as broken.

## Testing

New test drives the CLI with `PYTHONIOENCODING=cp1252`, so **this is caught on the Linux CI runner**, not only on the machine where it surfaced. It asserts the bilingual text arrives intact, not merely that nothing crashed — covering the human path and the `--json` path.

Verified it genuinely catches the bug: with `enable_utf8_output()` commented out, the new test fails with the original `UnicodeEncodeError` on both subtests.

```
python3 -m unittest discover -s forge/tests -p 'test_*.py'
Ran 1090 tests ... OK (skipped=41)
```

Before this branch, that same command on this host gave `FAILED (failures=2, errors=4)`.

## Not in this PR

The pattern is broader than the one script: roughly 14 non-test sites under `forge/` and `scripts/` call `read_text()`/`write_text()` with no explicit `encoding=`, and argparse help mangles the same way (`diagnose_render.py --help` prints `diagnostics � run BEFORE` on cp1252). Only the sites that actually carry non-ASCII fail today. I kept this PR to the path that is actually broken and am happy to follow up with the wider sweep if you want it.

## Verification note

The showcase TypeScript gates skip here (no `IMG2THREEJS_SHOWCASE_ROOT`), so this run has not proven the emitted Three.js compiles. This branch touches no codegen, so that gap is not load-bearing for these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
