### PR TITLE
feat: gate model space and non-humanoid animation

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -80,6 +80,8 @@ python3 forge/state.py mark <step-id> --state .img2threejs/state.json --evidence
 - one image path / screenshot / URL / attached image (if missing or unreadable, ask)
 - intended use: prop, game object, hero render, playable/destructible object, animation rig
   (default: real-time browser prop with interactive performance)
+- authoring coordinate frame, target runtime coordinate frame, and the single owner of any
+  conversion between them; never infer target forward from the reference pose or a viewer default
 - for a CS2 request, an authoritative classification record (family/subtype and evidence refs) or
   an explicit request for the user/vision provider to supply one; heuristic detection alone is not
   enough to select a geometry adapter
@@ -285,6 +287,9 @@ attachment, material, detail inventory, rig payload, character track). In short:
   passes a straight cone occupying roughly the right cells.
 - Character builds validate the rig payload (`stage5_rig/validate_rig_payload.py`) before binding a
   `THREE.Skeleton`; it proves payload integrity only, never pose stress or likeness.
+- Moving builds declare authoring and target model space and run
+  `stage5_rig/model_space_gate.py`. Non-humanoid articulated subjects use
+  `grimoire/readiness/non_humanoid_animation.md`; rigid pivots do not need a humanoid skeleton.
 - CS2 builds also run `cs2_review.py` against the versioned scene fixture.
 - Local state enforces 3 corrections per pass and 6 total by default; reaching either limit is a
   hard stop. `correction_loop.py` may stop earlier on repeated defects, oscillation, or plateau.
@@ -322,8 +327,10 @@ Full rule + examples: `grimoire/review/self_correction.md`.
 ## Left and right
 
 A left/right pair is a **reflection**, never a rotation: negate the lateral axis and nothing else,
-`(x, y, z) → (-x, y, z)`. With `forward: +Z`, Y up and a right-handed frame, the character's own
-left is **+X**. The convention lives as code in `forge/_shared/chirality.py`
+`(x, y, z) → (-x, y, z)`. In this skill's **authoring frame**, with `forward: +Z`, Y up and a
+right-handed frame, the character's own left is **+X**. This does not define a consumer's target
+forward; declare and gate any conversion with `stage5_rig/model_space_gate.py`. The chirality
+convention lives as code in `forge/_shared/chirality.py`
 (`CHARACTER_LEFT_SIGN`), with two different gates for the two defects that shipped from getting it
 wrong: `validate_chirality` catches a rotation-mistaken-for-reflection at spec time, and
 `medial_lateral_bias` vs a reference catches a pair that is wrong the same way on both sides.

--- a/forge/stage5_rig/model_space_gate.py
+++ b/forge/stage5_rig/model_space_gate.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Fail closed when authored visual forward and consumer model space disagree.
+
+The gate validates measured model-space evidence, not a label inferred from a screenshot. It uses
+only Python's standard library and is intentionally independent of Three.js or a DCC.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+
+EPSILON = 1e-6
+AXES = {
+    "+X": (1.0, 0.0, 0.0),
+    "-X": (-1.0, 0.0, 0.0),
+    "+Y": (0.0, 1.0, 0.0),
+    "-Y": (0.0, -1.0, 0.0),
+    "+Z": (0.0, 0.0, 1.0),
+    "-Z": (0.0, 0.0, -1.0),
+}
+CONVERSION_OWNERS = {"none", "export", "load-root-adapter"}
+
+
+def _finite_vector(value: Any, label: str, errors: list[str]) -> tuple[float, float, float] | None:
+    if (
+        not isinstance(value, list)
+        or len(value) != 3
+        or not all(
+            isinstance(item, (int, float))
+            and not isinstance(item, bool)
+            and math.isfinite(float(item))
+            for item in value
+        )
+    ):
+        errors.append(f"{label} must be a finite length-3 vector")
+        return None
+    return tuple(float(item) for item in value)
+
+
+def _dot(left: tuple[float, float, float], right: tuple[float, float, float]) -> float:
+    return sum(a * b for a, b in zip(left, right))
+
+
+def _length(value: tuple[float, float, float]) -> float:
+    return math.sqrt(_dot(value, value))
+
+
+def _normalized(value: tuple[float, float, float]) -> tuple[float, float, float] | None:
+    length = _length(value)
+    if length <= EPSILON:
+        return None
+    return tuple(item / length for item in value)
+
+
+def _frame(payload: dict[str, Any], name: str, errors: list[str]) -> tuple[str, str] | None:
+    frame = payload.get(name)
+    if not isinstance(frame, dict):
+        errors.append(f"{name} coordinate frame is required")
+        return None
+    up = frame.get("up")
+    forward = frame.get("forward")
+    if up not in AXES:
+        errors.append(f"{name}.up must be one of {sorted(AXES)}")
+    if forward not in AXES:
+        errors.append(f"{name}.forward must be one of {sorted(AXES)}")
+    if up not in AXES or forward not in AXES:
+        return None
+    if abs(_dot(AXES[up], AXES[forward])) > EPSILON:
+        errors.append(f"{name}.up and {name}.forward must be orthogonal")
+    return str(up), str(forward)
+
+
+def _identity_root(payload: dict[str, Any], errors: list[str]) -> None:
+    root = payload.get("rootTransform")
+    if not isinstance(root, dict):
+        errors.append("rootTransform is required")
+        return
+    position = _finite_vector(root.get("position"), "rootTransform.position", errors)
+    scale = _finite_vector(root.get("scale"), "rootTransform.scale", errors)
+    quaternion = root.get("quaternion")
+    if (
+        not isinstance(quaternion, list)
+        or len(quaternion) != 4
+        or not all(
+            isinstance(item, (int, float))
+            and not isinstance(item, bool)
+            and math.isfinite(float(item))
+            for item in quaternion
+        )
+    ):
+        errors.append("rootTransform.quaternion must be a finite length-4 quaternion")
+    elif any(
+        abs(float(actual) - expected) > EPSILON
+        for actual, expected in zip(quaternion, (0.0, 0.0, 0.0, 1.0))
+    ):
+        errors.append("semantic root quaternion must be identity")
+    if position is not None and _length(position) > EPSILON:
+        errors.append("semantic root position must be identity")
+    if scale is not None and any(abs(actual - 1.0) > EPSILON for actual in scale):
+        errors.append("semantic root scale must be identity")
+
+
+def validate(payload: dict[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    if payload.get("schemaVersion") != 1:
+        errors.append("schemaVersion must be 1")
+    if payload.get("handedness") != "right":
+        errors.append("handedness must be right")
+    authoring = _frame(payload, "authoring", errors)
+    target = _frame(payload, "target", errors)
+    owner = payload.get("conversionOwner")
+    if owner not in CONVERSION_OWNERS:
+        errors.append(f"conversionOwner must be one of {sorted(CONVERSION_OWNERS)}")
+    elif authoring is not None and target is not None:
+        if authoring != target and owner == "none":
+            errors.append("different authoring and target frames require one conversion owner")
+        if authoring == target and owner != "none":
+            errors.append("matching authoring and target frames must not add a conversion adapter")
+    _identity_root(payload, errors)
+
+    marker = _finite_vector(payload.get("forwardMarker"), "forwardMarker", errors)
+    front = _finite_vector(payload.get("frontFeature"), "frontFeature", errors)
+    rear = _finite_vector(payload.get("rearFeature"), "rearFeature", errors)
+    target_forward = AXES[target[1]] if target is not None else None
+    marker_direction = _normalized(marker) if marker is not None else None
+    if marker is not None and marker_direction is None:
+        errors.append("forwardMarker must not be at the semantic origin")
+    elif marker_direction is not None and target_forward is not None:
+        if _dot(marker_direction, target_forward) < 1.0 - EPSILON:
+            errors.append("forwardMarker does not point along target.forward")
+    if front is not None and target_forward is not None and _dot(front, target_forward) <= EPSILON:
+        errors.append("frontFeature is not on the declared target.forward side")
+    if rear is not None and target_forward is not None and _dot(rear, target_forward) >= -EPSILON:
+        errors.append("rearFeature is not opposite the declared target.forward side")
+
+    return {
+        "schemaVersion": 1,
+        "passed": not errors,
+        "errors": errors,
+        "summary": {
+            "authoringForward": authoring[1] if authoring is not None else None,
+            "targetForward": target[1] if target is not None else None,
+            "conversionOwner": owner,
+        },
+        "evidenceBoundary": (
+            "structural model-space evidence only; cardinal renders and runtime movement remain separate gates"
+        ),
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contract", type=Path, required=True)
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args(argv)
+    try:
+        payload = json.loads(args.contract.expanduser().read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError("contract root must be an object")
+        result = validate(payload)
+        serialized = json.dumps(result, indent=2, ensure_ascii=False) + "\n"
+        if args.out:
+            args.out.expanduser().parent.mkdir(parents=True, exist_ok=True)
+            args.out.expanduser().write_text(serialized, encoding="utf-8")
+        print(serialized, end="")
+        return 0 if result["passed"] else 1
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/forge/tests/test_model_space_gate.py
+++ b/forge/tests/test_model_space_gate.py
@@ -1,0 +1,71 @@
+import copy
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from forge.stage5_rig.model_space_gate import validate  # noqa: E402
+
+
+def contract():
+    return {
+        "schemaVersion": 1,
+        "handedness": "right",
+        "authoring": {"up": "+Y", "forward": "-X"},
+        "target": {"up": "+Y", "forward": "-Z"},
+        "conversionOwner": "export",
+        "rootTransform": {
+            "position": [0, 0, 0],
+            "quaternion": [0, 0, 0, 1],
+            "scale": [1, 1, 1],
+        },
+        "forwardMarker": [0, 0, -1],
+        "frontFeature": [0, 0.6, -1.23],
+        "rearFeature": [0, 0.66, 0.68],
+    }
+
+
+class ModelSpaceGateTest(unittest.TestCase):
+    def test_explicit_single_conversion_with_measured_features_passes(self):
+        result = validate(contract())
+        self.assertTrue(result["passed"], result)
+        self.assertEqual(result["summary"]["authoringForward"], "-X")
+        self.assertEqual(result["summary"]["targetForward"], "-Z")
+
+    def test_axis_mismatch_without_an_owner_is_a_hard_failure(self):
+        value = contract()
+        value["conversionOwner"] = "none"
+        result = validate(value)
+        self.assertFalse(result["passed"])
+        self.assertTrue(any("require one conversion owner" in error for error in result["errors"]))
+
+    def test_a_correct_label_cannot_hide_sideways_visible_geometry(self):
+        value = contract()
+        value["frontFeature"] = [-1.23, 0.6, 0]
+        value["rearFeature"] = [0.68, 0.66, 0]
+        result = validate(value)
+        self.assertFalse(result["passed"])
+        self.assertTrue(any("frontFeature" in error for error in result["errors"]))
+        self.assertTrue(any("rearFeature" in error for error in result["errors"]))
+
+    def test_marker_and_identity_root_are_independent_hard_gates(self):
+        value = copy.deepcopy(contract())
+        value["forwardMarker"] = [1, 0, 0]
+        value["rootTransform"]["quaternion"] = [0, 0.7071068, 0, 0.7071068]
+        result = validate(value)
+        self.assertFalse(result["passed"])
+        self.assertTrue(any("forwardMarker" in error for error in result["errors"]))
+        self.assertTrue(any("root quaternion" in error for error in result["errors"]))
+
+    def test_matching_frames_reject_a_redundant_adapter(self):
+        value = contract()
+        value["authoring"] = {"up": "+Y", "forward": "-Z"}
+        result = validate(value)
+        self.assertFalse(result["passed"])
+        self.assertTrue(any("must not add" in error for error in result["errors"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/grimoire/readiness/non_humanoid_animation.md
+++ b/grimoire/readiness/non_humanoid_animation.md
@@ -1,0 +1,71 @@
+# Non-humanoid articulated animation
+
+Use this contract for insects, quadrupeds, mechanical creatures, vehicles with articulated limbs,
+and other moving subjects whose topology is not a humanoid skeleton. Do not force a humanoid bone
+template onto a subject merely because the output needs `idle` and `walk` clips.
+
+## Declare model space before rigging
+
+The skill's internal procedural convention is right-handed, Y-up, forward `+Z`. That is an
+authoring convention, not a promise that the target application uses the same one. Record both the
+authoring and target frames, then name exactly one conversion owner: export or load-root adapter.
+Never distribute the same correction across geometry, camera, animation tracks, and gameplay.
+
+Create `model-space-contract.json` from measured scene data and run:
+
+```bash
+python3 forge/stage5_rig/model_space_gate.py --contract model-space-contract.json
+```
+
+The contract must contain an identity semantic root, a forward marker, one visible front feature,
+and one rear feature in target-root local coordinates. This prevents a correct-looking `forward`
+label or marker from hiding geometry that actually faces sideways. Then render front, side, rear,
+and quarter views from the declared target frame; the structural gate cannot replace those views.
+
+## Choose rigid pivots before skinning
+
+Rigid shells and mechanical segments belong under nested transform pivots. A limb hierarchy follows
+the actual motion chain, for example `hip -> knee -> ankle -> foot`; do not place the tibia and foot
+beside the hip and attempt to fake downstream motion from one rotation. Prefer identity rotations at
+rest and place geometry relative to its owning pivot.
+
+Use a skin only where a visible surface must deform across joints. A rigid insect or machine can be
+fully animation-ready with no `THREE.Skeleton`, skin indices, or weights. The humanoid rig payload
+gate is not applicable to that path; unique semantic pivots, resolvable tracks, pose stress, and
+bounds are the relevant evidence.
+
+## Define gait topology, not just keyframes
+
+Name limbs by side and longitudinal position. Define the contact groups before authoring a walk. A
+stable six-leg default is alternating tripods:
+
+- group A: left-front, right-middle, left-rear
+- group B: right-front, left-middle, right-rear
+
+Each group alternates stance and swing. Hip motion advances the limb, knee/ankle motion provides
+clearance, and the foot returns to a plausible contact pose. Body bob, head, antenna, tail, shell,
+or wind-up motion may follow the phase as secondary motion but must not own world movement.
+
+## Clip authority
+
+- locomotion clips are in-place unless the consumer explicitly owns a root-motion contract
+- the semantic root has no position or quaternion track
+- clip names are semantic (`idle`, `walk`, actor-specific actions), unique, and mapped once
+- every track target resolves after the production loader parses the exported asset
+- loop start and end poses agree; duration and loop policy are explicit
+- gameplay or another consumer owns actual position, facing, collision, and velocity selection
+
+## Required evidence
+
+Sample every looping locomotion clip at normalized phases `0`, `0.25`, `0.5`, `0.75`, and `1`.
+Record that:
+
+- opposing gait groups reverse lift phase
+- all transforms and animated bounds remain finite
+- feet and appendages do not materially intersect the body or detach at motion extremes
+- the phase-1 pose closes the phase-0 seam
+- the semantic root remains identity and does not drift
+- target-forward agrees with visible front in all cardinal views
+
+A single attractive animation frame is not animation evidence. A successful humanoid rig validator
+is not evidence for a rigid non-humanoid hierarchy.

--- a/grimoire/review/gates_reference.md
+++ b/grimoire/review/gates_reference.md
@@ -72,6 +72,11 @@ only the executable order and one-line summary; this file defines the mandatory 
   structural payload integrity only; pose stress, dynamic bounds, readable screenshots, and
   visual likeness remain separate gates. Payload ownership and non-goals:
   `grimoire/readiness/procedural_rigging_contract.md`.
+- **Model-space gate (moving builds, HARD)**: authoring and target frames are separate declarations.
+  `forge/stage5_rig/model_space_gate.py` requires one conversion owner when they differ, an identity
+  semantic root, target-forward marker, and measured front/rear features on opposite sides. A marker
+  or label alone cannot hide sideways geometry. Rigid insects, quadrupeds, and mechanical creatures
+  follow `grimoire/readiness/non_humanoid_animation.md`, not the humanoid skin payload by default.
 - **Tier 1 (legacy, still valid)**: "Tier 2 (AI-vision) never runs against a render that has not passed Tier 1." Run `forge/stage4_review/diagnose_render.py` (silhouette IoU/proportion/symmetry/per-part color) and record it (`--spec ... --in-place`) before requesting a comparison sheet; `orchestrate_passes.py check` refuses otherwise.
 - **Pre-spec / strict-quality**: blocks code gen until the spec is deep enough for its contract.
 - **Screenshot feedback**: `continue` is allowed only with a render + comparison sheet + global


### PR DESCRIPTION
## Summary

Adds a fail-closed model-space gate so a correct forward label or marker cannot hide geometry that actually faces sideways, and documents a rigid articulated animation path for insects, quadrupeds, and mechanical creatures.

Refs #112

## Changes

- Separate the skill authoring +Z convention from a consumer target coordinate frame.
- Validate one conversion owner, identity semantic root, target-forward marker, and measured front/rear features with a standard-library gate.
- Add rigid nested-pivot, gait-phase, in-place clip, binding, and phase-sampling guidance for non-humanoid subjects.
- Route moving builds through the new gate without changing the existing humanoid skin payload.

## Validation

- [x] Full Python suite: 1088 tests passed, 38 skipped.
- [x] Focused model-space tests: 5 passed.
- [x] Existing chirality and rig-payload tests: 37 passed.
- [x] Render or comparison-sheet review: not applicable; this PR adds structural validation and documentation without changing generated geometry.

## Contributor checklist

- [x] This PR keeps the code-only procedural reconstruction contract; it does not silently download meshes or art packs.
- [x] Existing object specs remain valid.
- [x] Tests were added for the new gate.
- [x] Skill and gate documentation were updated.