### PR TITLE
fix: an identity transform.scale no longer discards authored dimensions

### DIFF
--- a/forge/stage3_build/generate_threejs_factory.py
+++ b/forge/stage3_build/generate_threejs_factory.py
@@ -297,8 +297,34 @@ def scale_triple(component: dict[str, Any], transform: dict[str, Any]) -> tuple[
     return (1.0, 1.0, 1.0)
 
 
+def _is_identity_scale(value: Any) -> bool:
+    """True for a scale that multiplies by nothing, so carries no authored information."""
+    return (
+        isinstance(value, (list, tuple))
+        and len(value) == 3
+        and all(isinstance(item, (int, float)) and not isinstance(item, bool) for item in value)
+        and all(float(item) == 1.0 for item in value)
+    )
+
+
 def scale_vector(component: dict[str, Any], transform: dict[str, Any]) -> str:
-    if "scale" in transform:
+    """A part's real size, as the factor its unit-sized geometry is baked with.
+
+    WHY IDENTITY SCALE FALLS THROUGH TO `dimensions`. Both fields can express size, and
+    `transform.scale` used to win merely by BEING PRESENT. That is a trap rather than a
+    precedence rule, because `new_sculpt_spec.py` -- this repo's own scaffold -- writes
+    `"scale": [1, 1, 1]` into every component it emits. An author who then fills in the
+    `dimensions` block the schema asks for (and that `--strict-quality` checks the depth of)
+    gets `geometry.scale(1, 1, 1)`: every part unit-sized, a hammer head the same size as its
+    handle, and `PASS` from the validator, because nothing anywhere compares the two fields.
+    Measured on a five-component spec, all five parts came out unit cubes and cylinders.
+
+    An identity scale multiplies by nothing, so deferring to `dimensions` cannot change any
+    render that did not already have this bug: where `dimensions` is absent or itself unit, the
+    result is the same `1, 1, 1`. A genuinely authored non-uniform scale still wins, which is
+    what `test_hierarchy_scale.py` pins (its torso carries `[3, 1, 0.2]` and no `dimensions`).
+    """
+    if "scale" in transform and not _is_identity_scale(transform.get("scale")):
         return vector(transform.get("scale"), [1, 1, 1])
     dimensions = component.get("dimensions")
     if isinstance(dimensions, dict):

--- a/forge/tests/test_component_dimensions.py
+++ b/forge/tests/test_component_dimensions.py
@@ -1,0 +1,131 @@
+"""A scaffold's identity `transform.scale` must not silently delete authored `dimensions`.
+
+WHAT THIS PINS. `dimensions` and `transform.scale` can both express a part's size, and
+`scale_vector()` used to prefer `transform.scale` merely because the key existed. Since
+`new_sculpt_spec.py` writes `"scale": [1, 1, 1]` into every component it scaffolds, every spec
+authored on top of that scaffold emitted `geometry.scale(1, 1, 1)` -- unit-sized parts -- while
+`validate_sculpt_spec.py --strict-quality` still returned PASS, because no gate compares the two
+fields. A wrong model with a green gate is the failure mode this repo's own
+`GeometryNotImplementedError` docstring calls out: never silently substitute geometry.
+
+The fix is narrow on purpose: an identity scale multiplies by nothing, so it cannot be the
+authored answer when `dimensions` says otherwise. A real non-uniform scale still wins.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "forge" / "_shared"))
+sys.path.insert(0, str(ROOT / "forge" / "stage2_spec"))
+sys.path.insert(0, str(ROOT / "forge" / "stage3_build"))
+
+import generate_threejs_factory as generator  # noqa: E402
+
+NEW_SCULPT_SPEC = ROOT / "forge/stage2_spec/new_sculpt_spec.py"
+
+
+def spec_with(transform: dict, dimensions: dict) -> dict:
+    return {
+        "targetName": "Dimension Probe",
+        "targetId": "dimension-probe",
+        "schemaVersion": "2.1",
+        "suitability": "pass",
+        "coordinateFrame": {"front": "+Z", "up": "+Y", "scaleReference": "unit"},
+        "silhouette": {"boundingShape": "test", "symmetry": "bilateral"},
+        "proceduralStrategy": ["blockout"],
+        "materials": [{"id": "base", "name": "Base", "baseColor": "#808080"}],
+        "buildPasses": [{"id": "blockout", "acceptance": []}],
+        "componentTree": [
+            {
+                "id": "part",
+                "name": "Part",
+                "level": "macro",
+                "role": "body",
+                "primitive": "box",
+                "topologyClass": "assembled-solid",
+                "topologyRationale": "test",
+                "parent": None,
+                "material": "base",
+                "transform": copy.deepcopy(transform),
+                "dimensions": copy.deepcopy(dimensions),
+            }
+        ],
+    }
+
+
+SCAFFOLD_TRANSFORM = {"position": [0, 0, 0], "rotation": [0, 0, 0], "scale": [1, 1, 1]}
+REAL_DIMENSIONS = {"width": 0.52, "height": 0.22, "depth": 0.2, "units": "relative"}
+
+
+class ComponentDimensionsTest(unittest.TestCase):
+    def emit(self, transform: dict, dimensions: dict) -> str:
+        return generator.generate(spec_with(transform, dimensions), "blockout")
+
+    def test_authored_dimensions_survive_a_scaffold_identity_scale(self):
+        """The regression itself: scaffold transform plus real dimensions."""
+        source = self.emit(SCAFFOLD_TRANSFORM, REAL_DIMENSIONS)
+        self.assertIn("Geometry.scale(0.52, 0.22, 0.2);", source)
+        self.assertNotIn("Geometry.scale(1.0, 1.0, 1.0);", source)
+
+    def test_an_authored_non_uniform_scale_still_wins(self):
+        """Backward compatibility. `test_hierarchy_scale.py` builds a rig exactly this way."""
+        transform = {"position": [0, 0, 0], "rotation": [0, 0, 0], "scale": [3.0, 1.0, 0.2]}
+        source = self.emit(transform, REAL_DIMENSIONS)
+        self.assertIn("Geometry.scale(3.0, 1.0, 0.2);", source)
+
+    def test_identity_scale_with_no_dimensions_is_still_identity(self):
+        source = self.emit(SCAFFOLD_TRANSFORM, {})
+        self.assertIn("Geometry.scale(1.0, 1.0, 1.0);", source)
+
+    def test_a_missing_scale_key_still_reads_dimensions(self):
+        source = self.emit({"position": [0, 0, 0], "rotation": [0, 0, 0]}, REAL_DIMENSIONS)
+        self.assertIn("Geometry.scale(0.52, 0.22, 0.2);", source)
+
+    def test_only_an_exact_unit_triple_counts_as_identity(self):
+        """Float ones are identity too; anything that actually scales is left alone."""
+        identity = self.emit(
+            {"position": [0, 0, 0], "rotation": [0, 0, 0], "scale": [1.0, 1.0, 1.0]},
+            REAL_DIMENSIONS,
+        )
+        self.assertIn("Geometry.scale(0.52, 0.22, 0.2);", identity)
+
+        near_identity = self.emit(
+            {"position": [0, 0, 0], "rotation": [0, 0, 0], "scale": [1, 1, 2]},
+            REAL_DIMENSIONS,
+        )
+        self.assertIn("Geometry.scale(1.0, 1.0, 2.0);", near_identity)
+
+    def test_the_scaffold_really_does_emit_an_identity_scale(self):
+        """Guards the premise: if the scaffold stops writing `scale`, this trap is gone with it.
+
+        Kept as a live check rather than a comment, because the fix above is only load-bearing
+        for as long as the scaffold keeps seeding the field.
+        """
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            out = Path(temporary_directory) / "spec.json"
+            result = subprocess.run(
+                [sys.executable, str(NEW_SCULPT_SPEC), "Scale Probe", "--out", str(out)],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            spec = json.loads(out.read_text(encoding="utf-8"))
+
+        components = spec["componentTree"]
+        self.assertTrue(components)
+        for component in components:
+            self.assertEqual(component["transform"].get("scale"), [1, 1, 1], component["id"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this changes

`scale_vector()` returned `transform.scale` on the mere presence of the key, so `dimensions` was only ever read when the field was absent. This makes an **identity** scale fall through to `dimensions`.

Refs #108

## Why this is the default path, not an edge case

`new_sculpt_spec.py` — this repo's own scaffold — writes `"scale": [1, 1, 1]` into every component it emits:

```
$ python3 forge/stage2_spec/new_sculpt_spec.py "Scale Probe" --out spec.json
$ python3 -c "import json;d=json.load(open('spec.json'));print([c['transform'] for c in d['componentTree']])"
[{'position': [0, 0, 0], 'rotation': [0, 0, 0], 'scale': [1, 1, 1]}]
```

So the normal flow — scaffold a spec, author a componentTree, fill in the `dimensions` block the schema asks for and that `--strict-quality` checks the depth of — emits `geometry.scale(1, 1, 1)` for every part. On the five-component spec I hit this with, all five came out unit cubes and cylinders: a hammer head the same size as its handle.

What makes it worth fixing rather than documenting is that **`--strict-quality` returns `PASS`** on those specs, because no gate compares the two fields. A structurally wrong model behind a green gate is the failure mode `GeometryNotImplementedError` in this same file exists to prevent:

> Never silently substitute a box for this case — that produced structurally-wrong renders ... with no signal that anything was wrong.

It also contradicts the generator's own stated contract a few hundred lines down:

> Every other primitive is authored unit-sized in `geometry_for()`; its real dimensions are applied to the vertex data now, not to the pivot's `.scale`.

## Why identity specifically

`[1, 1, 1]` multiplies by nothing, so it cannot be the authored answer when `dimensions` says otherwise. Deferring to `dimensions` cannot change any render that did not already have this bug: where `dimensions` is absent or itself unit, the result is the same `1, 1, 1`.

A genuinely authored non-uniform scale still wins. `test_hierarchy_scale.py` depends on that directly — its torso carries `[3, 1, 0.2]` and no `dimensions` block — and still passes.

I deliberately did **not** change the scaffold to stop emitting the field. Fixing the precedence covers specs already written against the old scaffold too; changing only the scaffold would leave those silently wrong.

## Testing

`forge/tests/test_component_dimensions.py` covers the regression, the backward-compatible non-uniform case, both degenerate cases (no `dimensions`, no `scale` key), the float-`1.0` boundary, and the premise itself — if the scaffold ever stops seeding `transform.scale`, the guard is no longer load-bearing and the test says so rather than passing vacuously.

Re-ran every scale-sensitive test in the suite:

```
test_component_dimensions                      OK
test_hierarchy_scale                           OK (skipped=1)
test_repetition_system_scale                   OK (skipped=1)
test_attachment_does_not_override_primitive    OK
test_humanoid_silhouette_profile               OK (skipped=1)
test_stand_proud_emission                      OK (skipped=1)
test_tapered_sweep                             OK (skipped=3)
test_visual_hull                               OK (skipped=3)
test_primitive_watertightness                  OK (skipped=1)
test_hair_material                             OK (skipped=1)
test_subdivision                               OK (skipped=12)
```

End-to-end on a real spec, with the scaffold's `scale: [1, 1, 1]` left in place exactly as written:

```
before:  mesh_head_1Geometry.scale(1.0, 1.0, 1.0);
after:   mesh_head_1Geometry.scale(0.52, 0.22, 0.2);
```

The emitted factory was then bundled and rendered headlessly. Before the fix the model was unit primitives stacked on each other; after, correct proportions.

## Verification note

The showcase TypeScript gates skip in my environment (no `IMG2THREEJS_SHOWCASE_ROOT`), so the suite alone has not proven the emitted Three.js compiles. Since this touches codegen, I checked that separately: typechecked the generated factory under `tsc --strict` against real `three` + `@types/three` (exit 0), then bundled and rendered it in headless Chromium — 5 meshes, 5,856 triangles, no page errors. Worth a maintainer re-running against the actual showcase before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
