### PR TITLE
feat: offline TRELLIS dense-evidence bridge with fail-closed A/B acceptance

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,10 @@ forge-suite:
   # the emitted TypeScript with node), not forge runtime deps.
   image: python:3.13-slim
   before_script:
-    - apt-get update -qq && apt-get install -y -qq git nodejs > /dev/null
+    - apt-get update -qq && apt-get install -y -qq git curl xz-utils > /dev/null
+    # Node >= 22 for --experimental-strip-types (Debian's nodejs is 18)
+    - curl -fsSL https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-x64.tar.xz | tar -xJ -C /usr/local --strip-components=1
+    - node --version
     - pip install -q huggingface_hub
   script:
     - python -m unittest discover -s forge/tests -p 'test_*.py'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,12 @@ stages:
 
 forge-suite:
   stage: test
-  image: python:3.12-slim
+  # 3.13 to match the verified local environment; git and huggingface_hub are
+  # test-fixture dependencies of the free-assist suite, not forge runtime deps.
+  image: python:3.13-slim
+  before_script:
+    - apt-get update -qq && apt-get install -y -qq git > /dev/null
+    - pip install -q huggingface_hub
   script:
     - python -m unittest discover -s forge/tests -p 'test_*.py'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+# CI for the dense-evidence pipeline: the stdlib forge suite plus the isolated
+# mesh3d extractor tests. Everything runs offline against the repo itself —
+# no provider call, no upload, no token. Environment-dependent gates
+# (showcase TypeScript smoke) skip by design without IMG2THREEJS_SHOWCASE_ROOT.
+stages:
+  - test
+
+forge-suite:
+  stage: test
+  image: python:3.12-slim
+  script:
+    - python -m unittest discover -s forge/tests -p 'test_*.py'
+
+dense-evidence-mesh3d:
+  stage: test
+  image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+  script:
+    - uv sync --project integrations/mesh3d
+    - PYTHONPATH="$PWD" uv run --project integrations/mesh3d python -m unittest discover -s integrations/mesh3d/tests -t .

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,11 +7,12 @@ stages:
 
 forge-suite:
   stage: test
-  # 3.13 to match the verified local environment; git and huggingface_hub are
-  # test-fixture dependencies of the free-assist suite, not forge runtime deps.
+  # 3.13 to match the verified local environment. git, nodejs and
+  # huggingface_hub are test-fixture dependencies (the geometry suites execute
+  # the emitted TypeScript with node), not forge runtime deps.
   image: python:3.13-slim
   before_script:
-    - apt-get update -qq && apt-get install -y -qq git > /dev/null
+    - apt-get update -qq && apt-get install -y -qq git nodejs > /dev/null
     - pip install -q huggingface_hub
   script:
     - python -m unittest discover -s forge/tests -p 'test_*.py'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-> Last updated: 2026-09-01 03:30
+> Last updated: 2026-09-01 21:45
 
 # Changelog
 
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ZeroGPU Spaces plus separately installed local SF3D, with immutable zero-spend policy, explicit
   upload approval, no automatic retry/fallback, cache-before-network reuse, durable raw-GLB resume,
   credential redaction, normalized GLB/OBJ artifacts, and fail-closed structural admission.
+- Add `forge/stage2_spec/rebase_component_frames.py`, a one-shot converter from object-frame
+  absolute component transforms to the parent-local contract (never in place, refuses rotated
+  parents, emits a reviewable change report), plus a frame-sanity check in
+  `validate_sculpt_spec.py` that flags implausible parent-local offsets as quality warnings —
+  errors under `--strict-quality` — so an object-frame spec is caught at validation time instead
+  of rendering as floating parts.
 - Add an offline dense evidence bridge from admitted cached meshes to bounded, reversible
   ObjectSculptSpec proposals. It adds strict JSON contracts, content-addressed extraction,
   explicit component mappings, hash-bound influence approval, source-authoritative A/B review,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-> Last updated: 2026-09-01 23:20
+> Last updated: 2026-09-02 00:05
 
 # Changelog
 
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `validate_sculpt_spec.py` that flags implausible parent-local offsets as quality warnings —
   errors under `--strict-quality` — so an object-frame spec is caught at validation time instead
   of rendering as floating parts.
+- Emit instanced repetition-system geometry at the LOW tessellation tier: an instanced
+  micro-part never deforms or subdivides, and hero-tier instances multiplied a curb ring of
+  cubes into 44,928 triangles — half a diorama's budget (focused tests in
+  `test_instanced_cluster_tessellation.py`).
 - Size the emitted look-dev shadow camera and light positions from the spec's estimated world
   radius instead of a fixed character-scale `±2.6` box, so a larger model's contact shadow can
   actually land (`estimate_model_radius` + focused tests in `test_lookdev_shadow_bounds.py`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,25 @@
+> Last updated: 2026-09-01 00:42
+
 # Changelog
 
 All notable changes to **img2threejs** are documented here.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add a provider-neutral free generative-assist CLI for reviewed TRELLIS and Stable Fast 3D
+  ZeroGPU Spaces plus separately installed local SF3D, with immutable zero-spend policy, explicit
+  upload approval, no automatic retry/fallback, cache-before-network reuse, durable raw-GLB resume,
+  credential redaction, normalized GLB/OBJ artifacts, and fail-closed structural admission.
+
+### Security
+
+- Discover Hugging Face credentials only through the supported token store or `HF_TOKEN`; the new
+  CLI exposes no token, endpoint, paid fallback, retry, refill, or cost-override argument.
 
 ## [1.5.1] — 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-> Last updated: 2026-09-01 21:45
+> Last updated: 2026-09-01 23:20
 
 # Changelog
 
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `validate_sculpt_spec.py` that flags implausible parent-local offsets as quality warnings —
   errors under `--strict-quality` — so an object-frame spec is caught at validation time instead
   of rendering as floating parts.
+- Size the emitted look-dev shadow camera and light positions from the spec's estimated world
+  radius instead of a fixed character-scale `±2.6` box, so a larger model's contact shadow can
+  actually land (`estimate_model_radius` + focused tests in `test_lookdev_shadow_bounds.py`).
 - Add an offline dense evidence bridge from admitted cached meshes to bounded, reversible
   ObjectSculptSpec proposals. It adds strict JSON contracts, content-addressed extraction,
   explicit component mappings, hash-bound influence approval, source-authoritative A/B review,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-> Last updated: 2026-09-02 00:05
+> Last updated: 2026-09-03 10:40
 
 # Changelog
 
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `validate_sculpt_spec.py` that flags implausible parent-local offsets as quality warnings —
   errors under `--strict-quality` — so an object-frame spec is caught at validation time instead
   of rendering as floating parts.
+- Resolve reference PBR maps through a servable `url` only: the extractor's authoring-machine
+  `path` is provenance, and falling back to it produced textures that never loaded (every
+  material white). A map with a path and no url now takes the procedural route
+  (`test_reference_map_url.py`).
 - Emit instanced repetition-system geometry at the LOW tessellation tier: an instanced
   micro-part never deforms or subdivides, and hero-tier instances multiplied a curb ring of
   cubes into 44,928 triangles — half a diorama's budget (focused tests in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-> Last updated: 2026-09-01 00:42
+> Last updated: 2026-09-01 03:30
 
 # Changelog
 
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ZeroGPU Spaces plus separately installed local SF3D, with immutable zero-spend policy, explicit
   upload approval, no automatic retry/fallback, cache-before-network reuse, durable raw-GLB resume,
   credential redaction, normalized GLB/OBJ artifacts, and fail-closed structural admission.
+- Add an offline dense evidence bridge from admitted cached meshes to bounded, reversible
+  ObjectSculptSpec proposals. It adds strict JSON contracts, content-addressed extraction,
+  explicit component mappings, hash-bound influence approval, source-authoritative A/B review,
+  optional workflow routing, and code-only runtime guards; it never ships or copies provider mesh
+  topology into the procedural factory.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> Last updated: 2026-09-01 00:44
+> Last updated: 2026-09-01 03:30
 
 <div align="center">
 
@@ -296,6 +296,15 @@ provider; tokens are not accepted on the CLI. Generated meshes remain blocked fr
 procedural build until structural and visual admission complete. Usage and security contract:
 [`docs/integrations/free-generative-assist.md`](docs/integrations/free-generative-assist.md).
 Install its isolated optional dependencies with `uv sync --project integrations/mesh3d`.
+
+### Optional offline dense evidence
+
+An admitted cached proxy can be converted into bounded dense evidence for a reversible spec
+proposal. Merged meshes are limited to global massing; component measurements require explicit
+human-reviewed mappings and a hash-bound influence approval. The source image remains authoritative,
+and the accepted runtime remains code-only TypeScript/Three.js with no GLB/OBJ loader or provider
+artifact. The bridge performs no upload or provider call:
+[`docs/integrations/trellis-dense-evidence.md`](docs/integrations/trellis-dense-evidence.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> Last updated: 2026-09-01 03:30
+> Last updated: 2026-09-01 21:55
 
 <div align="center">
 
@@ -234,6 +234,7 @@ The net effect: you still get a faithful 3D model from an image, but the expensi
 | `stage2_spec/new_pre_spec_assessment.py` | Classify the object, score complexity, emit a quality contract. |
 | `stage2_spec/new_sculpt_spec.py` | Author the ObjectSculptSpec from the assessment. |
 | `stage2_spec/validate_sculpt_spec.py` | Validate the spec; `--strict-quality` blocks shallow specs before codegen. |
+| `stage2_spec/rebase_component_frames.py` | Convert object-frame component transforms to the parent-local contract (new file + change report). |
 | `stage1_intake/extract_pbr_evidence.py` | Reference-derived PBR evidence per crop (inference, not inverse rendering). |
 | `stage1_intake/material_region_analysis.py` | Crop material regions, run texture/PBR evidence, and resolve registry profiles. |
 | `stage2_spec/apply_material_analysis.py` | Wire region assignments, priors, maps, and provenance into ObjectSculptSpec. |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> Last updated: 2026-09-01 00:44
+
 <div align="center">
 
 <img src="assets/logo.svg" width="112" height="104" alt="img2threejs logo" />
@@ -284,6 +286,16 @@ It applies **only** when a build has a GLB to measure — skip it entirely other
 image-driven pipeline instead. Reproduces `girl-character`'s shipped `crossSections.ts` exactly (748
 rings, 86,240 ring points). Method and per-stage rationale:
 [`PIPELINE.md`](integrations/glb_character_pipeline/PIPELINE.md).
+
+### Optional zero-spend generative reference
+
+`integrations.mesh3d.free_assist` can obtain a cached, resumable reference proxy from reviewed
+TRELLIS or Stable Fast 3D ZeroGPU Spaces, or from a separately installed local SF3D checkout. Its
+cost policy is immutable at zero; every hosted upload is explicit; failures never retry or switch
+provider; tokens are not accepted on the CLI. Generated meshes remain blocked from influencing the
+procedural build until structural and visual admission complete. Usage and security contract:
+[`docs/integrations/free-generative-assist.md`](docs/integrations/free-generative-assist.md).
+Install its isolated optional dependencies with `uv sync --project integrations/mesh3d`.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,3 +1,5 @@
+> Last updated: 2026-09-01 00:42
+
 # img2threejs Roadmap
 
 Where img2threejs is going: from rebuilding one object at a time to generating whole playable
@@ -17,6 +19,13 @@ can plan around.
 | v1.3 | Quality & efficiency (Divine Eye) | 2026-07-22 | Deterministic multi-signal review harness, input-integrity and geometry-truth gates, reference-grounded texture/material analysis, CIEDE2000 colour math |
 | v1.4 | Weapon Pipeline | 2026-07-25–26 | CS2 image-matched reconstruction, provenance-aware intake and local search, projection-first finishes, family-specific adapters, structural review and component-coverage gates |
 | v1.5 | The Character Update | 2026-08-12 | Skeleton derived from the component tree and bound to `SkinnedMesh` geometry, geodesic skinning, hair as a five-stage subsystem with a hard scalp-exposure gate, chirality gates, interior-difference review, `tapered-sweep`, material pipeline with a blocking acceptance gate, resumable workflow state |
+
+## Implemented after v1.5.1
+
+- **Free generative assist** — opt-in TRELLIS/SF3D ZeroGPU reference proxies with an immutable
+  zero-spend policy, explicit upload approval, no automatic retry/fallback, content-addressed cache,
+  durable raw-GLB resume, credential redaction, and structural admission. The single live ZeroGPU
+  acceptance run remains a separately approved external test.
 
 ### v1.2 — Humanoid character generator
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-> Last updated: 2026-09-01 00:42
+> Last updated: 2026-09-01 03:30
 
 # img2threejs Roadmap
 
@@ -26,6 +26,10 @@ can plan around.
   zero-spend policy, explicit upload approval, no automatic retry/fallback, content-addressed cache,
   durable raw-GLB resume, credential redaction, and structural admission. The single live ZeroGPU
   acceptance run remains a separately approved external test.
+- **Offline dense evidence** — reviewed cached proxies can now inform bounded global massing or
+  explicitly mapped component measurements through hash-bound human approval, reversible spec
+  deltas, dual-baseline review, and runtime guards. The shipped model remains code-only; provider
+  topology and GLB/OBJ assets never become runtime dependencies.
 
 ### v1.2 — Humanoid character generator
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -5,6 +5,8 @@ license: Apache-2.0
 version: 1.5.1
 ---
 
+> Last updated: 2026-09-01 00:42
+
 # img2threejs — Image to procedural Three.js
 
 Rebuild the object visible in a reference image as a **code-only** procedural Three.js model,
@@ -115,6 +117,11 @@ Full flags: `grimoire/scripts.md`. Never let a script *score* visuals — that i
     implementation** — write the proven change back to the spec or TypeScript, rebuild, recapture.
     Full adapter + MCP routing and authority boundaries:
     `docs/integrations/reference_fidelity_tooling.md`.
+1d. **Optional free generative reference** — only after a read-only zero-cost preflight and exact
+    upload approval, `python3 -m integrations.mesh3d.free_assist` may obtain a TRELLIS/SF3D proxy.
+    It never retries or switches provider automatically, resumes local failures from the persisted
+    raw GLB, and cannot influence reconstruction until mesh and visual admission pass. Full safety,
+    cache, credential, and local-SF3D contract: `docs/integrations/free-generative-assist.md`.
 2. **Pre-Spec Assessment Gate** — classify + score complexity + write the quality contract:
    `forge/stage2_spec/new_pre_spec_assessment.py "Name" --image <img> --complexity <simple|moderate|complex|ultra-complex> --out assessment.json`. Rules: `grimoire/intake/quality_contract.md`.
    Set `objectClass.primaryDomain` (`object` | `character` | `hybrid`) and fill the seeded

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,11 @@
+> Last updated: 2026-09-01 03:30
+
 ---
 name: img2threejs
 description: Turn an object or character reference image into a quality-gated, animation-ready procedural Three.js model built in code. Use for image-to-3D reconstruction, detail-accurate object rebuilds, stylized/likeness-maximized human characters, sculpt specs, and staged code generation.
 license: Apache-2.0
 version: 1.5.1
 ---
-
-> Last updated: 2026-09-01 00:42
 
 # img2threejs — Image to procedural Three.js
 
@@ -122,6 +122,12 @@ Full flags: `grimoire/scripts.md`. Never let a script *score* visuals — that i
     It never retries or switches provider automatically, resumes local failures from the persisted
     raw GLB, and cannot influence reconstruction until mesh and visual admission pass. Full safety,
     cache, credential, and local-SF3D contract: `docs/integrations/free-generative-assist.md`.
+1e. **Optional dense-evidence bridge** — after a cached GLB has structural and visual review, the
+    offline `integrations.mesh3d.dense_evidence` extractor may convert it into bounded massing or
+    explicitly mapped component measurements. Extraction always starts at scope `none`; a separate
+    human approval binds GLB/evidence/review/scope/spec hashes before a reversible proposed spec is
+    emitted. The source image stays authoritative and the runtime stays code-only; merged meshes are
+    capped at global massing. Full contract: `docs/integrations/trellis-dense-evidence.md`.
 2. **Pre-Spec Assessment Gate** — classify + score complexity + write the quality contract:
    `forge/stage2_spec/new_pre_spec_assessment.py "Name" --image <img> --complexity <simple|moderate|complex|ultra-complex> --out assessment.json`. Rules: `grimoire/intake/quality_contract.md`.
    Set `objectClass.primaryDomain` (`object` | `character` | `hybrid`) and fill the seeded

--- a/docs/integrations/free-generative-assist.md
+++ b/docs/integrations/free-generative-assist.md
@@ -1,0 +1,80 @@
+> Last updated: 2026-09-01 00:50
+
+# Free generative assist
+
+This optional integration obtains a generated GLB/OBJ reference proxy while enforcing an immutable `maxCostUsd = 0`. It does not replace the procedural Three.js deliverable, and a structurally valid provider result is not ground truth or visual acceptance.
+
+The reviewed providers are:
+
+- `hf-zerogpu-trellis` at `trellis-community/TRELLIS`, the preferred hosted multi-view route.
+- `hf-zerogpu-sf3d` at `stabilityai/stable-fast-3d`, a manual single-image fallback.
+- `local-sf3d`, an already-installed Stable Fast 3D checkout selected separately.
+
+There is no paid provider, arbitrary endpoint, cost override, refill, automatic provider switch, or automatic retry. Hosted admission requires the live Hugging Face metadata to report the reviewed Space as `RUNNING`, its domain as `READY`, and both current and requested hardware as `zero-a10g`. Missing or changed evidence fails closed.
+
+## Hosted workflow
+
+Log in through supported Hugging Face tooling; credentials are discovered from that token store or `HF_TOKEN` and are never command arguments:
+
+```bash
+uv sync --project integrations/mesh3d
+hf auth login
+
+uv run --project integrations/mesh3d python -m integrations.mesh3d.free_assist preflight reference/front.png \
+  --provider hf-zerogpu-trellis \
+  --out-dir artifacts/my-object/free-assist
+```
+
+Read `preflight.json`: it names the exact files, provider, endpoint evidence, parameters, cache key, and zero-cost policy. Preflight performs no upload. Only after reviewing it, run one request:
+
+```bash
+uv run --project integrations/mesh3d python -m integrations.mesh3d.free_assist generate reference/front.png \
+  --provider hf-zerogpu-trellis \
+  --out-dir artifacts/my-object/free-assist \
+  --approve-upload
+```
+
+`--approve-upload` applies to that invocation's provider, files, hashes, endpoint revision, parameters, and cache key. A failure stops; there is no automatic retry and Stable Fast 3D is never selected automatically. Switching hosted provider requires a new command and new upload approval.
+
+ZeroGPU quotas, queue times, authentication rules, and Space availability are external live state. The tool therefore does not hard-code a permanent free-minute allowance: it re-checks hardware state before a non-cached run and denies uncertainty. It never buys credits or upgrades hardware.
+
+## Cache and resume
+
+The cache is keyed by ordered input hashes, provider, endpoint revision, parameters, and normalizer version. A verified completed match is reused before any metadata network request, upload, or generation. Raw output is written atomically to `runs/<id>/raw/reference.glb` and hashed in the provider receipt before local conversion begins.
+
+If OBJ conversion or admission fails, resume from that durable GLB:
+
+```bash
+uv run --project integrations/mesh3d python -m integrations.mesh3d.free_assist resume \
+  --run artifacts/my-object/free-assist/runs/<run-id>
+```
+
+Resume has no provider adapter and cannot consume ZeroGPU quota. It verifies the raw hash before deriving normalized artifacts.
+
+## Local Stable Fast 3D
+
+Local mode does not install software or accept model terms. The user must review and accept the gated Stability AI model license themselves, install the official checkout separately, then expose only these non-secret signals:
+
+```bash
+export SF3D_ROOT=/absolute/path/to/stable-fast-3d
+export SF3D_MODEL_ACCESS_APPROVED=1
+
+uv run --project integrations/mesh3d python -m integrations.mesh3d.free_assist generate reference/front.png \
+  --provider local-sf3d \
+  --out-dir artifacts/my-object/free-assist \
+  --approve-local-run
+```
+
+Preflight requires `SF3D_ROOT/run.py`, at least 12 GiB free disk and 16 GiB physical/unified memory. Apple Silicon with at least 32 GiB is reported as eligible for experimental MPS; smaller supported machines are routed to CPU for safety. `--force-cpu` explicitly requests CPU. Installation, model downloads, and license acceptance require their own user-controlled process and are not performed here.
+
+## Admission and privacy
+
+Normalization produces GLB, OBJ, mesh inventory, provider receipt, status, and structural admission. The gate checks GLB v2 structure, mesh/material/BIN inventory, finite non-degenerate bounds, compression declarations, GLB/OBJ axis-scale agreement, and vertex/triangle ceilings. It deliberately leaves `admittedForProceduralInfluence: false` until a preview, silhouette/aspect/scale comparison, and human review of invented hidden surfaces are recorded through the normal img2threejs visual gates.
+
+Reports redact authorization, cookies, HF tokens, bearer values, and signed URL query fields. Request artifacts store image names and hashes rather than credentials. Do not place `.env` files or tokens in the repository.
+
+Tripo Studio Free remains a manual external option rather than a guaranteed free API provider. Meshy Free is excluded because its free plan does not provide the API automation/export contract required here. Local TRELLIS is excluded on Apple Silicon; TRELLIS' supported implementation is CUDA/Linux-oriented. These exclusions prevent a marketing-tier label from being treated as proof that an automated request is free.
+
+## Verification boundary
+
+Automated tests use fixture GLBs and injected metadata only; they make no provider calls. One separate live acceptance run against TRELLIS ZeroGPU remains intentionally unexecuted until the user explicitly approves a non-sensitive input upload and the consumption of one free-quota generation. That live check must retain the browser preview and comparison evidence.

--- a/docs/integrations/trellis-dense-evidence.md
+++ b/docs/integrations/trellis-dense-evidence.md
@@ -1,0 +1,163 @@
+> Last updated: 2026-09-01 03:30
+
+# TRELLIS dense-evidence bridge
+
+This optional bridge turns an already cached and reviewed TRELLIS or Stable Fast 3D mesh into
+bounded geometric evidence for the native img2threejs pipeline. The source image is authoritative;
+the generated mesh is advisory. The final artifact remains a semantic, editable, code-only
+TypeScript/Three.js factory.
+
+The bridge is offline and preserves the free-assist policy `maxCostUsd = 0`. Extraction makes no provider call,
+performs no upload, consumes no quota, accepts no token argument, and never retries
+or switches providers. The normalized GLB/OBJ and their reviews are immutable inputs. They are
+never shipped at runtime and are never copied into procedural source code.
+
+## Authority and scope
+
+Influence is deny-by-default and has exactly three levels:
+
+- `none`: the extractor's output; no procedural parameter may change.
+- `global-massing`: bounded whole-object dimensions and component positions may be proposed.
+- `component-measurements`: only explicitly mapped, observed component dimensions may be proposed.
+
+A merged one-mesh/one-primitive asset is capped at `global-massing`. Multipart node and primitive
+boundaries remain candidate selectors; names, materials, colors, connected components, and provider
+metadata never become semantic labels automatically. `component-measurements` requires a
+human-reviewed component map with confidence at least 0.80. Hidden and rear surfaces from a single
+view remain non-authoritative.
+
+The accepted ObjectSculptSpec is never overwritten. The bridge emits
+`proposed-object-sculpt-spec.json`, `spec-delta.json`, and `fit-plan.json`; the reverse delta must
+restore the accepted spec exactly. Version 1 cannot modify IDs, hierarchy, topology, primitive
+types, geometry descriptors, materials, pivots, sockets, attachments, repetition systems,
+interactions, or build passes.
+
+## Pipeline order
+
+```text
+cached free_assist run
+  -> reviewed alignment manifest
+  -> offline extraction/cache
+  -> stdlib evidence validation
+  -> optional explicit component map
+  -> hash-bound human influence approval
+  -> proposed spec + reversible delta + fit plan
+  -> existing strict validation and factory generation
+  -> browser A/B comparison against source and advisory GLB
+  -> accept proposal or retain image-only baseline
+```
+
+The A/B gate requires all existing deterministic geometry gates, no critical source-feature
+regression, at most `0.02` source silhouette regression, and at least `0.01` improvement against a
+declared evidence metric. A better match to the advisory GLB cannot hide a worse match to the source
+image.
+
+## Reviewed alignment
+
+Extraction does not solve a camera or guess chirality. Supply an alignment JSON with a finite
+16-number `sourceViewTransform`, `+Y` up, `+Z` forward, right-handed output, an axis-operation audit,
+`chiralityStatus`, browser-capture paths and hashes, silhouette IoU, and projected aspect-ratio
+error. Global use requires IoU at least `0.65`; component use requires at least `0.75`; aspect-ratio
+error must not exceed `0.15`. Ambiguous chirality caps influence at `global-massing`.
+
+## Offline commands
+
+Install only the isolated optional mesh environment:
+
+```bash
+uv sync --project integrations/mesh3d
+```
+
+Inspect the maximum possible scope without writing an approval:
+
+```bash
+uv run --project integrations/mesh3d python -m integrations.mesh3d.dense_evidence propose-scope \
+  --run RUN \
+  --source-image reference.png \
+  --alignment reviewed-alignment.json
+```
+
+Extract or reuse the content-addressed cache:
+
+```bash
+uv run --project integrations/mesh3d python -m integrations.mesh3d.dense_evidence extract \
+  --run RUN \
+  --source-image reference.png \
+  --alignment reviewed-alignment.json \
+  --out-dir RUN/dense-evidence
+
+uv run --project integrations/mesh3d python -m integrations.mesh3d.dense_evidence verify-cache \
+  --run RUN \
+  --source-image reference.png \
+  --alignment reviewed-alignment.json \
+  --out-dir RUN/dense-evidence
+```
+
+Validate through the stdlib core:
+
+```bash
+python3 forge/stage1_intake/check_dense_evidence.py \
+  --evidence RUN/dense-evidence/dense-evidence.v1.json \
+  --spec object-sculpt-spec.json \
+  --out dense-evidence-validation.json
+```
+
+For multipart evidence, seed an empty map and fill it only after review:
+
+```bash
+python3 forge/stage2_spec/new_component_evidence_map.py \
+  --spec object-sculpt-spec.json \
+  --evidence RUN/dense-evidence/dense-evidence.v1.json \
+  --out component-evidence-map.json
+```
+
+Create a hash-bound approval only after the user approves this exact tuple:
+
+```bash
+python3 forge/stage4_review/admit_dense_influence.py \
+  --evidence RUN/dense-evidence/dense-evidence.v1.json \
+  --visual-review RUN/review/visual-review.json \
+  --target-spec object-sculpt-spec.json \
+  --scope global-massing \
+  --approve-influence \
+  --out influence-admission.json
+```
+
+Omitting `--approve-influence` returns `NEEDS_USER_ACTION` and writes no ALLOW record. A changed
+GLB, evidence file, review, requested scope, component map, or target spec invalidates the approval.
+
+Generate the reversible proposal, never in place:
+
+```bash
+python3 forge/stage2_spec/apply_dense_evidence.py \
+  --spec object-sculpt-spec.json \
+  --evidence RUN/dense-evidence/dense-evidence.v1.json \
+  --admission influence-admission.json \
+  --out proposed-object-sculpt-spec.json \
+  --delta-out spec-delta.json \
+  --fit-plan-out fit-plan.json
+```
+
+Then run the existing strict validator, factory generator, browser captures, and
+`compare_dense_evidence.py`. Runtime scanning rejects GLB/OBJ loaders, mesh asset paths, provider
+URLs, signed URLs, and copied mesh payload markers.
+
+## Cache, resume, and artifacts
+
+`dense-evidence/` contains `extraction-request.json`, `alignment.json`,
+`dense-evidence.v1.json`, and `status.json`. The cache identity binds normalized GLB/OBJ hashes,
+ordered source-image hashes, extractor/alignment versions, exact alignment, and measurement caps.
+A component-map change invalidates mapping/proposal work without recomputing base geometry.
+
+Local extraction failures record a normalized category and last durable artifact. Re-running resumes
+from the existing normalized GLB/OBJ; it can never trigger generation. A cache hit is returned only
+after authoritative hashes are recomputed.
+
+Exit codes are `0` for pass/cache hit/accepted, `1` for a valid policy or quality `DENY`, `2` for
+malformed input or local execution failure, and `3` when explicit approval or browser evidence is
+required. Common categories include `evidence_hash_mismatch`, `alignment_failed`,
+`semantic_boundary_insufficient`, `component_mapping_invalid`, `influence_scope_exceeded`,
+`source_fidelity_regression`, `fit_no_improvement`, and `browser_evidence_missing`.
+
+This route is optional and generic-object-only in version 1. It does not replace the image-only,
+character, or CS2 pipelines, and TRELLIS does not generate the final procedural factory.

--- a/docs/specs/component-evidence-map.v1.schema.json
+++ b/docs/specs/component-evidence-map.v1.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://img2threejs.local/schemas/component-evidence-map.v1.schema.json",
+  "title": "Component Evidence Map v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "targetSpecSha256", "evidenceSha256", "glbSha256", "mappings", "extensions"],
+  "properties": {
+    "schemaVersion": {"const": 1},
+    "kind": {"const": "component-evidence-map"},
+    "targetSpecSha256": {"$ref": "#/$defs/sha256"},
+    "evidenceSha256": {"$ref": "#/$defs/sha256"},
+    "glbSha256": {"$ref": "#/$defs/sha256"},
+    "availableComponentIds": {"type": "array", "items": {"type": "string"}},
+    "candidateRegions": {"type": "array", "items": {"type": "object"}},
+    "mappings": {"type": "array", "items": {"$ref": "#/$defs/mapping"}},
+    "extensions": {"type": "object"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "mapping": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["componentId", "selectors", "mappingMethod", "evidenceRefs", "confidence", "permittedFields", "observedSurface", "hiddenLimitations"],
+      "properties": {
+        "componentId": {"type": "string", "minLength": 1},
+        "selectors": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": false, "required": ["regionId"], "properties": {"regionId": {"type": "string", "minLength": 1}}}},
+        "mappingMethod": {"const": "human-reviewed-node-boundary"},
+        "evidenceRefs": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "confidence": {"type": "number", "minimum": 0.8, "maximum": 1.0},
+        "permittedFields": {"type": "array", "minItems": 1, "items": {"enum": ["dimensions.width", "dimensions.height", "dimensions.depth", "dimensions.radius", "dimensions.length"]}},
+        "observedSurface": {"const": true},
+        "hiddenLimitations": {"type": "array", "items": {"type": "string"}}
+      }
+    }
+  }
+}

--- a/docs/specs/dense-evidence.v1.schema.json
+++ b/docs/specs/dense-evidence.v1.schema.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://img2threejs.local/schemas/dense-evidence.v1.schema.json",
+  "title": "Dense Evidence v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "kind", "extractorVersion", "createdAt", "provenance", "cache", "admission", "alignment", "globalGeometry", "regions", "uncertainty", "extensions"],
+  "properties": {
+    "schemaVersion": {"const": 1},
+    "kind": {"const": "dense-evidence"},
+    "extractorVersion": {"const": "dense-evidence-extractor-v1"},
+    "createdAt": {"type": "string", "format": "date-time"},
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["providerId", "runPath", "glbPath", "glbSha256", "objSha256", "sourceImageSha256", "visualReviewStatus", "alignmentProfileVersion", "alignmentSha256"],
+      "properties": {
+        "providerId": {"type": "string", "minLength": 1},
+        "runPath": {"type": "string", "minLength": 1},
+        "glbPath": {"type": "string", "minLength": 1},
+        "glbSha256": {"$ref": "#/$defs/sha256"},
+        "objSha256": {"$ref": "#/$defs/sha256"},
+        "sourceImageSha256": {"type": "array", "minItems": 1, "items": {"$ref": "#/$defs/sha256"}},
+        "visualReviewStatus": {"type": "string", "minLength": 1},
+        "alignmentProfileVersion": {"const": "source-view-alignment-v1"},
+        "alignmentSha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "cache": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["baseExtractionKey", "measurementConfigSha256"],
+      "properties": {
+        "baseExtractionKey": {"$ref": "#/$defs/sha256"},
+        "measurementConfigSha256": {"$ref": "#/$defs/sha256"}
+      }
+    },
+    "admission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["structuralStatus", "semanticStatus", "maximumInfluenceScope", "approvedInfluenceScope"],
+      "properties": {
+        "structuralStatus": {"enum": ["pass", "structural-pass-visual-review-required"]},
+        "semanticStatus": {"enum": ["sufficient", "insufficient"]},
+        "maximumInfluenceScope": {"enum": ["global-massing", "component-measurements"]},
+        "approvedInfluenceScope": {"const": "none"}
+      }
+    },
+    "alignment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schemaVersion", "profileVersion", "sourceViewTransform", "upAxis", "forwardAxis", "handedness", "axisOperationAudit", "chiralityStatus", "sourceViewSilhouetteIou", "projectedAspectRatioError", "browserCaptures"],
+      "properties": {
+        "schemaVersion": {"const": 1},
+        "profileVersion": {"const": "source-view-alignment-v1"},
+        "sourceViewTransform": {"type": "array", "minItems": 16, "maxItems": 16, "items": {"type": "number"}},
+        "upAxis": {"const": "+Y"},
+        "forwardAxis": {"const": "+Z"},
+        "handedness": {"const": "right-handed"},
+        "axisOperationAudit": {"type": "array", "minItems": 1, "items": {"type": "string", "minLength": 1}},
+        "chiralityStatus": {"enum": ["reviewed", "ambiguous"]},
+        "sourceViewSilhouetteIou": {"type": "number", "minimum": 0, "maximum": 1},
+        "projectedAspectRatioError": {"type": "number", "minimum": 0, "maximum": 1},
+        "browserCaptures": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": false, "required": ["path", "sha256", "view"], "properties": {"path": {"type": "string"}, "sha256": {"$ref": "#/$defs/sha256"}, "view": {"type": "string"}}}},
+        "extensions": {"type": "object"}
+      }
+    },
+    "globalGeometry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["bounds", "principalAxes", "occupancyGrid", "crossSections", "silhouetteViews"],
+      "properties": {
+        "bounds": {"$ref": "#/$defs/bounds"},
+        "principalAxes": {"type": "array", "minItems": 3, "maxItems": 3},
+        "occupancyGrid": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["resolution", "occupiedCells", "occupiedCellCount"],
+          "properties": {
+            "resolution": {"type": "integer", "minimum": 1, "maximum": 32},
+            "occupiedCells": {"type": "array", "maxItems": 32768, "items": {"type": "array", "minItems": 3, "maxItems": 3, "items": {"type": "integer", "minimum": 0, "maximum": 31}}},
+            "occupiedCellCount": {"type": "integer", "minimum": 0, "maximum": 32768}
+          }
+        },
+        "crossSections": {"type": "array", "maxItems": 32},
+        "silhouetteViews": {"type": "array", "minItems": 1}
+      }
+    },
+    "regions": {"type": "array", "items": {"$ref": "#/$defs/region"}},
+    "uncertainty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceViewCount", "hiddenSurfacePolicy", "rearConfidence", "singleViewLimitations"],
+      "properties": {
+        "sourceViewCount": {"type": "integer", "minimum": 1},
+        "hiddenSurfacePolicy": {"const": "non-authoritative"},
+        "rearConfidence": {"enum": ["low", "medium"]},
+        "singleViewLimitations": {"type": "array", "minItems": 1, "items": {"type": "string"}}
+      }
+    },
+    "extensions": {"type": "object"}
+  },
+  "$defs": {
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "vec3": {"type": "array", "minItems": 3, "maxItems": 3, "items": {"type": "number"}},
+    "bounds": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["min", "max", "size"],
+      "properties": {"min": {"$ref": "#/$defs/vec3"}, "max": {"$ref": "#/$defs/vec3"}, "size": {"$ref": "#/$defs/vec3"}}
+    },
+    "region": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["regionId", "node", "geometry", "candidateOnly", "semanticLabel", "bounds"],
+      "properties": {
+        "regionId": {"type": "string"}, "node": {"type": "string"}, "geometry": {"type": "string"},
+        "candidateOnly": {"const": true}, "semanticLabel": {"type": "null"}, "bounds": {"$ref": "#/$defs/bounds"}
+      }
+    }
+  }
+}

--- a/docs/superpowers/plans/2026-09-01-free-generative-assist.md
+++ b/docs/superpowers/plans/2026-09-01-free-generative-assist.md
@@ -1,0 +1,275 @@
+> Last updated: 2026-09-01 00:25
+
+# Free Generative Assist Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in, zero-spend, approval-gated and resumable reference-mesh generator for hosted TRELLIS, hosted Stable Fast 3D, and a separately installed local Stable Fast 3D checkout.
+
+**Architecture:** Keep provider dependencies isolated in `integrations/mesh3d/free_assist/`; the package has immutable policy/registry data, injected live probes, provider adapters, durable artifacts, cache lookup, normalization, and admission. The CLI performs a read-only preflight, re-runs that preflight before a single approved generation, and resumes only from an already persisted raw GLB. The stdlib `forge/` core remains unchanged and receives only normalized GLB/OBJ/report artifacts.
+
+**Tech Stack:** Python 3.10+ stdlib for policy/orchestration/tests; optional `huggingface_hub`, `gradio_client`, and `trimesh` at provider/normalization boundaries; `unittest` fixtures; Hugging Face Space metadata API.
+
+---
+
+## File map
+
+- `integrations/mesh3d/free_assist/model.py`: enums, immutable zero-cost policy, request/preflight/run records, JSON helpers.
+- `integrations/mesh3d/free_assist/registry.py`: the only reviewed provider/endpoint allowlist and live ZeroGPU admission.
+- `integrations/mesh3d/free_assist/security.py`: token/signed-URL redaction and safe atomic JSON writes.
+- `integrations/mesh3d/free_assist/providers.py`: TRELLIS, hosted SF3D, and already-installed local SF3D adapters; optional imports occur only on generation.
+- `integrations/mesh3d/free_assist/pipeline.py`: hashing/cache, preflight, one-shot generation, raw recovery boundary, normalization, and mesh admission.
+- `integrations/mesh3d/free_assist/cli.py`, `__main__.py`: `preflight`, `generate`, and `resume` commands with no token argument.
+- `forge/tests/test_free_generative_assist.py`: offline behavior and fixture integration tests; no provider calls.
+- `docs/integrations/free-generative-assist.md`: safety model, usage, prerequisites, and exclusions.
+- `README.md`, `SKILL.md`, `ROADMAP.md`, `CHANGELOG.md`: honest discoverability and capability status.
+
+### Task 1: Immutable policy, provider registry, and redaction
+
+**Files:**
+- Create: `integrations/mesh3d/__init__.py`
+- Create: `integrations/mesh3d/free_assist/__init__.py`
+- Create: `integrations/mesh3d/free_assist/model.py`
+- Create: `integrations/mesh3d/free_assist/registry.py`
+- Create: `integrations/mesh3d/free_assist/security.py`
+- Test: `forge/tests/test_free_generative_assist.py`
+
+- [ ] **Step 1: Write failing policy and registry tests**
+
+```python
+def test_policy_is_immutable_and_zero_cost(self):
+    self.assertEqual(ZeroSpendPolicy().max_cost_usd, 0)
+    with self.assertRaises(dataclasses.FrozenInstanceError):
+        ZeroSpendPolicy().max_cost_usd = 1
+
+def test_unknown_or_non_zero_hardware_fails_closed(self):
+    request = make_request("hf-zerogpu-trellis")
+    self.assertEqual(preflight(request, metadata={"hardware": "a10g"}).decision, Decision.DENY)
+    with self.assertRaises(UnknownProvider):
+        provider_spec("unknown")
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.PolicyRegistryTest -v`
+Expected: `ModuleNotFoundError: integrations.mesh3d.free_assist`.
+
+- [ ] **Step 3: Implement the immutable contract and exact allowlist**
+
+```python
+@dataclass(frozen=True)
+class ZeroSpendPolicy:
+    max_cost_usd: int = 0
+    allow_paid_fallback: bool = False
+    allow_credit_purchase: bool = False
+    allow_automatic_retry: bool = False
+    allow_automatic_provider_switch: bool = False
+
+PROVIDERS = {
+    "hf-zerogpu-trellis": ProviderSpec("trellis-community/TRELLIS", "zero-a10g", True),
+    "hf-zerogpu-sf3d": ProviderSpec("stabilityai/stable-fast-3d", "zero-a10g", True),
+    "local-sf3d": ProviderSpec("local", "local", False),
+}
+```
+
+Admission accepts hosted providers only when `runtime.stage == RUNNING`, a runtime domain is `READY`, and both current/requested hardware equal `zero-a10g`; missing fields return `DENY`. Redaction recursively removes bearer/HF tokens, cookies, authorization values, and sensitive URL query values before any exception/report is serialized.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.PolicyRegistryTest -v`
+Expected: policy, unknown-provider, hardware, and redaction tests pass.
+
+### Task 2: Content-addressed requests and read-only preflight
+
+**Files:**
+- Create: `integrations/mesh3d/free_assist/pipeline.py`
+- Modify: `forge/tests/test_free_generative_assist.py`
+
+- [ ] **Step 1: Write failing cache-key and preflight tests**
+
+```python
+def test_cache_key_changes_for_inputs_provider_revision_and_parameters(self):
+    base = request_for(self.image)
+    keys = {compute_cache_key(replace(base, seed=n)) for n in (0, 1)}
+    self.assertEqual(len(keys), 2)
+
+def test_preflight_does_not_construct_or_call_provider(self):
+    probe = RecordingMetadataProbe(ZERO_GPU_METADATA)
+    report = preflight(request_for(self.image), metadata_probe=probe)
+    self.assertEqual(report.decision, Decision.NEEDS_USER_ACTION)
+    self.assertEqual(probe.calls, ["trellis-community/TRELLIS"])
+    self.assertFalse(self.upload.called)
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.RequestPreflightTest -v`
+Expected: imports for `compute_cache_key` and `preflight` fail.
+
+- [ ] **Step 3: Implement canonical hashing and preflight**
+
+```python
+def compute_cache_key(request: GenerationRequest) -> str:
+    payload = {"images": [sha256_file(p) for p in request.images],
+               "providerId": request.provider_id,
+               "endpointRevision": request.endpoint_revision,
+               "parameters": request.parameters,
+               "normalizerVersion": NORMALIZER_VERSION}
+    return hashlib.sha256(canonical_json(payload)).hexdigest()
+```
+
+`preflight` validates files, probes only metadata/capability, checks cache before network generation, writes `preflight.json` atomically, and returns `NEEDS_USER_ACTION` for an admitted hosted request until exact upload approval is supplied. Local preflight checks platform, `SF3D_ROOT/run.py`, disk, memory, token availability, and separately reported license/install/run approvals; it never installs or accepts terms.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.RequestPreflightTest -v`
+Expected: all request, hashing, cache, and no-upload tests pass.
+
+### Task 3: One-shot provider adapters and durable raw GLB
+
+**Files:**
+- Create: `integrations/mesh3d/free_assist/providers.py`
+- Modify: `integrations/mesh3d/free_assist/pipeline.py`
+- Modify: `forge/tests/test_free_generative_assist.py`
+
+- [ ] **Step 1: Write failing one-call, approval, and no-fallback tests**
+
+```python
+def test_generate_requires_exact_upload_approval(self):
+    with self.assertRaises(AssistFailure) as error:
+        generate(self.request, approve_upload=False, adapter=self.adapter)
+    self.assertEqual(error.exception.category, "upload_not_approved")
+    self.assertEqual(self.adapter.calls, 0)
+
+def test_provider_failure_is_not_retried_or_switched(self):
+    self.adapter.failure = RuntimeError("queue failed")
+    with self.assertRaises(AssistFailure):
+        generate(self.request, approve_upload=True, adapter=self.adapter)
+    self.assertEqual(self.adapter.calls, 1)
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.GenerationTest -v`
+Expected: generation entrypoint is missing.
+
+- [ ] **Step 3: Implement adapters and durable write boundary**
+
+TRELLIS calls `/start_session` then exactly one `/generate_and_extract_glb`; hosted SF3D calls exactly one `/run_button`; both discover credentials only through `huggingface_hub.get_token()`/`HF_TOKEN`. The local adapter runs `<SF3D_ROOT>/run.py` once through `sys.executable` after explicit local approval. Copy the returned GLB to `runs/<id>/raw/reference.glb.tmp`, verify GLB magic, rename atomically, hash it, then write a redacted receipt/status. No adapter knows about or invokes another adapter.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.GenerationTest -v`
+Expected: approval, one-call, response extraction, redaction, and no-fallback tests pass.
+
+### Task 4: Resume, normalization, cache, and admission
+
+**Files:**
+- Modify: `integrations/mesh3d/free_assist/pipeline.py`
+- Modify: `forge/tests/test_free_generative_assist.py`
+
+- [ ] **Step 1: Write failing fixture integration tests**
+
+```python
+def test_normalization_failure_resumes_raw_without_generation(self):
+    run = make_run_with_triangle_glb(self.root)
+    first = resume(run, obj_writer=raising_writer)
+    second = resume(run, obj_writer=fixture_obj_writer)
+    self.assertEqual(first["failureCategory"], "normalization_failed")
+    self.assertEqual(second["status"], "complete")
+    self.assertEqual(self.adapter.calls, 0)
+
+def test_invalid_glb_and_degenerate_bounds_fail_admission(self):
+    self.assertEqual(admit_glb(self.bad_glb)["failureCategory"], "invalid_glb")
+    self.assertEqual(admit_glb(self.flat_glb)["failureCategory"], "mesh_admission_failed")
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.ResumeAdmissionTest -v`
+Expected: resume/admission functions are missing.
+
+- [ ] **Step 3: Implement normalization and admission**
+
+Reuse `forge.stage1_intake.probe_glb.probe_glb` and the existing OBJ conversion helper. Admission requires readable GLB v2, mesh/material/BIN inventory, finite non-zero bounds, and configurable vertex/triangle ceilings; it records compression and OBJ availability. Resume reads only `raw/reference.glb`, verifies its recorded hash, recreates normalized artifacts and reports, and never obtains a provider adapter. On success update `cache-index.json` atomically; a matching later request returns the existing completed run without network access.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.ResumeAdmissionTest -v`
+Expected: TRELLIS/SF3D-shaped fixture responses, invalid GLB, resume, and cache tests pass.
+
+### Task 5: Safe CLI contract
+
+**Files:**
+- Create: `integrations/mesh3d/free_assist/cli.py`
+- Create: `integrations/mesh3d/free_assist/__main__.py`
+- Modify: `forge/tests/test_free_generative_assist.py`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+```python
+def test_help_has_no_token_or_spend_override(self):
+    result = run_cli("--help")
+    self.assertNotIn("--hf-token", result.stdout)
+    self.assertNotIn("max-cost", result.stdout)
+
+def test_generate_without_approval_never_calls_provider(self):
+    result = run_cli("generate", str(self.image), "--provider", "hf-zerogpu-trellis",
+                     "--out-dir", str(self.root))
+    self.assertEqual(result.returncode, 3)
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.CliTest -v`
+Expected: module CLI is missing.
+
+- [ ] **Step 3: Implement `preflight`, `generate`, and `resume`**
+
+The parser exposes exact provider choices, image paths, output/run path, reviewed generation parameters, `--approve-upload`, and `--approve-local-run`; it exposes no endpoint override, token, paid fallback, retry, or cost override. JSON is the default report format; exit codes are `0` complete/cache hit, `2` invalid invocation/local error, and `3` policy/user-action denial.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.CliTest -v`
+Expected: CLI safety and fixture-driven subprocess tests pass without network.
+
+### Task 6: Documentation and complete verification
+
+**Files:**
+- Create: `docs/integrations/free-generative-assist.md`
+- Modify: `README.md`
+- Modify: `SKILL.md`
+- Modify: `ROADMAP.md`
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add a failing documentation contract test**
+
+```python
+def test_docs_state_free_limits_and_manual_live_gate(self):
+    text = DOC.read_text()
+    for phrase in ("maxCostUsd = 0", "ZeroGPU", "--approve-upload", "resume",
+                   "no automatic retry", "separate live acceptance"):
+        self.assertIn(phrase, text)
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist.DocumentationTest -v`
+Expected: missing documentation file.
+
+- [ ] **Step 3: Document the implemented boundary**
+
+Explain current quota/queue data as live preflight evidence rather than a permanent number; token login; exact upload review; hosted/provider visibility and licenses; local SF3D gated access, MPS/CPU/disk/memory prerequisites; why Tripo/Meshy are manual/excluded; resume/cache; generated mesh as proxy; and the separately approved one-run live test. Add release-facing links and mark the live acceptance as deliberately not yet executed.
+
+- [ ] **Step 4: Run focused and full verification**
+
+Run: `python3 -m unittest forge.tests.test_free_generative_assist -v`
+Expected: all free-assist tests pass with no network.
+
+Run: `python3 -m unittest discover -s forge/tests -p 'test_*.py'`
+Expected: baseline 1,083 tests plus new tests pass; optional showcase tests may remain skipped.
+
+Run: `python3 -m integrations.mesh3d.free_assist --help && git diff --check && rg -n "hf_[A-Za-z0-9]{20,}|Bearer [A-Za-z0-9]" integrations/mesh3d/free_assist forge/tests/test_free_generative_assist.py docs/integrations/free-generative-assist.md`
+Expected: CLI help succeeds, diff check is clean, and credential scan has no matches.
+
+The separately approved live TRELLIS ZeroGPU acceptance run is not executed in this plan.

--- a/docs/superpowers/plans/2026-09-01-trellis-dense-evidence-integration.md
+++ b/docs/superpowers/plans/2026-09-01-trellis-dense-evidence-integration.md
@@ -1,0 +1,1027 @@
+> Last updated: 2026-09-01 20:10
+
+# TRELLIS Dense-Evidence Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task in the current checkout. Steps use checkbox (`- [x]`) syntax for tracking. Do not dispatch subagents unless the user later requests delegation.
+
+**Goal:** Connect an already admitted, cached TRELLIS/SF3D GLB to the native img2threejs pipeline as offline, bounded geometric evidence while preserving a semantic, editable, code-only TypeScript/Three.js runtime model.
+
+**Architecture:** Add an optional `integrations/mesh3d/dense_evidence/` extractor that reads immutable free-assist artifacts and emits bounded, versioned JSON. Keep `forge/` stdlib-only: it validates that JSON, binds an explicit human-approved influence tuple, creates a reversible proposed `ObjectSculptSpec`, and compares image-only versus evidence-assisted browser results. The source image remains authoritative; merged GLBs can influence only global massing, and no provider call, upload, runtime GLB, automatic semantic labeling, or in-place accepted-spec mutation is allowed.
+
+**Tech Stack:** Python 3.11-3.13; stdlib `argparse`, `dataclasses`, `hashlib`, `json`, `pathlib`, `unittest`; optional existing mesh3d environment with `trimesh`, NumPy, and SciPy; existing ObjectSculptSpec validator/generator; existing browser render bridge and image comparison helpers.
+
+---
+
+## Authorization and worktree constraints
+
+- The current checkout is intentionally dirty. Preserve the existing edits to `forge/tests/test_free_generative_assist.py`, `integrations/mesh3d/pyproject.toml`, and `integrations/mesh3d/uv.lock`.
+- Add dense-evidence tests in new files so the prior free-assist bugfix is not rewritten accidentally.
+- The approved implementation must remain offline. Do not invoke TRELLIS, SF3D, Hugging Face, Gradio, upload APIs, or provider metadata probes.
+- Use the cached whimsical-house run only for the final read-only acceptance. Never modify `raw/`, `normalized/`, `review/admission.json`, or `review/visual-review.json`.
+- Do not commit, push, deploy, delete, or clean generated/user artifacts without a separate explicit authorization.
+
+## File map
+
+### New optional integration files
+
+- `integrations/mesh3d/dense_evidence/__init__.py`: stable public imports and extractor version.
+- `integrations/mesh3d/dense_evidence/__main__.py`: module entry point.
+- `integrations/mesh3d/dense_evidence/model.py`: enums, typed records, canonical hashing, atomic JSON writes, and fail-closed errors.
+- `integrations/mesh3d/dense_evidence/alignment.py`: validates the reviewed source-view transform, chirality, IoU, aspect ratio, and admissible scope.
+- `integrations/mesh3d/dense_evidence/regions.py`: inventories mesh/node/primitive boundaries and applies explicit region selectors without inventing labels.
+- `integrations/mesh3d/dense_evidence/extract.py`: loads normalized GLB/OBJ, extracts capped bounds/PCA/occupancy/cross-sections, and writes immutable-provenance evidence.
+- `integrations/mesh3d/dense_evidence/cache.py`: content-addressed extraction cache and downstream invalidation keys.
+- `integrations/mesh3d/dense_evidence/cli.py`: offline `extract`, `propose-scope`, and `verify-cache` commands.
+- `integrations/mesh3d/tests/test_dense_evidence.py`: optional-dependency unit and offline extraction tests.
+
+### New stdlib core files
+
+- `forge/stage1_intake/check_dense_evidence.py`: validates schema, hashes, admission, uncertainty, scope ceiling, and optional component map.
+- `forge/stage2_spec/new_component_evidence_map.py`: seeds a deny-by-default mapping against existing component IDs.
+- `forge/stage2_spec/apply_dense_evidence.py`: emits a proposed spec, reversible delta, and bounded fit plan without changing the accepted spec.
+- `forge/stage4_review/admit_dense_influence.py`: records approval bound to GLB/evidence/review/scope/spec hashes.
+- `forge/stage4_review/compare_dense_evidence.py`: evaluates the dual baseline and returns accept/deny with explicit regressions.
+- `forge/tests/test_dense_evidence_contract.py`: stdlib schema, mapping, admission, proposal, workflow, and CLI tests.
+- `forge/tests/test_dense_evidence_review.py`: dual-baseline and runtime-source guard tests.
+
+### Documentation/schema files
+
+- `docs/specs/dense-evidence.v1.schema.json`: machine-readable evidence contract.
+- `docs/specs/component-evidence-map.v1.schema.json`: explicit mapping contract.
+- `docs/integrations/trellis-dense-evidence.md`: operating guide, authority model, artifact layout, and offline commands.
+- `SKILL.md`: route the optional free-assist output through the new bridge only after admission and influence approval.
+- `README.md`, `ROADMAP.md`, `CHANGELOG.md`: expose the implemented boundary and non-goals honestly.
+
+### Existing files modified
+
+- `forge/_shared/workflow_state.py`: add the optional dense-evidence setup gate only when selected.
+- `forge/state.py`: add `--dense-evidence` to `init`.
+- `forge/tests/test_workflow_state.py`: prove image-only compatibility and optional route ordering.
+- `integrations/mesh3d/pyproject.toml`: add no dependency unless extraction demonstrates a missing existing runtime dependency.
+- `integrations/mesh3d/uv.lock`: update only if `pyproject.toml` genuinely changes.
+
+## Stable contracts chosen by this plan
+
+### Evidence scope
+
+```python
+class InfluenceScope(str, Enum):
+    NONE = "none"
+    GLOBAL_MASSING = "global-massing"
+    COMPONENT_MEASUREMENTS = "component-measurements"
+
+SCOPE_RANK = {
+    InfluenceScope.NONE: 0,
+    InfluenceScope.GLOBAL_MASSING: 1,
+    InfluenceScope.COMPONENT_MEASUREMENTS: 2,
+}
+```
+
+There is no automatic, topology-copy, or full-mesh scope. Extraction always writes `approvedInfluenceScope: "none"`; only `admit_dense_influence.py` can produce a separate approval record with a higher scope. This removes the apparent circularity in the specification's example record.
+
+### Version-1 evidence limits
+
+```python
+EXTRACTOR_VERSION = "dense-evidence-extractor-v1"
+ALIGNMENT_PROFILE_VERSION = "source-view-alignment-v1"
+MAX_OCCUPANCY_RESOLUTION = 32
+MAX_CROSS_SECTIONS = 32
+MAX_CROSS_SECTION_POINTS = 64
+MIN_GLOBAL_IOU = 0.65
+MIN_COMPONENT_IOU = 0.75
+MAX_ASPECT_RATIO_ERROR = 0.15
+MIN_COMPONENT_CONFIDENCE = 0.80
+```
+
+### Version-1 mutation allowlist
+
+The bridge changes numeric geometry only. It never changes IDs, parent links, topology classes, primitive names, materials, pivots, sockets, attachments, interactions, repetition systems, or build passes.
+
+```python
+GLOBAL_NUMERIC_FIELDS = frozenset({
+    "dimensions.width", "dimensions.height", "dimensions.depth",
+    "dimensions.radius", "dimensions.length",
+    "transform.position.0", "transform.position.1", "transform.position.2",
+})
+
+COMPONENT_NUMERIC_FIELDS = frozenset({
+    "dimensions.width", "dimensions.height", "dimensions.depth",
+    "dimensions.radius", "dimensions.length",
+})
+```
+
+`global-massing` applies one shared per-axis scale vector to all existing top-level and descendant component dimensions and local positions. `component-measurements` may additionally change only the dimension fields explicitly named in an approved component mapping. Geometry-descriptor mutation remains denied in version 1; the specification permits it but does not require it, and adding descriptor-specific semantics without per-primitive contracts would violate YAGNI and the reversible-delta guarantee.
+
+### Exit codes
+
+- `0`: valid/complete/cache hit/accepted.
+- `1`: valid input but policy or quality gate returns `DENY`.
+- `2`: malformed input, unreadable artifact, or local execution error.
+- `3`: explicit approval or browser evidence is required.
+
+## Task 1: Evidence model, hashing, and immutable provider-run validation
+
+**Files:**
+- Create: `integrations/mesh3d/dense_evidence/__init__.py`
+- Create: `integrations/mesh3d/dense_evidence/model.py`
+- Create: `integrations/mesh3d/dense_evidence/cache.py`
+- Create: `integrations/mesh3d/tests/test_dense_evidence.py`
+
+- [x] **Step 1: Write failing model and cache tests**
+
+```python
+class DenseEvidenceModelTest(unittest.TestCase):
+    def test_scope_enum_contains_only_three_deny_by_default_values(self):
+        self.assertEqual(
+            [item.value for item in InfluenceScope],
+            ["none", "global-massing", "component-measurements"],
+        )
+
+    def test_run_validation_rejects_hash_drift_and_unreviewed_mesh(self):
+        run = make_completed_run(self.root, visual_status="reviewed")
+        validated = validate_provider_run(run, (self.source,))
+        self.assertEqual(validated.glb_sha256, sha256_file(run / "normalized/reference.glb"))
+        (run / "normalized/reference.glb").write_bytes(b"changed")
+        with self.assertRaisesRegex(DenseEvidenceError, "evidence_hash_mismatch"):
+            validate_provider_run(run, (self.source,))
+
+    def test_cache_key_changes_for_every_authoritative_input(self):
+        base = ExtractionCacheInput("a" * 64, "b" * 64, ("c" * 64,), "v1", "a1", None, "m1")
+        keys = {
+            extraction_cache_key(base),
+            extraction_cache_key(dataclasses.replace(base, glb_sha256="d" * 64)),
+            extraction_cache_key(dataclasses.replace(base, source_image_sha256=("e" * 64,))),
+            extraction_cache_key(dataclasses.replace(base, measurement_config_sha256="m2")),
+        }
+        self.assertEqual(len(keys), 4)
+```
+
+- [x] **Step 2: Run the optional test to verify RED**
+
+Run:
+
+```bash
+uv run --project integrations/mesh3d python -m unittest integrations.mesh3d.tests.test_dense_evidence.DenseEvidenceModelTest -v
+```
+
+Expected: `ModuleNotFoundError: integrations.mesh3d.dense_evidence`.
+
+- [x] **Step 3: Implement immutable records, canonical hashes, and provider-run validation**
+
+```python
+@dataclass(frozen=True)
+class ProviderRun:
+    root: Path
+    source_image_sha256: tuple[str, ...]
+    glb_sha256: str
+    obj_sha256: str
+    provider_id: str
+    structural_status: str
+    visual_review_status: str
+    semantic_status: str
+
+class DenseEvidenceError(RuntimeError):
+    def __init__(self, category: str, message: str):
+        super().__init__(f"{category}: {message}")
+        self.category = category
+
+def canonical_sha256(value: object) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+```
+
+`validate_provider_run()` must resolve the run directory, load `provider-receipt.json`, `review/admission.json`, and `review/visual-review.json`, recompute normalized GLB/OBJ and ordered source-image hashes, require structural `pass`, require a completed visual review, and derive semantic readiness from `probe_glb.py` data. It returns `mesh_not_structurally_admitted`, `visual_review_missing`, or `evidence_hash_mismatch` without touching any run artifact. Treat the house verdict `retain-as-generative-proxy-only` as reviewed but cap it at global evidence.
+
+- [x] **Step 4: Implement content-addressed cache records**
+
+```python
+def extraction_cache_key(value: ExtractionCacheInput) -> str:
+    return canonical_sha256({
+        "normalizedGlbSha256": value.glb_sha256,
+        "normalizedObjSha256": value.obj_sha256,
+        "sourceImageSha256": list(value.source_image_sha256),
+        "extractorVersion": value.extractor_version,
+        "alignmentProfileVersion": value.alignment_profile_version,
+        "componentMapSha256": value.component_map_sha256,
+        "measurementConfigSha256": value.measurement_config_sha256,
+    })
+```
+
+Write cache/status JSON atomically under `dense-evidence/`; a component-map change invalidates only mapping/proposal keys, not the base geometry extraction key.
+
+- [x] **Step 5: Run the test to verify GREEN**
+
+Run:
+
+```bash
+uv run --project integrations/mesh3d python -m unittest integrations.mesh3d.tests.test_dense_evidence.DenseEvidenceModelTest -v
+```
+
+Expected: scope, immutable-run, hash-drift, atomic-write, and cache-key tests pass.
+
+## Task 2: Reviewed alignment and bounded global extraction
+
+**Files:**
+- Create: `integrations/mesh3d/dense_evidence/alignment.py`
+- Create: `integrations/mesh3d/dense_evidence/regions.py`
+- Create: `integrations/mesh3d/dense_evidence/extract.py`
+- Modify: `integrations/mesh3d/tests/test_dense_evidence.py`
+
+- [x] **Step 1: Write failing alignment and extraction tests**
+
+```python
+class DenseEvidenceExtractionTest(unittest.TestCase):
+    def test_merged_glb_is_capped_at_global_massing(self):
+        run = make_completed_run(self.root, mesh_count=1, primitive_count=1)
+        result = extract_run(run, (self.source,), valid_alignment(), self.out)
+        self.assertEqual(result["admission"]["maximumInfluenceScope"], "global-massing")
+        self.assertEqual(result["admission"]["approvedInfluenceScope"], "none")
+        self.assertEqual(result["regions"], [])
+        self.assertLessEqual(result["globalGeometry"]["occupancyGrid"]["resolution"], 32)
+
+    def test_threshold_failure_denies_instead_of_relaxing(self):
+        with self.assertRaisesRegex(DenseEvidenceError, "alignment_failed"):
+            validate_alignment({**valid_alignment(), "sourceViewSilhouetteIou": 0.64}, "global-massing")
+
+    def test_single_view_hidden_surfaces_are_non_authoritative(self):
+        result = extract_run(make_completed_run(self.root), (self.source,), valid_alignment(), self.out)
+        self.assertEqual(result["uncertainty"]["hiddenSurfacePolicy"], "non-authoritative")
+        self.assertEqual(result["uncertainty"]["rearConfidence"], "low")
+```
+
+- [x] **Step 2: Run the extraction tests to verify RED**
+
+Run:
+
+```bash
+uv run --project integrations/mesh3d python -m unittest integrations.mesh3d.tests.test_dense_evidence.DenseEvidenceExtractionTest -v
+```
+
+Expected: imports for `validate_alignment` and `extract_run` fail.
+
+- [x] **Step 3: Implement alignment validation with no automatic camera solving**
+
+```python
+def maximum_scope(alignment: dict[str, object], semantic_status: str) -> InfluenceScope:
+    iou = finite_unit(alignment["sourceViewSilhouetteIou"], "sourceViewSilhouetteIou")
+    aspect_error = finite_unit(alignment["projectedAspectRatioError"], "projectedAspectRatioError")
+    if aspect_error > MAX_ASPECT_RATIO_ERROR or iou < MIN_GLOBAL_IOU:
+        raise DenseEvidenceError("alignment_failed", "source-view thresholds were not met")
+    if semantic_status == "sufficient" and iou >= MIN_COMPONENT_IOU:
+        return InfluenceScope.COMPONENT_MEASUREMENTS
+    return InfluenceScope.GLOBAL_MASSING
+```
+
+Require a 16-float finite `sourceViewTransform`, `+Y` up, `+Z` forward, right-handed output, an explicit axis-operation audit, chirality status, source silhouette IoU, aspect-ratio error, browser capture paths, and hashes. `chirality_ambiguous` caps the result at global evidence; it never guesses a reflection.
+
+- [x] **Step 4: Implement mesh sampling and bounded measurements**
+
+Load the normalized GLB with `trimesh.load(..., force="scene", process=False)`, apply node transforms, and concatenate sampled world-space vertices. Compute:
+
+```python
+global_geometry = {
+    "bounds": {"min": mins.tolist(), "max": maxs.tolist(), "size": (maxs - mins).tolist()},
+    "principalAxes": pca_axes(points),
+    "occupancyGrid": sparse_occupancy(points, resolution=min(config.resolution, 32)),
+    "crossSections": cross_sections(points, axis="y", count=min(config.sections, 32), max_points=64),
+    "silhouetteViews": [reviewed_source_view(alignment)],
+}
+```
+
+Reject non-finite points, zero-volume bounds, missing geometry, resolution above `32^3`, more than 32 sections, or more than 64 points per section. Store sparse occupied cell indices and resampled section profiles, never full vertices/indices.
+
+- [x] **Step 5: Implement candidate-boundary inventory without semantic labels**
+
+```python
+def inventory_boundaries(scene: trimesh.Scene) -> list[dict[str, object]]:
+    return [
+        {"regionId": f"node:{node}/geometry:{geometry}", "node": node,
+         "geometry": geometry, "candidateOnly": True, "semanticLabel": None}
+        for node, geometry in sorted(scene.graph.nodes_geometry)
+    ]
+```
+
+A one-node/one-geometry/one-primitive scene emits no component regions. Multipart records remain `candidateOnly: true`; names/materials are provenance selectors, not accepted semantic labels.
+
+- [x] **Step 6: Run extraction tests to verify GREEN**
+
+Run:
+
+```bash
+uv run --project integrations/mesh3d python -m unittest integrations.mesh3d.tests.test_dense_evidence.DenseEvidenceExtractionTest -v
+```
+
+Expected: merged, multipart-candidate, mirrored, degenerate, threshold, occupancy-cap, cross-section-cap, and uncertainty tests pass.
+
+## Task 3: Offline extractor CLI and resumability
+
+**Files:**
+- Create: `integrations/mesh3d/dense_evidence/cli.py`
+- Create: `integrations/mesh3d/dense_evidence/__main__.py`
+- Modify: `integrations/mesh3d/dense_evidence/__init__.py`
+- Modify: `integrations/mesh3d/tests/test_dense_evidence.py`
+
+- [x] **Step 1: Write failing CLI/no-network tests**
+
+```python
+class DenseEvidenceCliTest(unittest.TestCase):
+    def test_help_exposes_no_provider_upload_token_or_retry_flags(self):
+        result = run_cli("--help")
+        for forbidden in ("provider", "upload", "token", "retry", "endpoint", "max-cost"):
+            self.assertNotIn(f"--{forbidden}", result.stdout)
+
+    def test_extract_cache_hit_does_not_load_mesh_again(self):
+        first = run_cli("extract", "--run", str(self.run), "--source-image", str(self.source),
+                        "--alignment", str(self.alignment), "--out-dir", str(self.out))
+        self.assertEqual(first.returncode, 0)
+        second = run_cli("verify-cache", "--run", str(self.run), "--source-image", str(self.source),
+                         "--alignment", str(self.alignment), "--out-dir", str(self.out))
+        self.assertEqual(json.loads(second.stdout)["cacheHit"], True)
+```
+
+- [x] **Step 2: Run CLI tests to verify RED**
+
+Run:
+
+```bash
+uv run --project integrations/mesh3d python -m unittest integrations.mesh3d.tests.test_dense_evidence.DenseEvidenceCliTest -v
+```
+
+Expected: module entry point is missing.
+
+- [x] **Step 3: Implement the exact offline commands**
+
+```text
+python -m integrations.mesh3d.dense_evidence extract \
+  --run RUN --source-image IMAGE [--source-image IMAGE] \
+  --alignment ALIGNMENT.json --out-dir RUN/dense-evidence
+
+python -m integrations.mesh3d.dense_evidence propose-scope \
+  --run RUN --source-image IMAGE --alignment ALIGNMENT.json
+
+python -m integrations.mesh3d.dense_evidence verify-cache \
+  --run RUN --source-image IMAGE --alignment ALIGNMENT.json \
+  --out-dir RUN/dense-evidence
+```
+
+`extract` writes `extraction-request.json`, `alignment.json`, `dense-evidence.v1.json`, and `status.json` atomically. A cache hit returns the persisted evidence only after rechecking every authoritative hash. A failed extraction records a category and last durable artifact, and a later invocation resumes locally from normalized GLB/OBJ.
+
+- [x] **Step 4: Add an import/network construction guard**
+
+Patch `socket.socket`, `urllib.request.urlopen`, `huggingface_hub`, and free-assist provider factory symbols to raise during every test. Assert that extraction completes anyway. The dense-evidence package must not import `integrations.mesh3d.free_assist.providers` or accept credentials.
+
+- [x] **Step 5: Run CLI tests to verify GREEN**
+
+Run:
+
+```bash
+uv run --project integrations/mesh3d python -m unittest integrations.mesh3d.tests.test_dense_evidence.DenseEvidenceCliTest -v
+```
+
+Expected: CLI, cache, resume, atomic artifact, and no-network tests pass.
+
+## Task 4: Machine-readable schemas and stdlib admission validator
+
+**Files:**
+- Create: `docs/specs/dense-evidence.v1.schema.json`
+- Create: `docs/specs/component-evidence-map.v1.schema.json`
+- Create: `forge/stage1_intake/check_dense_evidence.py`
+- Create: `forge/tests/test_dense_evidence_contract.py`
+
+- [x] **Step 1: Write failing stdlib validator tests**
+
+```python
+class DenseEvidenceContractTest(unittest.TestCase):
+    def test_valid_global_record_passes_without_optional_dependencies(self):
+        report = validate_dense_evidence(valid_evidence(), expected_spec=None, component_map=None)
+        self.assertTrue(report["passed"])
+        self.assertEqual(report["maximumInfluenceScope"], "global-massing")
+
+    def test_merged_mesh_component_claim_fails_closed(self):
+        evidence = valid_evidence(maximum_scope="global-massing")
+        mapping = valid_component_map()
+        report = validate_dense_evidence(evidence, expected_spec=valid_spec(), component_map=mapping)
+        self.assertIn("semantic_boundary_insufficient", report["failureCategories"])
+
+    def test_single_view_hidden_measurement_is_rejected(self):
+        mapping = valid_component_map(permitted_fields=["dimensions.depth"], observed=False)
+        report = validate_dense_evidence(valid_evidence(), valid_spec(), mapping)
+        self.assertIn("component_mapping_invalid", report["failureCategories"])
+```
+
+- [x] **Step 2: Run validator tests to verify RED**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_contract.DenseEvidenceContractTest -v
+```
+
+Expected: `forge.stage1_intake.check_dense_evidence` is missing.
+
+- [x] **Step 3: Add complete JSON schemas**
+
+The evidence schema must require exactly the top-level contract groups and constrain all hashes, enums, transform lengths, confidence values, occupancy resolution, cross-section counts, and hidden-surface policy. The component-map schema must require:
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "component-evidence-map",
+  "targetSpecSha256": "<64 lowercase hex>",
+  "evidenceSha256": "<64 lowercase hex>",
+  "glbSha256": "<64 lowercase hex>",
+  "mappings": [{
+    "componentId": "roof-main",
+    "selectors": [{"regionId": "node:Roof/geometry:RoofMesh"}],
+    "mappingMethod": "human-reviewed-node-boundary",
+    "evidenceRefs": ["review/semantic-roof.png"],
+    "confidence": 0.86,
+    "permittedFields": ["dimensions.width", "dimensions.height"],
+    "observedSurface": true,
+    "hiddenLimitations": ["rear slope is non-authoritative"]
+  }]
+}
+```
+
+Set `additionalProperties: false` on authority-bearing records; reserve optional non-authoritative extension data under an explicit `extensions` object.
+
+- [x] **Step 4: Implement pure-stdlib semantic validation**
+
+```python
+def validate_dense_evidence(
+    evidence: object,
+    expected_spec: dict[str, object] | None = None,
+    component_map: dict[str, object] | None = None,
+) -> dict[str, object]:
+    errors: list[str] = []
+    categories: set[str] = set()
+    # Validate exact schema version/kind, hashes, finite values, caps, authority and mapping.
+    return {
+        "schemaVersion": 1,
+        "passed": not errors,
+        "failureCategories": sorted(categories),
+        "errors": errors,
+        "maximumInfluenceScope": maximum_scope,
+    }
+```
+
+Do not import NumPy, SciPy, trimesh, provider code, or JSON Schema libraries. The CLI accepts `--evidence`, optional `--spec`, optional `--component-map`, `--out`, and returns `0` pass, `1` deny, `2` malformed invocation.
+
+- [x] **Step 5: Run validator tests to verify GREEN**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_contract.DenseEvidenceContractTest -v
+```
+
+Expected: provenance, caps, merged/multipart, hash drift, confidence, overlap, hidden-surface, unknown-component, and forbidden-field tests pass.
+
+## Task 5: Explicit component-map authoring
+
+**Files:**
+- Create: `forge/stage2_spec/new_component_evidence_map.py`
+- Modify: `forge/tests/test_dense_evidence_contract.py`
+
+- [x] **Step 1: Write failing map-seeding tests**
+
+```python
+class ComponentEvidenceMapTest(unittest.TestCase):
+    def test_seed_lists_existing_components_and_candidate_regions_without_mapping_them(self):
+        result = seed_component_map(valid_spec(), multipart_evidence())
+        self.assertEqual(result["mappings"], [])
+        self.assertEqual(result["availableComponentIds"], ["body", "roof-main"])
+        self.assertTrue(all(item["candidateOnly"] for item in result["candidateRegions"]))
+
+    def test_merged_evidence_refuses_component_map_seed(self):
+        with self.assertRaisesRegex(ValueError, "semantic_boundary_insufficient"):
+            seed_component_map(valid_spec(), valid_evidence(maximum_scope="global-massing"))
+```
+
+- [x] **Step 2: Run map tests to verify RED**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_contract.ComponentEvidenceMapTest -v
+```
+
+Expected: map seeder import fails.
+
+- [x] **Step 3: Implement deny-by-default seeding and CLI**
+
+```text
+python3 forge/stage2_spec/new_component_evidence_map.py \
+  --spec object-sculpt-spec.json \
+  --evidence dense-evidence.v1.json \
+  --out component-evidence-map.json
+```
+
+Hash the exact input bytes, list current component IDs and candidate selectors, and emit an empty `mappings` array. Never infer labels from node names, materials, colors, connected components, or provider metadata. Validation requires confidence `>= 0.80`, explicit evidence refs, observed-surface status, non-overlapping exclusive selectors, and only known component IDs.
+
+- [x] **Step 4: Run map tests to verify GREEN**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_contract.ComponentEvidenceMapTest -v
+```
+
+Expected: empty seed, merged refusal, unknown component, duplicate selector, low confidence, and hash binding tests pass.
+
+## Task 6: Hash-bound influence admission
+
+**Files:**
+- Create: `forge/stage4_review/admit_dense_influence.py`
+- Modify: `forge/tests/test_dense_evidence_contract.py`
+
+- [x] **Step 1: Write failing admission tests**
+
+```python
+class DenseInfluenceAdmissionTest(unittest.TestCase):
+    def test_approval_is_bound_to_glb_evidence_review_scope_and_spec(self):
+        record = create_admission(
+            evidence_path=self.evidence, visual_review_path=self.review,
+            target_spec_path=self.spec, requested_scope="global-massing",
+        )
+        self.assertEqual(record["decision"], "ALLOW")
+        self.assertEqual(set(record["binding"]), {
+            "glbSha256", "evidenceSha256", "visualReviewSha256", "scope", "targetSpecSha256"
+        })
+
+    def test_scope_above_evidence_ceiling_is_denied(self):
+        result = create_admission(self.evidence, self.review, self.spec, "component-measurements")
+        self.assertEqual(result["decision"], "DENY")
+        self.assertEqual(result["failureCategory"], "semantic_boundary_insufficient")
+```
+
+- [x] **Step 2: Run admission tests to verify RED**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_contract.DenseInfluenceAdmissionTest -v
+```
+
+Expected: admission module is missing.
+
+- [x] **Step 3: Implement explicit admission with no implicit approval**
+
+```text
+python3 forge/stage4_review/admit_dense_influence.py \
+  --evidence dense-evidence.v1.json \
+  --visual-review review/visual-review.json \
+  --target-spec object-sculpt-spec.json \
+  --scope global-massing \
+  --approve-influence \
+  --out influence-admission.json
+```
+
+Without `--approve-influence`, return `NEEDS_USER_ACTION` and write no ALLOW record. Refuse a scope above the extractor/validator ceiling. Recompute every hash when creating and consuming admission. A changed GLB, evidence, review, scope, map, or target spec invalidates the approval.
+
+- [x] **Step 4: Run admission tests to verify GREEN**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_contract.DenseInfluenceAdmissionTest -v
+```
+
+Expected: no-approval, tuple binding, scope ceiling, stale review, changed target spec, and changed evidence tests pass.
+
+## Task 7: Reversible ObjectSculptSpec proposals and bounded fitting
+
+**Files:**
+- Create: `forge/stage2_spec/apply_dense_evidence.py`
+- Modify: `forge/tests/test_dense_evidence_contract.py`
+
+- [x] **Step 1: Write failing non-mutation and allowlist tests**
+
+```python
+class DenseEvidenceProposalTest(unittest.TestCase):
+    def test_global_proposal_is_copy_only_and_reversible(self):
+        accepted = valid_spec()
+        before = copy.deepcopy(accepted)
+        proposal, delta, fit_plan = build_proposal(accepted, self.evidence, self.admission)
+        self.assertEqual(accepted, before)
+        self.assertNotEqual(proposal, accepted)
+        self.assertEqual(apply_reverse_delta(proposal, delta), accepted)
+        self.assertTrue(all(item["scope"] == "global-massing" for item in delta["changes"]))
+
+    def test_forbidden_fields_never_change(self):
+        proposal, delta, _ = build_proposal(valid_spec(), self.evidence, self.admission)
+        for change in delta["changes"]:
+            self.assertIn(change["field"], GLOBAL_NUMERIC_FIELDS)
+        self.assertEqual(component_signature(proposal), component_signature(valid_spec()))
+```
+
+- [x] **Step 2: Run proposal tests to verify RED**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_contract.DenseEvidenceProposalTest -v
+```
+
+Expected: proposal module is missing.
+
+- [x] **Step 3: Implement global-massing proposal math**
+
+```python
+def bounded_ratio(measured: float, authored: float, maximum_delta: float) -> float:
+    raw = measured / authored
+    return min(1.0 + maximum_delta, max(1.0 - maximum_delta, raw))
+
+def scale_dimensions(component: dict[str, object], xyz: tuple[float, float, float]) -> None:
+    dimensions = component.get("dimensions")
+    if isinstance(dimensions, dict):
+        for field, factor in (("width", xyz[0]), ("height", xyz[1]), ("depth", xyz[2])):
+            if isinstance(dimensions.get(field), (int, float)):
+                dimensions[field] = float(dimensions[field]) * factor
+```
+
+Derive the authored aggregate bounds from existing component dimensions/transforms, compute one shared axis scale, clamp each axis using `qualityContract.denseEvidence.maxNumericDeltaFraction` or default `0.20`, apply it consistently to dimensions and local positions, and record old/new/measured/confidence/source-region/reason for every numeric change. Radius uses the mean X/Z factor; length uses the component's declared dominant axis only when present, otherwise it is not changed.
+
+- [x] **Step 4: Implement component-measurement proposals**
+
+Require a valid component map and admission at component scope. For each mapping, read only reviewed region bounds and modify only explicitly permitted dimension fields. Reject hierarchy, topology, material, pivot, socket, attachment, interaction, repetition, or geometry-descriptor paths with `influence_scope_exceeded`.
+
+- [x] **Step 5: Emit proposal, delta, and fit plan atomically**
+
+```text
+python3 forge/stage2_spec/apply_dense_evidence.py \
+  --spec object-sculpt-spec.json \
+  --evidence dense-evidence.v1.json \
+  --admission influence-admission.json \
+  [--component-map component-evidence-map.json] \
+  --out proposed-object-sculpt-spec.json \
+  --delta-out spec-delta.json \
+  --fit-plan-out fit-plan.json
+```
+
+The `fit-plan.json` names the bounded parameter vector, baseline hashes, correction group, required browser views, minimum improvement `0.01`, maximum source silhouette regression `0.02`, and existing correction-loop budget. No `--in-place` flag exists.
+
+- [x] **Step 6: Validate proposed specs through the existing validator**
+
+Run within the test:
+
+```bash
+python3 forge/stage2_spec/validate_sculpt_spec.py proposed-object-sculpt-spec.json
+python3 forge/stage2_spec/validate_sculpt_spec.py proposed-object-sculpt-spec.json --strict-quality
+```
+
+If either fails, persist proposal/delta/fit plan and return `strict_quality_failed`; never change the accepted spec or factory.
+
+- [x] **Step 7: Run proposal tests to verify GREEN**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_contract.DenseEvidenceProposalTest -v
+```
+
+Expected: non-mutation, reversibility, bounds, global consistency, component allowlist, scope, admission-hash, and strict-validation tests pass.
+
+## Task 8: Optional workflow-state routing without image-only regression
+
+**Files:**
+- Modify: `forge/_shared/workflow_state.py`
+- Modify: `forge/state.py`
+- Modify: `forge/tests/test_workflow_state.py`
+
+- [x] **Step 1: Write failing opt-in routing tests**
+
+```python
+def test_dense_evidence_step_is_absent_by_default(self):
+    ids = [item["id"] for item in new_state("reference.png")["checklist"]]
+    self.assertNotIn("dense-evidence-admission", ids)
+
+def test_dense_evidence_route_adds_ordered_optional_gate(self):
+    state = new_state("reference.png", spec="spec.json", dense_evidence=True)
+    ids = [item["id"] for item in state["checklist"]]
+    self.assertLess(ids.index("reference-admission"), ids.index("dense-evidence-admission"))
+    self.assertLess(ids.index("dense-evidence-admission"), ids.index("strict-validation"))
+    command = next(item["command"] for item in state["checklist"] if item["id"] == "dense-evidence-admission")
+    self.assertIn("check_dense_evidence.py", command)
+```
+
+- [x] **Step 2: Run workflow tests to verify RED**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_workflow_state.WorkflowStateTest.test_dense_evidence_step_is_absent_by_default forge.tests.test_workflow_state.WorkflowStateTest.test_dense_evidence_route_adds_ordered_optional_gate -v
+```
+
+Expected: `new_state()` rejects `dense_evidence`.
+
+- [x] **Step 3: Add the opt-in state flag and setup step**
+
+```python
+DENSE_EVIDENCE_STEPS: Final = ((
+    "dense-evidence-admission",
+    "Validate dense-evidence.v1.json, record hash-bound influence approval, and emit a proposed spec; never mutate {spec} in place",
+),)
+
+def new_state(..., dense_evidence: bool = False) -> dict[str, Any]:
+    # Insert only when requested and persist artifacts.denseEvidenceSelected.
+```
+
+Add `forge/state.py init --dense-evidence`, store the selection in `artifacts`, and validate it as a boolean. Keep schema version 1 backward compatible by treating an absent field as false. Do not add this route to `character` or `cs2`; return a clear state error if combined in version 1.
+
+- [x] **Step 4: Run workflow tests to verify GREEN**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_workflow_state -v
+```
+
+Expected: all existing workflow tests plus opt-in route tests pass unchanged for image-only runs.
+
+## Task 9: Dual-baseline comparison and final acceptance decision
+
+**Files:**
+- Create: `forge/stage4_review/compare_dense_evidence.py`
+- Create: `forge/tests/test_dense_evidence_review.py`
+
+- [x] **Step 1: Write failing dual-baseline tests**
+
+```python
+class DenseEvidenceReviewTest(unittest.TestCase):
+    def test_candidate_needs_source_safety_and_evidence_improvement(self):
+        report = compare_dense_evidence(
+            baseline_source={"silhouetteIou": 0.81, "criticalFeatures": {"roof": True}},
+            candidate_source={"silhouetteIou": 0.80, "criticalFeatures": {"roof": True}},
+            baseline_evidence={"massingSimilarity": 0.70},
+            candidate_evidence={"massingSimilarity": 0.72},
+            deterministic_gates=clean_gates(),
+            admission=valid_admission(),
+        )
+        self.assertEqual(report["decision"], "ALLOW")
+
+    def test_glb_improvement_cannot_hide_source_regression(self):
+        report = compare_dense_evidence(
+            baseline_source={"silhouetteIou": 0.81, "criticalFeatures": {"roof": True}},
+            candidate_source={"silhouetteIou": 0.78, "criticalFeatures": {"roof": True}},
+            baseline_evidence={"massingSimilarity": 0.50},
+            candidate_evidence={"massingSimilarity": 0.95},
+            deterministic_gates=clean_gates(),
+            admission=valid_admission(),
+        )
+        self.assertEqual(report["failureCategory"], "source_fidelity_regression")
+```
+
+- [x] **Step 2: Run review tests to verify RED**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_review.DenseEvidenceReviewTest -v
+```
+
+Expected: comparison module is missing.
+
+- [x] **Step 3: Implement the exact decision rule**
+
+```python
+source_regression = baseline_source_iou - candidate_source_iou
+evidence_improvement = max(
+    candidate_evidence[name] - baseline_evidence[name]
+    for name in declared_evidence_targets
+)
+allowed = (
+    not critical_regressions
+    and source_regression <= 0.02
+    and evidence_improvement >= 0.01
+    and all(deterministic_gates.values())
+    and within_approved_scope
+    and browser_hashes_complete
+)
+```
+
+Consume recorded image-only and candidate source metrics plus provider/procedural geometry-pass metrics. Require strict-quality, pass order, turntable, attachment, and intersection gates. For merged GLBs, per-region claims remain blocked even if global scores improve. Output `source_fidelity_regression`, `fit_no_improvement`, `influence_scope_exceeded`, or `browser_evidence_missing` as appropriate.
+
+- [x] **Step 4: Add runtime-source exclusion tests**
+
+Scan the generated candidate factory and its package graph. Fail if it contains `GLTFLoader`, `.glb`, `.obj`, binary `fetch(`, provider endpoint strings, signed URLs, or copied mesh payload markers. Assert that the accepted runtime remains a TypeScript factory built from the proposed spec.
+
+- [x] **Step 5: Run review tests to verify GREEN**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_review -v
+```
+
+Expected: source regression, evidence improvement, critical feature, missing browser evidence, dirty deterministic gate, scope, and runtime-loader tests pass.
+
+## Task 10: Documentation and discoverability
+
+**Files:**
+- Create: `docs/integrations/trellis-dense-evidence.md`
+- Modify: `SKILL.md`
+- Modify: `README.md`
+- Modify: `ROADMAP.md`
+- Modify: `CHANGELOG.md`
+- Modify: `forge/tests/test_dense_evidence_contract.py`
+
+- [x] **Step 1: Write failing documentation contract tests**
+
+```python
+class DenseEvidenceDocumentationTest(unittest.TestCase):
+    def test_docs_define_authority_cost_and_runtime_boundaries(self):
+        text = DOC.read_text(encoding="utf-8")
+        for phrase in (
+            "source image is authoritative", "maxCostUsd = 0", "offline",
+            "global-massing", "component-measurements", "no provider call",
+            "never shipped at runtime", "proposed-object-sculpt-spec.json",
+        ):
+            self.assertIn(phrase, text)
+
+    def test_every_changed_markdown_starts_with_last_updated(self):
+        for path in CHANGED_MARKDOWN:
+            self.assertRegex(path.read_text(encoding="utf-8").splitlines()[0], r"^> Last updated: 2026-09-01 \d{2}:\d{2}$")
+```
+
+- [x] **Step 2: Run documentation tests to verify RED**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_contract.DenseEvidenceDocumentationTest -v
+```
+
+Expected: integration guide is missing.
+
+- [x] **Step 3: Write the operating guide and route documentation**
+
+Document the exact order:
+
+```text
+cached free_assist run
+  -> reviewed alignment manifest
+  -> offline extraction/cache
+  -> stdlib evidence validation
+  -> optional explicit component map
+  -> hash-bound human influence approval
+  -> proposed spec + reversible delta + fit plan
+  -> existing strict validation and factory generation
+  -> browser A/B comparison against source and advisory GLB
+  -> accept proposal or retain image-only baseline
+```
+
+State single-view uncertainty, merged-mesh limitation, immutable provider artifacts, no automatic semantic labels, no token arguments, no upload/provider retry, no quota use, no runtime GLB, and no character-route replacement. Include failure categories, exit codes, cache invalidation, resume behavior, and complete example commands.
+
+- [x] **Step 4: Update public capability status**
+
+Add the new optional route to `SKILL.md` after free generative reference acquisition, and to README/roadmap/changelog without implying that TRELLIS directly generates the final semantic factory. Keep every changed Markdown file's `Last updated` line first.
+
+- [x] **Step 5: Run documentation tests to verify GREEN**
+
+Run:
+
+```bash
+python3 -m unittest forge.tests.test_dense_evidence_contract.DenseEvidenceDocumentationTest -v
+```
+
+Expected: route, safety, authority, uncertainty, and Last-updated contracts pass.
+
+## Task 11: Offline integration, cached-house acceptance, and regression verification
+
+**Files:**
+- Modify: `integrations/mesh3d/tests/test_dense_evidence.py`
+- Modify: `forge/tests/test_dense_evidence_contract.py`
+- Modify: `forge/tests/test_dense_evidence_review.py`
+- Create locally, do not commit: cached-run `dense-evidence/` artifacts listed by the specification
+
+- [x] **Step 1: Add a generated-fixture end-to-end test**
+
+```python
+def test_cached_run_to_proposed_spec_is_offline_and_preserves_inputs(self):
+    before = hash_tree(self.run / "raw", self.run / "normalized", self.run / "review")
+    evidence = extract_run(self.run, (self.source,), valid_alignment(), self.out)
+    admission = approved_global_admission(evidence, self.spec, self.review)
+    proposal, delta, fit_plan = build_proposal(self.spec_payload, evidence, admission)
+    self.assertEqual(hash_tree(self.run / "raw", self.run / "normalized", self.run / "review"), before)
+    self.assertTrue(delta["changes"])
+    self.assertEqual(fit_plan["maximumSourceSilhouetteRegression"], 0.02)
+    self.assertEqual(PROVIDER_CALLS, [])
+```
+
+- [x] **Step 2: Run all focused suites**
+
+Run:
+
+```bash
+uv run --project integrations/mesh3d python -m unittest integrations.mesh3d.tests.test_dense_evidence -v
+python3 -m unittest forge.tests.test_dense_evidence_contract forge.tests.test_dense_evidence_review forge.tests.test_workflow_state -v
+```
+
+Expected: all focused optional and stdlib tests pass with no network access.
+
+- [x] **Step 3: Exercise the cached whimsical-house boundary read-only**
+
+Use:
+
+```text
+/Users/nicco/Desktop/img2threejs-free-assist-artifacts/whimsical-hearth-house/runs/20260831T234449.690726Z-16e8f1d8c0
+```
+
+First hash all immutable input artifacts. Author a reviewed `alignment.json` from the existing browser evidence; do not create new provider output. Run `propose-scope`, then `extract`. Expected:
+
+- provider calls: `0`;
+- monetary cost: `$0`;
+- raw/normalized/review input hashes unchanged;
+- semantic boundary: merged/insufficient;
+- maximum scope: `global-massing`;
+- approved scope in evidence: `none`;
+- component influence: denied;
+- extraction/proposal artifacts: preserved locally.
+
+Do not manufacture an `ALLOW` influence record merely to make the acceptance green. The cached house succeeds by demonstrating the conservative boundary. Any actual global-massing approval remains a separate user decision tied to exact hashes.
+
+- [x] **Step 4: Generate and typecheck only when the proposal is actually admitted**
+
+If a hash-bound `global-massing` approval exists, run:
+
+```bash
+python3 forge/stage2_spec/validate_sculpt_spec.py proposed-object-sculpt-spec.json --strict-quality
+python3 forge/stage3_build/generate_threejs_factory.py proposed-object-sculpt-spec.json --out src/createObjectModel.ts
+IMG2THREEJS_SHOWCASE_ROOT=/Users/nicco/.config/superpowers/worktrees/img2threejs-showcase/cartoon-courier python3 forge/tests/test_showcase_tsc_smoke.py
+```
+
+If approval is absent, record `influence_not_approved` and stop before factory generation. This is expected fail-closed behavior, not a failed implementation.
+
+- [x] **Step 5: Run the complete offline test suites**
+
+Run:
+
+```bash
+python3 -m unittest discover -s forge/tests -v
+uv run --project integrations/mesh3d python -m unittest discover -s integrations/mesh3d/tests -v
+```
+
+Expected: the existing forge suite and new mesh3d suite pass; documented environment-dependent skips remain explicit; no test performs an external request.
+
+- [x] **Step 6: Run security, runtime, and formatting checks**
+
+Run:
+
+```bash
+rg -n --hidden -g '!integrations/mesh3d/.venv/**' -g '!*.lock' '(hf_[A-Za-z0-9]{20,}|Bearer[[:space:]]+[A-Za-z0-9._-]+|token=|authorization)' .
+rg -n '(GLTFLoader|\.glb|\.obj|trellis-community|stabilityai/stable-fast-3d)' src integrations/mesh3d/dense_evidence forge/stage1_intake/check_dense_evidence.py forge/stage2_spec/apply_dense_evidence.py
+git diff --check
+git status --short --branch
+```
+
+Expected: no credential match; any `.glb`/`.obj` matches are confined to offline adapter/validator paths, never runtime `src`; no whitespace errors; only intended files plus preserved pre-existing changes are listed.
+
+- [x] **Step 7: Produce a final evidence summary without committing**
+
+Report:
+
+- focused and full test counts/results;
+- exact cached-house artifact paths and hashes;
+- zero provider calls and zero spend;
+- maximum and approved influence scopes;
+- whether a proposed spec/factory was generated or correctly blocked;
+- unchanged immutable input hashes;
+- remaining single-view and proxy-quality limitations;
+- complete `git status --short --branch` separating prior edits from this implementation.
+
+## Self-review against the approved specification
+
+- Source image, ObjectSculptSpec, and generated-mesh authority are separated explicitly.
+- The extractor is optional-dependency code; `forge/` remains stdlib-only and communicates through JSON.
+- Merged GLBs are capped at global evidence; multipart boundaries stay candidates until explicit mapping.
+- Influence has exactly `none`, `global-massing`, and `component-measurements` scopes.
+- Approval binds the exact GLB, evidence, review, scope, and target-spec hashes.
+- Hidden single-view surfaces remain non-authoritative.
+- The accepted spec is never overwritten; proposal and delta are reversible.
+- The final runtime is code-only and rejects GLB/OBJ loaders or provider artifacts.
+- Dual-baseline acceptance prevents a provider match from hiding source-image regression.
+- Cache and resume are downstream-only and cannot trigger provider work.
+- Automated tests are offline; the cached house is reused without a new upload or generation.
+- The image-only and character routes remain backward compatible.
+- No commit, push, deployment, destructive cleanup, purchase, refill, or quota-consuming action is part of this plan.
+
+## Execution checkpoint
+
+After approval, execute this plan inline with `superpowers:executing-plans`, then use `superpowers:test-driven-development` for every implementation task, `superpowers:systematic-debugging` for unexpected failures, and `superpowers:verification-before-completion` before reporting success. Pause if the cached house needs a new influence approval; extraction itself remains offline and read-only over existing provider artifacts.
+
+## Execution record — 2026-09-01
+
+All tasks are implemented and verified: forge suite 1169 tests OK (29
+environment-dependent skips), mesh3d suite 14 tests OK, security/runtime/
+whitespace checks clean. The cached whimsical-house acceptance was completed
+end-to-end offline (0 provider calls, $0, immutable inputs hash-verified
+unchanged): extraction, validation, hash-bound `global-massing` admission,
+reversible proposal, typechecked candidate factory, and the dual-baseline
+browser A/B. Final decision: **DENY — retain the image-only baseline**
+(`dense-evidence/ab/ab-decision.json`): the candidate improves the declared
+evidence target massingSimilarity 0.649 → 0.923 but regresses source
+silhouette IoU by 0.0211 (cap 0.02), and the turntable/intersection gates
+fail on the generated blockout for both variants alike. The conservative
+boundary held exactly as designed; artifacts and metrics are preserved under
+the run's `dense-evidence/ab/` directory.

--- a/forge/_shared/workflow_state.py
+++ b/forge/_shared/workflow_state.py
@@ -38,6 +38,13 @@ SETUP_STEPS: Final = (
     ("strict-validation", "python3 forge/stage2_spec/validate_sculpt_spec.py {spec} --strict-quality"),
 )
 
+DENSE_EVIDENCE_STEPS: Final = (
+    (
+        "dense-evidence-admission",
+        "python3 forge/stage1_intake/check_dense_evidence.py --evidence dense-evidence/dense-evidence.v1.json --spec {spec} --out dense-evidence-validation.json; require a separate hash-bound influence approval before emitting a proposed spec and never mutate {spec} in place",
+    ),
+)
+
 CHARACTER_STEPS: Final = (
     (
         "character-contract-read",
@@ -101,12 +108,24 @@ def new_state(
     spec: str = "",
     max_per_pass: int = 3,
     max_total: int = 6,
+    dense_evidence: bool = False,
 ) -> dict[str, Any]:
     if profile not in {"generic", "cs2", "character"}:
         raise WorkflowStateError("profile must be generic, cs2, or character")
     if max_per_pass < 1 or max_total < 1 or max_per_pass > max_total:
         raise WorkflowStateError("loop limits require 1 <= max-per-pass <= max-total")
+    if not isinstance(dense_evidence, bool):
+        raise WorkflowStateError("dense evidence selection must be a boolean")
+    if dense_evidence and profile != "generic":
+        raise WorkflowStateError("dense evidence version 1 is available only for the generic profile")
     setup = [_step(*item, scope="setup") for item in SETUP_STEPS]
+    if dense_evidence:
+        dense_insertion = next(
+            index for index, item in enumerate(setup) if item["id"] == "reference-admission"
+        ) + 1
+        setup[dense_insertion:dense_insertion] = [
+            _step(*item, scope="setup") for item in DENSE_EVIDENCE_STEPS
+        ]
     insertion = next(index for index, item in enumerate(setup) if item["id"] == "local-spec-search")
     if profile == "cs2":
         setup[insertion:insertion] = [_step(*item, scope="setup") for item in CS2_STEPS]
@@ -131,7 +150,11 @@ def new_state(
             "maxPerPass": max_per_pass,
             "maxTotal": max_total,
         },
-        "artifacts": {"reference": reference, "spec": spec},
+        "artifacts": {
+            "reference": reference,
+            "spec": spec,
+            "denseEvidenceSelected": dense_evidence,
+        },
         "passHistory": [],
         "reviewCursor": 0,
         "iterationAction": "initial",
@@ -174,6 +197,16 @@ def validate_state(state: Any) -> dict[str, Any]:
     artifacts = state.get("artifacts")
     if not isinstance(artifacts, dict) or not artifacts.get("reference"):
         raise WorkflowStateError("state artifacts.reference is required")
+    dense_selected = artifacts.get("denseEvidenceSelected", False)
+    if not isinstance(dense_selected, bool):
+        raise WorkflowStateError("state artifacts.denseEvidenceSelected must be a boolean")
+    if dense_selected and state.get("profile") != "generic":
+        raise WorkflowStateError("dense evidence version 1 is available only for the generic profile")
+    has_dense_step = any(
+        entry.get("id") == "dense-evidence-admission" for entry in checklist
+    )
+    if dense_selected != has_dense_step:
+        raise WorkflowStateError("dense evidence selection and checklist step disagree")
     review_cursor = state.get("reviewCursor", 0)
     if not isinstance(review_cursor, int) or review_cursor < 0:
         raise WorkflowStateError("state reviewCursor must be a non-negative integer")

--- a/forge/stage1_intake/check_dense_evidence.py
+++ b/forge/stage1_intake/check_dense_evidence.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Pure-stdlib validator for bounded dense-evidence records."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCOPES = ("none", "global-massing", "component-measurements")
+SCOPE_RANK = {value: index for index, value in enumerate(SCOPES)}
+HASH_FIELDS = ("glbSha256", "objSha256", "alignmentSha256")
+COMPONENT_FIELDS = {
+    "dimensions.width",
+    "dimensions.height",
+    "dimensions.depth",
+    "dimensions.radius",
+    "dimensions.length",
+}
+TOP_LEVEL_FIELDS = {
+    "schemaVersion",
+    "kind",
+    "extractorVersion",
+    "createdAt",
+    "provenance",
+    "cache",
+    "admission",
+    "alignment",
+    "globalGeometry",
+    "regions",
+    "uncertainty",
+    "extensions",
+}
+ALIGNMENT_FIELDS = {
+    "schemaVersion",
+    "profileVersion",
+    "sourceViewTransform",
+    "upAxis",
+    "forwardAxis",
+    "handedness",
+    "axisOperationAudit",
+    "chiralityStatus",
+    "sourceViewSilhouetteIou",
+    "projectedAspectRatioError",
+    "browserCaptures",
+    "extensions",
+}
+
+
+def _canonical_sha256(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+
+
+def _is_hash(value: object) -> bool:
+    return isinstance(value, str) and len(value) == 64 and all(
+        character in "0123456789abcdef" for character in value
+    )
+
+
+def _finite(value: object) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(float(value))
+    )
+
+
+def _component_ids(spec: dict[str, object]) -> set[str]:
+    found: set[str] = set()
+
+    def visit(items: object) -> None:
+        if not isinstance(items, list):
+            return
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if isinstance(item.get("id"), str):
+                found.add(item["id"])
+            visit(item.get("children"))
+
+    visit(spec.get("componentTree"))
+    return found
+
+
+def _failure(
+    errors: list[str], categories: set[str], category: str, message: str
+) -> None:
+    errors.append(message)
+    categories.add(category)
+
+
+def _validate_global_geometry(
+    geometry: object, errors: list[str], categories: set[str]
+) -> None:
+    if not isinstance(geometry, dict):
+        _failure(errors, categories, "schema_invalid", "globalGeometry must be an object")
+        return
+    bounds = geometry.get("bounds")
+    if not isinstance(bounds, dict):
+        _failure(errors, categories, "schema_invalid", "globalGeometry.bounds is required")
+    else:
+        for field in ("min", "max", "size"):
+            values = bounds.get(field)
+            if not isinstance(values, list) or len(values) != 3 or not all(
+                _finite(value) for value in values
+            ):
+                _failure(errors, categories, "schema_invalid", f"bounds.{field} must be finite xyz")
+        size = bounds.get("size")
+        if isinstance(size, list) and len(size) == 3 and all(_finite(item) for item in size):
+            if any(float(item) <= 0 for item in size):
+                _failure(errors, categories, "degenerate_geometry", "bounds size must be positive")
+    occupancy = geometry.get("occupancyGrid")
+    if not isinstance(occupancy, dict):
+        _failure(errors, categories, "schema_invalid", "occupancyGrid is required")
+    else:
+        resolution = occupancy.get("resolution")
+        if not isinstance(resolution, int) or isinstance(resolution, bool) or not 1 <= resolution <= 32:
+            _failure(
+                errors,
+                categories,
+                "measurement_limit_exceeded",
+                "occupancy resolution must be in [1, 32]",
+            )
+        cells = occupancy.get("occupiedCells")
+        if not isinstance(cells, list):
+            _failure(errors, categories, "schema_invalid", "occupiedCells must be a list")
+        elif isinstance(resolution, int):
+            for cell in cells:
+                if not isinstance(cell, list) or len(cell) != 3 or not all(
+                    isinstance(value, int) and 0 <= value < resolution for value in cell
+                ):
+                    _failure(errors, categories, "schema_invalid", "occupied cell is out of range")
+                    break
+            if occupancy.get("occupiedCellCount") != len(cells):
+                _failure(errors, categories, "schema_invalid", "occupiedCellCount does not match")
+    sections = geometry.get("crossSections")
+    if not isinstance(sections, list):
+        _failure(errors, categories, "schema_invalid", "crossSections must be a list")
+    elif len(sections) > 32:
+        _failure(
+            errors, categories, "measurement_limit_exceeded", "more than 32 cross-sections"
+        )
+    else:
+        for section in sections:
+            profile = section.get("profile") if isinstance(section, dict) else None
+            if not isinstance(profile, list) or len(profile) > 64:
+                _failure(
+                    errors,
+                    categories,
+                    "measurement_limit_exceeded",
+                    "cross-section profile exceeds 64 points",
+                )
+                continue
+            if not all(
+                isinstance(point, list)
+                and len(point) == 2
+                and all(_finite(value) for value in point)
+                for point in profile
+            ):
+                _failure(errors, categories, "schema_invalid", "profile points must be finite xy")
+
+
+def _validate_alignment(
+    alignment: object,
+    expected_hash: object,
+    errors: list[str],
+    categories: set[str],
+) -> None:
+    if not isinstance(alignment, dict):
+        _failure(errors, categories, "schema_invalid", "alignment must be an object")
+        return
+    unknown = set(alignment) - ALIGNMENT_FIELDS
+    required = ALIGNMENT_FIELDS - {"extensions"}
+    missing = required - set(alignment)
+    if unknown or missing:
+        _failure(
+            errors,
+            categories,
+            "schema_invalid",
+            f"alignment fields mismatch: missing={sorted(missing)} unknown={sorted(unknown)}",
+        )
+    if expected_hash != _canonical_sha256(alignment):
+        _failure(errors, categories, "evidence_hash_mismatch", "alignment content hash drift")
+    if alignment.get("schemaVersion") != 1 or alignment.get("profileVersion") != "source-view-alignment-v1":
+        _failure(errors, categories, "schema_invalid", "alignment version is invalid")
+    transform = alignment.get("sourceViewTransform")
+    if not isinstance(transform, list) or len(transform) != 16 or not all(
+        _finite(value) for value in transform
+    ):
+        _failure(errors, categories, "schema_invalid", "sourceViewTransform must be 16 finite numbers")
+    if (
+        alignment.get("upAxis") != "+Y"
+        or alignment.get("forwardAxis") != "+Z"
+        or alignment.get("handedness") != "right-handed"
+    ):
+        _failure(errors, categories, "schema_invalid", "alignment canonical axes are invalid")
+    if alignment.get("chiralityStatus") not in {"reviewed", "ambiguous"}:
+        _failure(errors, categories, "schema_invalid", "alignment chiralityStatus is invalid")
+    audit = alignment.get("axisOperationAudit")
+    if not isinstance(audit, list) or not audit or not all(
+        isinstance(item, str) and item.strip() for item in audit
+    ):
+        _failure(errors, categories, "schema_invalid", "alignment axis audit is required")
+    iou = alignment.get("sourceViewSilhouetteIou")
+    aspect = alignment.get("projectedAspectRatioError")
+    if not _finite(iou) or not 0 <= float(iou) <= 1 or not _finite(aspect) or not 0 <= float(aspect) <= 1:
+        _failure(errors, categories, "schema_invalid", "alignment metrics must be in [0, 1]")
+    elif float(iou) < 0.65 or float(aspect) > 0.15:
+        _failure(errors, categories, "alignment_failed", "alignment quality thresholds were not met")
+    captures = alignment.get("browserCaptures")
+    if not isinstance(captures, list) or not captures:
+        _failure(errors, categories, "schema_invalid", "alignment browser captures are required")
+    else:
+        for capture in captures:
+            if (
+                not isinstance(capture, dict)
+                or set(capture) != {"path", "sha256", "view"}
+                or not isinstance(capture.get("path"), str)
+                or not isinstance(capture.get("view"), str)
+                or not _is_hash(capture.get("sha256"))
+            ):
+                _failure(errors, categories, "schema_invalid", "alignment browser capture is invalid")
+                break
+
+
+def _validate_component_map(
+    evidence: dict[str, object],
+    spec: dict[str, object] | None,
+    component_map: dict[str, object],
+    errors: list[str],
+    categories: set[str],
+) -> None:
+    admission = evidence.get("admission", {})
+    if not isinstance(admission, dict) or admission.get("maximumInfluenceScope") != "component-measurements":
+        _failure(
+            errors,
+            categories,
+            "semantic_boundary_insufficient",
+            "component mapping exceeds the evidence scope ceiling",
+        )
+        return
+    if spec is None:
+        _failure(errors, categories, "component_mapping_invalid", "target spec is required")
+        return
+    if component_map.get("schemaVersion") != 1 or component_map.get("kind") != "component-evidence-map":
+        _failure(errors, categories, "component_mapping_invalid", "component map contract is invalid")
+    if component_map.get("targetSpecSha256") != _canonical_sha256(spec):
+        _failure(errors, categories, "evidence_hash_mismatch", "component map target spec hash drift")
+    if component_map.get("evidenceSha256") != _canonical_sha256(evidence):
+        _failure(errors, categories, "evidence_hash_mismatch", "component map evidence hash drift")
+    provenance = evidence.get("provenance", {})
+    if not isinstance(provenance, dict) or component_map.get("glbSha256") != provenance.get("glbSha256"):
+        _failure(errors, categories, "evidence_hash_mismatch", "component map GLB hash drift")
+    component_ids = _component_ids(spec)
+    region_ids = {
+        item.get("regionId")
+        for item in evidence.get("regions", [])
+        if isinstance(item, dict) and isinstance(item.get("regionId"), str)
+    }
+    used_selectors: set[str] = set()
+    mappings = component_map.get("mappings")
+    if not isinstance(mappings, list):
+        _failure(errors, categories, "component_mapping_invalid", "mappings must be a list")
+        return
+    for mapping in mappings:
+        if not isinstance(mapping, dict):
+            _failure(errors, categories, "component_mapping_invalid", "mapping must be an object")
+            continue
+        if mapping.get("componentId") not in component_ids:
+            _failure(errors, categories, "component_mapping_invalid", "mapping names unknown component")
+        confidence = mapping.get("confidence")
+        if not _finite(confidence) or float(confidence) < 0.80 or float(confidence) > 1.0:
+            _failure(errors, categories, "component_mapping_invalid", "mapping confidence must be >= 0.80")
+        if mapping.get("observedSurface") is not True:
+            _failure(errors, categories, "component_mapping_invalid", "hidden surfaces cannot be measured")
+        if not isinstance(mapping.get("evidenceRefs"), list) or not mapping["evidenceRefs"]:
+            _failure(errors, categories, "component_mapping_invalid", "mapping evidenceRefs are required")
+        fields = mapping.get("permittedFields")
+        if not isinstance(fields, list) or not fields or any(field not in COMPONENT_FIELDS for field in fields):
+            _failure(errors, categories, "component_mapping_invalid", "mapping field is forbidden")
+        selectors = mapping.get("selectors")
+        if not isinstance(selectors, list) or not selectors:
+            _failure(errors, categories, "component_mapping_invalid", "selectors are required")
+            continue
+        for selector in selectors:
+            region_id = selector.get("regionId") if isinstance(selector, dict) else None
+            if region_id not in region_ids or region_id in used_selectors:
+                _failure(errors, categories, "component_mapping_invalid", "selector is unknown or duplicated")
+            if isinstance(region_id, str):
+                used_selectors.add(region_id)
+
+
+def validate_dense_evidence(
+    evidence: object,
+    expected_spec: dict[str, object] | None = None,
+    component_map: dict[str, object] | None = None,
+) -> dict[str, object]:
+    errors: list[str] = []
+    categories: set[str] = set()
+    maximum_scope = "none"
+    if not isinstance(evidence, dict):
+        _failure(errors, categories, "schema_invalid", "evidence must be a JSON object")
+    else:
+        unknown = set(evidence) - TOP_LEVEL_FIELDS
+        missing = TOP_LEVEL_FIELDS - set(evidence)
+        if unknown or missing:
+            _failure(
+                errors,
+                categories,
+                "schema_invalid",
+                f"top-level fields mismatch: missing={sorted(missing)} unknown={sorted(unknown)}",
+            )
+        if evidence.get("schemaVersion") != 1 or evidence.get("kind") != "dense-evidence":
+            _failure(errors, categories, "schema_invalid", "unsupported dense-evidence contract")
+        provenance = evidence.get("provenance")
+        if not isinstance(provenance, dict):
+            _failure(errors, categories, "schema_invalid", "provenance is required")
+        else:
+            for field in HASH_FIELDS:
+                if not _is_hash(provenance.get(field)):
+                    _failure(errors, categories, "evidence_hash_mismatch", f"invalid {field}")
+            sources = provenance.get("sourceImageSha256")
+            if not isinstance(sources, list) or not sources or not all(_is_hash(item) for item in sources):
+                _failure(errors, categories, "evidence_hash_mismatch", "invalid source image hashes")
+        expected_alignment_hash = (
+            provenance.get("alignmentSha256") if isinstance(provenance, dict) else None
+        )
+        _validate_alignment(
+            evidence.get("alignment"), expected_alignment_hash, errors, categories
+        )
+        cache = evidence.get("cache")
+        if not isinstance(cache, dict) or not all(
+            _is_hash(cache.get(field))
+            for field in ("baseExtractionKey", "measurementConfigSha256")
+        ):
+            _failure(errors, categories, "evidence_hash_mismatch", "invalid cache hashes")
+        admission = evidence.get("admission")
+        if not isinstance(admission, dict):
+            _failure(errors, categories, "schema_invalid", "admission is required")
+        else:
+            maximum_scope = str(admission.get("maximumInfluenceScope", "none"))
+            approved_scope = admission.get("approvedInfluenceScope")
+            if maximum_scope not in SCOPES or approved_scope != "none":
+                _failure(errors, categories, "schema_invalid", "evidence scope contract is invalid")
+            if admission.get("semanticStatus") == "insufficient" and maximum_scope == "component-measurements":
+                _failure(
+                    errors,
+                    categories,
+                    "semantic_boundary_insufficient",
+                    "insufficient semantics cannot authorize component evidence",
+                )
+        uncertainty = evidence.get("uncertainty")
+        if not isinstance(uncertainty, dict) or uncertainty.get("hiddenSurfacePolicy") != "non-authoritative":
+            _failure(errors, categories, "schema_invalid", "hidden surfaces must be non-authoritative")
+        _validate_global_geometry(evidence.get("globalGeometry"), errors, categories)
+        regions = evidence.get("regions")
+        if not isinstance(regions, list) or any(
+            not isinstance(item, dict)
+            or item.get("candidateOnly") is not True
+            or item.get("semanticLabel") is not None
+            for item in regions if isinstance(regions, list)
+        ):
+            _failure(errors, categories, "schema_invalid", "regions must remain candidate-only")
+        if component_map is not None:
+            _validate_component_map(
+                evidence, expected_spec, component_map, errors, categories
+            )
+    return {
+        "schemaVersion": 1,
+        "passed": not errors,
+        "failureCategories": sorted(categories),
+        "errors": errors,
+        "maximumInfluenceScope": maximum_scope,
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--spec", type=Path)
+    parser.add_argument("--component-map", type=Path)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        evidence = json.loads(args.evidence.read_text(encoding="utf-8"))
+        spec = json.loads(args.spec.read_text(encoding="utf-8")) if args.spec else None
+        mapping = (
+            json.loads(args.component_map.read_text(encoding="utf-8"))
+            if args.component_map
+            else None
+        )
+        report = validate_dense_evidence(evidence, spec, mapping)
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps(report, ensure_ascii=False))
+        return 0 if report["passed"] else 1
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as error:
+        print(json.dumps({"passed": False, "error": str(error)}), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/forge/stage2_spec/apply_dense_evidence.py
+++ b/forge/stage2_spec/apply_dense_evidence.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python3
+"""Create reversible, bounded ObjectSculptSpec proposals from admitted evidence."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from forge.stage1_intake.check_dense_evidence import validate_dense_evidence
+
+
+GLOBAL_NUMERIC_FIELDS = frozenset(
+    {
+        "dimensions.width",
+        "dimensions.height",
+        "dimensions.depth",
+        "dimensions.radius",
+        "dimensions.length",
+        "transform.position.0",
+        "transform.position.1",
+        "transform.position.2",
+    }
+)
+COMPONENT_NUMERIC_FIELDS = frozenset(
+    {
+        "dimensions.width",
+        "dimensions.height",
+        "dimensions.depth",
+        "dimensions.radius",
+        "dimensions.length",
+    }
+)
+
+
+def _canonical_sha256(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    ).hexdigest()
+
+
+def bounded_ratio(measured: float, authored: float, maximum_delta: float) -> float:
+    if not math.isfinite(measured) or not math.isfinite(authored) or authored <= 0:
+        raise ValueError("invalid_geometry_measurement: sizes must be finite and positive")
+    raw = measured / authored
+    return min(1.0 + maximum_delta, max(1.0 - maximum_delta, raw))
+
+
+def _components(spec: dict[str, object]) -> list[tuple[dict[str, Any], list[object], tuple[float, float, float]]]:
+    result: list[tuple[dict[str, Any], list[object], tuple[float, float, float]]] = []
+
+    def visit(items: object, path: list[object], parent_position: tuple[float, float, float]) -> None:
+        if not isinstance(items, list):
+            return
+        for index, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+            transform = item.get("transform")
+            position = transform.get("position") if isinstance(transform, dict) else None
+            local = (
+                tuple(float(value) for value in position)
+                if isinstance(position, list)
+                and len(position) == 3
+                and all(isinstance(value, (int, float)) and not isinstance(value, bool) for value in position)
+                else (0.0, 0.0, 0.0)
+            )
+            world = tuple(parent_position[axis] + local[axis] for axis in range(3))
+            item_path = [*path, index]
+            result.append((item, item_path, world))
+            visit(item.get("children"), [*item_path, "children"], world)
+
+    visit(spec.get("componentTree"), ["componentTree"], (0.0, 0.0, 0.0))
+    return result
+
+
+def _authored_size(spec: dict[str, object]) -> tuple[float, float, float]:
+    minimum = [math.inf, math.inf, math.inf]
+    maximum = [-math.inf, -math.inf, -math.inf]
+    seen = False
+    for component, _path, world in _components(spec):
+        dimensions = component.get("dimensions")
+        if not isinstance(dimensions, dict):
+            continue
+        values = [dimensions.get("width"), dimensions.get("height"), dimensions.get("depth")]
+        if not all(
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(float(value))
+            and float(value) > 0
+            for value in values
+        ):
+            continue
+        seen = True
+        for axis, value in enumerate(values):
+            half = float(value) / 2.0
+            minimum[axis] = min(minimum[axis], world[axis] - half)
+            maximum[axis] = max(maximum[axis], world[axis] + half)
+    if not seen:
+        raise ValueError("invalid_geometry_measurement: no component xyz dimensions")
+    return tuple(maximum[axis] - minimum[axis] for axis in range(3))
+
+
+def _max_delta(spec: dict[str, object]) -> float:
+    quality = spec.get("qualityContract")
+    dense = quality.get("denseEvidence") if isinstance(quality, dict) else None
+    value = dense.get("maxNumericDeltaFraction") if isinstance(dense, dict) else 0.20
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(float(value))
+        or not 0 < float(value) <= 0.5
+    ):
+        raise ValueError("invalid_dense_evidence_policy: maxNumericDeltaFraction must be in (0, 0.5]")
+    return float(value)
+
+
+def _set_change(
+    component: dict[str, Any],
+    path: list[object],
+    field: str,
+    new_value: float,
+    changes: list[dict[str, object]],
+    *,
+    scope: str,
+    measured: float,
+    confidence: float,
+    source_region: str,
+) -> None:
+    tokens: list[object] = field.split(".")
+    resolved_tokens: list[object] = []
+    target: Any = component
+    for token in tokens[:-1]:
+        if isinstance(target, dict):
+            target = target.get(token)
+            resolved_tokens.append(token)
+        elif isinstance(target, list):
+            index = int(token)
+            target = target[index]
+            resolved_tokens.append(index)
+        else:
+            return
+    final = tokens[-1]
+    old: object
+    if isinstance(target, dict):
+        old = target.get(final)
+        if not isinstance(old, (int, float)) or isinstance(old, bool):
+            return
+        target[final] = new_value
+    elif isinstance(target, list):
+        index = int(final)
+        if index >= len(target) or not isinstance(target[index], (int, float)) or isinstance(target[index], bool):
+            return
+        old = target[index]
+        target[index] = new_value
+        resolved_final: object = index
+    else:
+        return
+    if isinstance(target, dict):
+        resolved_final = final
+    if math.isclose(float(old), new_value, rel_tol=1e-12, abs_tol=1e-12):
+        if isinstance(target, dict):
+            target[final] = old
+        else:
+            target[int(final)] = old
+        return
+    changes.append(
+        {
+            "path": [*path, *resolved_tokens, resolved_final],
+            "componentId": component.get("id"),
+            "field": field,
+            "old": float(old),
+            "new": float(new_value),
+            "measured": float(measured),
+            "confidence": float(confidence),
+            "sourceRegion": source_region,
+            "scope": scope,
+            "reason": "bounded dense-evidence measurement proposal",
+        }
+    )
+
+
+def _validate_binding(
+    spec: dict[str, object],
+    evidence: dict[str, object],
+    admission: dict[str, object],
+    component_map: dict[str, object] | None,
+) -> str:
+    if admission.get("decision") != "ALLOW" or not isinstance(admission.get("binding"), dict):
+        raise ValueError("influence_not_approved: ALLOW admission is required")
+    binding = admission["binding"]
+    scope = admission.get("approvedInfluenceScope")
+    provenance = evidence.get("provenance")
+    if scope not in {"global-massing", "component-measurements"}:
+        raise ValueError("influence_scope_exceeded: unsupported approval scope")
+    expected = {
+        "targetSpecSha256": _canonical_sha256(spec),
+        "evidenceSha256": _canonical_sha256(evidence),
+        "glbSha256": provenance.get("glbSha256") if isinstance(provenance, dict) else None,
+        "scope": scope,
+    }
+    if component_map is not None:
+        expected["componentMapSha256"] = _canonical_sha256(component_map)
+    if any(binding.get(field) != value for field, value in expected.items()):
+        raise ValueError("admission_hash_mismatch: approval tuple no longer matches inputs")
+    return str(scope)
+
+
+def _global_proposal(
+    proposal: dict[str, object], evidence: dict[str, object], changes: list[dict[str, object]]
+) -> tuple[float, float, float]:
+    geometry = evidence.get("globalGeometry")
+    bounds = geometry.get("bounds") if isinstance(geometry, dict) else None
+    measured = bounds.get("size") if isinstance(bounds, dict) else None
+    if not isinstance(measured, list) or len(measured) != 3:
+        raise ValueError("invalid_geometry_measurement: evidence bounds size is missing")
+    authored = _authored_size(proposal)
+    maximum_delta = _max_delta(proposal)
+    measured_values = tuple(float(value) for value in measured)
+    if not all(math.isfinite(value) and value > 0 for value in measured_values):
+        raise ValueError("invalid_geometry_measurement: evidence bounds must be finite and positive")
+    authored_anchor = math.prod(authored) ** (1.0 / 3.0)
+    measured_anchor = math.prod(measured_values) ** (1.0 / 3.0)
+    scale = tuple(
+        bounded_ratio(
+            measured_values[axis] / measured_anchor,
+            authored[axis] / authored_anchor,
+            maximum_delta,
+        )
+        for axis in range(3)
+    )
+    for component, path, _world in _components(proposal):
+        dimensions = component.get("dimensions")
+        if isinstance(dimensions, dict):
+            for field, factor, measurement in (
+                ("dimensions.width", scale[0], float(measured[0])),
+                ("dimensions.height", scale[1], float(measured[1])),
+                ("dimensions.depth", scale[2], float(measured[2])),
+            ):
+                value = dimensions.get(field.split(".")[-1])
+                if isinstance(value, (int, float)) and not isinstance(value, bool):
+                    _set_change(component, path, field, float(value) * factor, changes, scope="global-massing", measured=measurement, confidence=0.8, source_region="global")
+            radius = dimensions.get("radius")
+            if isinstance(radius, (int, float)) and not isinstance(radius, bool):
+                _set_change(component, path, "dimensions.radius", float(radius) * ((scale[0] + scale[2]) / 2.0), changes, scope="global-massing", measured=(float(measured[0]) + float(measured[2])) / 2.0, confidence=0.75, source_region="global")
+            length = dimensions.get("length")
+            dominant = component.get("dominantAxis")
+            if isinstance(length, (int, float)) and not isinstance(length, bool) and dominant in {"x", "y", "z"}:
+                axis = {"x": 0, "y": 1, "z": 2}[str(dominant)]
+                _set_change(component, path, "dimensions.length", float(length) * scale[axis], changes, scope="global-massing", measured=float(measured[axis]), confidence=0.75, source_region="global")
+        transform = component.get("transform")
+        position = transform.get("position") if isinstance(transform, dict) else None
+        if isinstance(position, list) and len(position) == 3:
+            for axis in range(3):
+                if isinstance(position[axis], (int, float)) and not isinstance(position[axis], bool):
+                    _set_change(component, path, f"transform.position.{axis}", float(position[axis]) * scale[axis], changes, scope="global-massing", measured=float(measured[axis]), confidence=0.8, source_region="global")
+    return scale
+
+
+def _component_proposal(
+    proposal: dict[str, object],
+    evidence: dict[str, object],
+    component_map: dict[str, object] | None,
+    changes: list[dict[str, object]],
+) -> None:
+    if component_map is not None:
+        mappings = component_map.get("mappings")
+        if isinstance(mappings, list):
+            for mapping in mappings:
+                fields = mapping.get("permittedFields") if isinstance(mapping, dict) else None
+                if isinstance(fields, list) and any(
+                    field not in COMPONENT_NUMERIC_FIELDS for field in fields
+                ):
+                    raise ValueError(
+                        "influence_scope_exceeded: component field is forbidden"
+                    )
+    validation = validate_dense_evidence(evidence, proposal, component_map)
+    if not validation["passed"]:
+        category = validation["failureCategories"][0] if validation["failureCategories"] else "component_mapping_invalid"
+        raise ValueError(f"{category}: {'; '.join(validation['errors'])}")
+    if component_map is None:
+        raise ValueError("component_mapping_invalid: component map is required")
+    components = {str(item.get("id")): (item, path) for item, path, _world in _components(proposal)}
+    regions = {
+        str(item.get("regionId")): item
+        for item in evidence.get("regions", [])
+        if isinstance(item, dict)
+    }
+    for mapping in component_map.get("mappings", []):
+        fields = mapping.get("permittedFields", [])
+        if any(field not in COMPONENT_NUMERIC_FIELDS for field in fields):
+            raise ValueError("influence_scope_exceeded: component field is forbidden")
+        component, path = components[str(mapping["componentId"])]
+        region = regions[str(mapping["selectors"][0]["regionId"])]
+        size = region["bounds"]["size"]
+        dimensions = component.get("dimensions", {})
+        for field in fields:
+            key = field.split(".")[-1]
+            if key not in {"width", "height", "depth"}:
+                continue
+            axis = {"width": 0, "height": 1, "depth": 2}[key]
+            old = dimensions.get(key)
+            if not isinstance(old, (int, float)) or isinstance(old, bool):
+                continue
+            factor = bounded_ratio(float(size[axis]), float(old), _max_delta(proposal))
+            _set_change(component, path, field, float(old) * factor, changes, scope="component-measurements", measured=float(size[axis]), confidence=float(mapping["confidence"]), source_region=str(region["regionId"]))
+
+
+def build_proposal(
+    accepted_spec: dict[str, object],
+    evidence: dict[str, object],
+    admission: dict[str, object],
+    component_map: dict[str, object] | None = None,
+) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
+    scope = _validate_binding(accepted_spec, evidence, admission, component_map)
+    proposal = copy.deepcopy(accepted_spec)
+    changes: list[dict[str, object]] = []
+    if scope == "global-massing":
+        scale = _global_proposal(proposal, evidence, changes)
+    else:
+        _component_proposal(proposal, evidence, component_map, changes)
+        scale = (1.0, 1.0, 1.0)
+    delta = {
+        "schemaVersion": 1,
+        "kind": "dense-evidence-spec-delta",
+        "acceptedSpecSha256": _canonical_sha256(accepted_spec),
+        "proposedSpecSha256": _canonical_sha256(proposal),
+        "evidenceSha256": _canonical_sha256(evidence),
+        "approvedScope": scope,
+        "changes": changes,
+    }
+    fit_plan = {
+        "schemaVersion": 1,
+        "kind": "dense-evidence-fit-plan",
+        "acceptedSpecSha256": delta["acceptedSpecSha256"],
+        "proposedSpecSha256": delta["proposedSpecSha256"],
+        "evidenceSha256": delta["evidenceSha256"],
+        "correctionGroup": "silhouette",
+        "parameterVector": list(scale),
+        "requiredBrowserViews": ["source", "front", "right", "rear", "left"],
+        "minimumEvidenceImprovement": 0.01,
+        "maximumSourceSilhouetteRegression": 0.02,
+        "correctionLoopBudget": {"maxPerPass": 3, "maxTotal": 6},
+    }
+    return proposal, delta, fit_plan
+
+
+def _set_path(root: object, path: list[object], value: object) -> None:
+    target: Any = root
+    for token in path[:-1]:
+        target = target[token]
+    target[path[-1]] = value
+
+
+def apply_reverse_delta(
+    proposed_spec: dict[str, object], delta: dict[str, object]
+) -> dict[str, object]:
+    restored = copy.deepcopy(proposed_spec)
+    changes = delta.get("changes", [])
+    if not isinstance(changes, list):
+        raise ValueError("delta changes must be a list")
+    for change in reversed(changes):
+        if not isinstance(change, dict) or not isinstance(change.get("path"), list):
+            raise ValueError("delta change path is invalid")
+        _set_path(restored, change["path"], change.get("old"))
+    return restored
+
+
+def _write_atomic(path: Path, value: object) -> None:
+    target = path.resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{target.name}.", suffix=".tmp", dir=target.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, indent=2, ensure_ascii=False, allow_nan=False)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, target)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", type=Path, required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--admission", type=Path, required=True)
+    parser.add_argument("--component-map", type=Path)
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument("--delta-out", type=Path, required=True)
+    parser.add_argument("--fit-plan-out", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        spec = json.loads(args.spec.read_text(encoding="utf-8"))
+        evidence = json.loads(args.evidence.read_text(encoding="utf-8"))
+        admission = json.loads(args.admission.read_text(encoding="utf-8"))
+        component_map = json.loads(args.component_map.read_text(encoding="utf-8")) if args.component_map else None
+        # Admissions created by the CLI bind exact file bytes. Rebind only after those exact
+        # hashes have been checked here, then use the same pure proposal implementation.
+        binding = admission.get("binding", {})
+        exact = {
+            "targetSpecSha256": hashlib.sha256(args.spec.read_bytes()).hexdigest(),
+            "evidenceSha256": hashlib.sha256(args.evidence.read_bytes()).hexdigest(),
+        }
+        if args.component_map:
+            exact["componentMapSha256"] = hashlib.sha256(args.component_map.read_bytes()).hexdigest()
+        if not isinstance(binding, dict) or any(binding.get(key) != value for key, value in exact.items()):
+            raise ValueError("admission_hash_mismatch: exact input bytes changed")
+        normalized = copy.deepcopy(admission)
+        normalized["binding"]["targetSpecSha256"] = _canonical_sha256(spec)
+        normalized["binding"]["evidenceSha256"] = _canonical_sha256(evidence)
+        if component_map is not None:
+            normalized["binding"]["componentMapSha256"] = _canonical_sha256(component_map)
+        proposal, delta, fit_plan = build_proposal(spec, evidence, normalized, component_map)
+        _write_atomic(args.out, proposal)
+        _write_atomic(args.delta_out, delta)
+        _write_atomic(args.fit_plan_out, fit_plan)
+        validator = ROOT / "forge" / "stage2_spec" / "validate_sculpt_spec.py"
+        normal = subprocess.run([sys.executable, str(validator), str(args.out)], capture_output=True, text=True, check=False)
+        strict = subprocess.run([sys.executable, str(validator), str(args.out), "--strict-quality"], capture_output=True, text=True, check=False)
+        if normal.returncode or strict.returncode:
+            print(json.dumps({"status": "strict_quality_failed", "normal": normal.stdout + normal.stderr, "strict": strict.stdout + strict.stderr}, ensure_ascii=False))
+            return 1
+        print(json.dumps({"status": "complete", "proposal": str(args.out), "changes": len(delta["changes"])}, ensure_ascii=False))
+        return 0
+    except (OSError, json.JSONDecodeError, ValueError, TypeError) as error:
+        print(str(error), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/forge/stage2_spec/new_component_evidence_map.py
+++ b/forge/stage2_spec/new_component_evidence_map.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Seed a deny-by-default component map without inferring semantic labels."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _canonical_sha256(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    ).hexdigest()
+
+
+def _component_ids(spec: dict[str, object]) -> list[str]:
+    result: list[str] = []
+
+    def visit(items: object) -> None:
+        if not isinstance(items, list):
+            return
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if isinstance(item.get("id"), str):
+                result.append(item["id"])
+            visit(item.get("children"))
+
+    visit(spec.get("componentTree"))
+    return sorted(result)
+
+
+def seed_component_map(
+    spec: dict[str, object], evidence: dict[str, object]
+) -> dict[str, Any]:
+    admission = evidence.get("admission")
+    if not isinstance(admission, dict) or admission.get("maximumInfluenceScope") != "component-measurements":
+        raise ValueError("semantic_boundary_insufficient: component map requires multipart evidence")
+    regions = evidence.get("regions")
+    if not isinstance(regions, list) or not regions:
+        raise ValueError("semantic_boundary_insufficient: no candidate regions")
+    provenance = evidence.get("provenance")
+    if not isinstance(provenance, dict):
+        raise ValueError("evidence provenance is missing")
+    return {
+        "schemaVersion": 1,
+        "kind": "component-evidence-map",
+        "targetSpecSha256": _canonical_sha256(spec),
+        "evidenceSha256": _canonical_sha256(evidence),
+        "glbSha256": provenance.get("glbSha256"),
+        "availableComponentIds": _component_ids(spec),
+        "candidateRegions": regions,
+        "mappings": [],
+        "extensions": {},
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", type=Path, required=True)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        spec = json.loads(args.spec.read_text(encoding="utf-8"))
+        evidence = json.loads(args.evidence.read_text(encoding="utf-8"))
+        result = seed_component_map(spec, evidence)
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(json.dumps(result, ensure_ascii=False))
+        return 0
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 1 if "semantic_boundary_insufficient" in str(error) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/forge/stage2_spec/rebase_component_frames.py
+++ b/forge/stage2_spec/rebase_component_frames.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Rebase object-frame component transforms onto the parent-local contract.
+
+ObjectSculptSpec authors `transform.position` and `attachment.localStart` /
+`attachment.localEnd` in PARENT-LOCAL coordinates (see
+grimoire/readiness/joint_attachment.md). A spec authored in object-frame
+absolute coordinates passes structural validation but renders with every
+child displaced by its parent's own offset (double-offset floating parts).
+
+This one-shot converter subtracts each component's parent object-frame
+position from the component's position and attachment endpoints, producing a
+new spec file (never in place) plus a JSON report of every changed field for
+human review. It refuses to guess: any non-zero rotation on a component that
+has children aborts the conversion, because the subtraction is only valid
+when parent frames are axis-aligned with the object frame.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+_EPSILON = 1e-9
+
+
+def _iter_components(tree: object) -> list[dict[str, Any]]:
+    result: list[dict[str, Any]] = []
+
+    def visit(items: object) -> None:
+        if not isinstance(items, list):
+            return
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if isinstance(item.get("id"), str):
+                result.append(item)
+            visit(item.get("children"))
+
+    visit(tree)
+    return result
+
+
+def _vector3(value: object, *, context: str) -> list[float]:
+    if (
+        not isinstance(value, list)
+        or len(value) != 3
+        or not all(isinstance(axis, (int, float)) and not isinstance(axis, bool) for axis in value)
+    ):
+        raise ValueError(f"{context} is not a numeric [x, y, z] vector")
+    return [float(axis) for axis in value]
+
+
+def _subtract(vector: list[float], delta: list[float]) -> list[float]:
+    return [round(a - b, 9) for a, b in zip(vector, delta)]
+
+
+def rebase_component_frames(spec: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return (rebased spec, change report). The input spec is not mutated."""
+    rebased = json.loads(json.dumps(spec))
+    components = _iter_components(rebased.get("componentTree"))
+    if not components:
+        raise ValueError("spec has no componentTree components to rebase")
+
+    by_id: dict[str, dict[str, Any]] = {}
+    for component in components:
+        component_id = component["id"]
+        if component_id in by_id:
+            raise ValueError(f"duplicate component id {component_id!r}")
+        by_id[component_id] = component
+
+    # The object-frame position of every component is its ORIGINAL authored
+    # position, so all deltas are read before any component is rewritten.
+    original_positions: dict[str, list[float]] = {}
+    parent_ids: set[str] = set()
+    for component in components:
+        component_id = component["id"]
+        transform = component.get("transform")
+        if not isinstance(transform, dict):
+            raise ValueError(f"component {component_id!r} has no transform")
+        original_positions[component_id] = _vector3(
+            transform.get("position"), context=f"component {component_id!r} transform.position"
+        )
+        parent = component.get("parent")
+        if parent is not None:
+            if not isinstance(parent, str) or parent not in by_id:
+                raise ValueError(f"component {component_id!r} references unknown parent {parent!r}")
+            parent_ids.add(parent)
+
+    for parent_id in sorted(parent_ids):
+        rotation = _vector3(
+            by_id[parent_id].get("transform", {}).get("rotation", [0, 0, 0]),
+            context=f"component {parent_id!r} transform.rotation",
+        )
+        if any(abs(axis) > _EPSILON for axis in rotation):
+            raise ValueError(
+                f"component {parent_id!r} has children and a non-zero rotation; "
+                "the object-frame subtraction is only valid for axis-aligned parent "
+                "frames — rebase this subtree manually"
+            )
+
+    changes: list[dict[str, Any]] = []
+    warnings: list[str] = []
+
+    def record(component_id: str, field: str, old: list[float], new: list[float]) -> list[float]:
+        if any(abs(a - b) > _EPSILON for a, b in zip(old, new)):
+            changes.append({"componentId": component_id, "field": field, "old": old, "new": new})
+        return new
+
+    for component in components:
+        component_id = component["id"]
+        parent = component.get("parent")
+        if parent is None:
+            continue
+        delta = original_positions[parent]
+        if all(abs(axis) <= _EPSILON for axis in delta):
+            continue
+        old_position = original_positions[component_id]
+        new_position = _subtract(old_position, delta)
+        component["transform"]["position"] = record(
+            component_id, "transform.position", old_position, new_position
+        )
+        if _magnitude(new_position) > _magnitude(old_position) + _EPSILON:
+            warnings.append(
+                f"component {component_id!r} moved further from its parent origin "
+                f"({old_position} -> {new_position}); it may already have been parent-local"
+            )
+        attachment = component.get("attachment")
+        if isinstance(attachment, dict):
+            for field in ("localStart", "localEnd"):
+                if attachment.get(field) is None:
+                    continue
+                old_value = _vector3(
+                    attachment[field], context=f"component {component_id!r} attachment.{field}"
+                )
+                attachment[field] = record(
+                    component_id, f"attachment.{field}", old_value, _subtract(old_value, delta)
+                )
+
+    report = {
+        "schemaVersion": 1,
+        "kind": "component-frame-rebase-report",
+        "targetId": spec.get("targetId"),
+        "componentCount": len(components),
+        "changedFieldCount": len(changes),
+        "changes": changes,
+        "warnings": warnings,
+    }
+    return rebased, report
+
+
+def _magnitude(vector: list[float]) -> float:
+    return sum(axis * axis for axis in vector) ** 0.5
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="object-frame spec to convert")
+    parser.add_argument("--output", type=Path, required=True, help="destination for the rebased spec")
+    parser.add_argument("--report", type=Path, required=True, help="destination for the change report")
+    args = parser.parse_args(argv)
+    if args.output.resolve() == args.input.resolve():
+        print("refusing to rewrite the input spec in place; choose a new --output", file=sys.stderr)
+        return 2
+    try:
+        spec = json.loads(args.input.read_text(encoding="utf-8"))
+        rebased, report = rebase_component_frames(spec)
+    except (OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"rebase failed: {error}", file=sys.stderr)
+        return 1
+    args.output.write_text(json.dumps(rebased, indent=2) + "\n", encoding="utf-8")
+    args.report.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(
+        f"rebased {report['changedFieldCount']} fields across {report['componentCount']} components"
+        + (f"; {len(report['warnings'])} warnings" if report["warnings"] else "")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/forge/stage2_spec/validate_sculpt_spec.py
+++ b/forge/stage2_spec/validate_sculpt_spec.py
@@ -2772,6 +2772,71 @@ def validate_rig_admission(
                 )
 
 
+def _frame_half_extents(component: dict[str, Any]) -> list[float] | None:
+    dimensions = component.get("dimensions")
+    if not isinstance(dimensions, dict):
+        return None
+    extents = [dimensions.get("width"), dimensions.get("height"), dimensions.get("depth")]
+    if not all(is_number(extent) and extent > 0 for extent in extents):
+        return None
+    return [float(extent) / 2.0 for extent in extents]
+
+
+def validate_component_frame_sanity(spec: dict[str, Any], warnings: list[str]) -> None:
+    """Flag child positions that cannot plausibly be parent-local.
+
+    The transform contract (grimoire/readiness/joint_attachment.md) puts
+    `transform.position` in the PARENT's local frame. A spec authored in
+    object-frame absolute coordinates still validates structurally but renders
+    with every child displaced by its parent's own offset. A child whose local
+    offset lands far outside its parent's volume is almost certainly authored
+    in the wrong frame, so this is a quality warning (an error under
+    --strict-quality), not a hard failure: legitimate overhangs stay inside
+    the slack.
+
+    Per axis, the plausible local reach is (P + child_half) * 1.5, where P is
+    the parent's FULL extent when the parent's primitive derives geometry from
+    its attachment segment (the node pivot then sits at localStart, typically
+    the part's base, so children legitimately reach the far end plus their own
+    half extent) and the parent's HALF extent for center-pivoted primitives.
+    """
+    components = [
+        component
+        for component in spec.get("componentTree", [])
+        if isinstance(component, dict) and isinstance(component.get("id"), str)
+    ]
+    by_id = {component["id"]: component for component in components}
+    for component in components:
+        component_id = component["id"]
+        parent_id = component.get("parent")
+        parent = by_id.get(parent_id) if isinstance(parent_id, str) else None
+        # The root container is unitless (relative 1x1x1); measuring children
+        # against it would flag every top-level part.
+        if parent is None or parent.get("parent") is None:
+            continue
+        transform = component.get("transform")
+        if not isinstance(transform, dict) or not as_number_list(transform.get("position"), 3):
+            continue
+        child_half = _frame_half_extents(component)
+        parent_half = _frame_half_extents(parent)
+        if child_half is None or parent_half is None:
+            continue
+        base_pivot = parent.get("primitive") in ATTACHMENT_PRIMITIVES
+        for axis_index, axis_name in enumerate(("x", "y", "z")):
+            parent_reach = parent_half[axis_index] * (2.0 if base_pivot else 1.0)
+            allowed = (parent_reach + child_half[axis_index]) * 1.5
+            offset = float(transform["position"][axis_index])
+            if abs(offset) > allowed:
+                warnings.append(
+                    f"quality: frame-sanity: component {component_id!r} transform.position "
+                    f"{axis_name}={offset:g} lies outside parent {parent_id!r}'s plausible "
+                    f"local volume (allowed +-{allowed:g}); positions must be parent-local, "
+                    "not object-frame absolute -- convert with "
+                    "forge/stage2_spec/rebase_component_frames.py"
+                )
+                break
+
+
 def validate_spec(spec: dict[str, Any]) -> tuple[list[str], list[str]]:
     errors: list[str] = []
     warnings: list[str] = []
@@ -2805,6 +2870,7 @@ def validate_spec(spec: dict[str, Any]) -> tuple[list[str], list[str]]:
     validate_pipeline_routing_contract(spec, errors)
     validate_cs2_view_dependent_environment(spec, errors)
     validate_components(spec, material_ids, evidence_ids, errors, warnings)
+    validate_component_frame_sanity(spec, warnings)
     lod_plan = spec.get("lodPlan")
     if lod_plan is not None and not isinstance(lod_plan, list):
         errors.append("lodPlan must be an array")

--- a/forge/stage3_build/generate_threejs_factory.py
+++ b/forge/stage3_build/generate_threejs_factory.py
@@ -3205,7 +3205,12 @@ def generate(spec: dict[str, Any], pass_id: str) -> str:
         "  const map = (maps as Record<string, unknown>)[channel];",
         "  if (!map || typeof map !== 'object') return null;",
         "  const record = map as Record<string, unknown>;",
-        "  const url = typeof record.url === 'string' && record.url.trim() ? record.url : record.path;",
+        # Only a servable `url` can back a texture. `path` is where the extractor wrote the
+        # evidence on the authoring machine -- provenance, never an asset the browser can
+        # fetch. Falling back to it produced a set of textures that never loaded, so every
+        # material rendered white (color forced to 0xffffff with roughness 1). A map with a
+        # path and no url is a deliberately unshipped map: take the procedural route.
+        "  const url = typeof record.url === 'string' && record.url.trim() ? record.url : null;",
         "  return typeof url === 'string' && url.trim() ? url : null;",
         "}",
         "",

--- a/forge/stage3_build/generate_threejs_factory.py
+++ b/forge/stage3_build/generate_threejs_factory.py
@@ -3867,7 +3867,11 @@ def generate(spec: dict[str, Any], pass_id: str) -> str:
                 f"  // repetition system: {system.get('id') or rep_var} (InstancedMesh, {mode}, count={count}, level={level})",
                 "  {",
                 f"    const parent = nodes[{json.dumps(parent_id)}] ?? root;",
-                f"    const geo = {geometry_for(primitive, {}, False, seg)};",
+                # Instanced micro-parts never deform or subdivide, so the LOW
+                # tessellation tier is always enough. At the model tier, a
+                # 26-stone curb ring of hero-tier boxes cost 44,928 triangles —
+                # half the whole diorama's budget spent on cubes.
+                f"    const geo = {geometry_for(primitive, {}, False, TESSELLATION_TIERS['low'])};",
                 f"    const mat = materialMap[{json.dumps(rep_material)}] ?? new THREE.MeshStandardMaterial({{ color: 0x888888 }});",
                 "    // Contract (PLAN_1.5 WS-E): instanceScale is ABSOLUTE, in the parent pivot's",
                 "    // local units -- it is never multiplied by the parent component's own declared",

--- a/forge/stage3_build/generate_threejs_factory.py
+++ b/forge/stage3_build/generate_threejs_factory.py
@@ -259,6 +259,60 @@ def json_literal(value: Any) -> str:
     return json.dumps(value, ensure_ascii=False)
 
 
+def estimate_model_radius(spec: dict[str, Any]) -> float:
+    """Estimate the model's world half-extent from authored transforms + dims.
+
+    Parent-local positions are accumulated down the tree (rotations ignored --
+    this is a bound estimate for sizing the look-dev shadow camera, not exact
+    geometry), and each component contributes |world position| plus half its
+    declared dimensions per axis. Falls back to a character-scale 2.0 when the
+    tree carries no numeric dimensions.
+    """
+    components = [
+        component
+        for component in spec.get("componentTree", [])
+        if isinstance(component, dict) and isinstance(component.get("id"), str)
+    ]
+    by_id = {component["id"]: component for component in components}
+    world_cache: dict[str, list[float]] = {}
+
+    def world_position(component_id: str, depth: int = 0) -> list[float]:
+        if component_id in world_cache:
+            return world_cache[component_id]
+        component = by_id[component_id]
+        transform = component.get("transform")
+        position = transform.get("position") if isinstance(transform, dict) else None
+        local = (
+            [float(axis) for axis in position]
+            if isinstance(position, list)
+            and len(position) == 3
+            and all(isinstance(axis, (int, float)) and not isinstance(axis, bool) for axis in position)
+            else [0.0, 0.0, 0.0]
+        )
+        parent = component.get("parent")
+        if depth < 64 and isinstance(parent, str) and parent in by_id:
+            base = world_position(parent, depth + 1)
+            local = [base[i] + local[i] for i in range(3)]
+        world_cache[component_id] = local
+        return local
+
+    radius = 0.0
+    for component in components:
+        dimensions = component.get("dimensions")
+        if not isinstance(dimensions, dict):
+            continue
+        extents = [dimensions.get("width"), dimensions.get("height"), dimensions.get("depth")]
+        if not all(
+            isinstance(extent, (int, float)) and not isinstance(extent, bool) and extent > 0
+            for extent in extents
+        ):
+            continue
+        world = world_position(component["id"])
+        for axis_index in range(3):
+            radius = max(radius, abs(world[axis_index]) + float(extents[axis_index]) / 2.0)
+    return radius if radius > 0 else 2.0
+
+
 def vector(values: Any, fallback: list[float]) -> str:
     if (
         isinstance(values, list)
@@ -3881,6 +3935,19 @@ def generate(spec: dict[str, Any], pass_id: str) -> str:
 
     look_dev_targets = spec.get("lookDevTargets", {})
     lighting_from_photo = spec.get("lightingFromPhoto", [])
+    # The look-dev shadow camera must COVER the model: fixed +-2.6 bounds sized
+    # for a character-scale asset silently clip the contact shadow of anything
+    # larger (a 10-unit diorama's shadow never lands past its own base). Scale
+    # the rig from the spec's estimated world radius instead.
+    model_radius = estimate_model_radius(spec)
+    shadow_half = round(max(2.6, model_radius * 1.4), 2)
+    shadow_far = round(max(30.0, model_radius * 8.0), 1)
+    light_scale = max(1.0, model_radius / 5.0)
+
+    def scaled_position(x: float, y: float, z: float) -> str:
+        return (
+            f"{round(x * light_scale, 2)}, {round(y * light_scale, 2)}, {round(z * light_scale, 2)}"
+        )
     lines.extend(
         [
             "",
@@ -3907,9 +3974,9 @@ def generate(spec: dict[str, Any], pass_id: str) -> str:
             "    mode === 'reference' ? 0xffcf8a : 0xfff4e8,",
             "    mode === 'grazing' ? 4.2 : mode === 'reference' ? 2.6 : 2.15,",
             "  );",
-            "  if (mode === 'grazing') key.position.set(7.5, 1.1, 4.0);",
-            "  else if (mode === 'reference') key.position.set(-4.5, 7.5, 5.0);",
-            "  else key.position.set(-4.0, 6.0, 5.5);",
+            f"  if (mode === 'grazing') key.position.set({scaled_position(7.5, 1.1, 4.0)});",
+            f"  else if (mode === 'reference') key.position.set({scaled_position(-4.5, 7.5, 5.0)});",
+            f"  else key.position.set({scaled_position(-4.0, 6.0, 5.5)});",
             "  key.castShadow = true;",
             "  key.shadow.mapSize.set(4096, 4096);",
             "  key.shadow.bias = -0.00025;",
@@ -3917,18 +3984,18 @@ def generate(spec: dict[str, Any], pass_id: str) -> str:
             "  key.shadow.radius = 7;",
             "  key.shadow.blurSamples = 24;",
             "  key.shadow.camera.near = 0.5;",
-            "  key.shadow.camera.far = 30;",
-            "  key.shadow.camera.left = -2.6;",
-            "  key.shadow.camera.right = 2.6;",
-            "  key.shadow.camera.top = 2.6;",
-            "  key.shadow.camera.bottom = -2.6;",
+            f"  key.shadow.camera.far = {shadow_far};",
+            f"  key.shadow.camera.left = -{shadow_half};",
+            f"  key.shadow.camera.right = {shadow_half};",
+            f"  key.shadow.camera.top = {shadow_half};",
+            f"  key.shadow.camera.bottom = -{shadow_half};",
             "  key.shadow.camera.updateProjectionMatrix();",
             "  lights.add(key);",
             "  const fill = new THREE.DirectionalLight(0xa8c4ff, mode === 'grazing' ? 0.12 : 0.42);",
-            "  fill.position.set(4.0, 3.0, 3.5);",
+            f"  fill.position.set({scaled_position(4.0, 3.0, 3.5)});",
             "  lights.add(fill);",
             "  const rim = new THREE.DirectionalLight(0xfff1c4, mode === 'grazing' ? 0.28 : 0.85);",
-            "  rim.position.set(0.5, 4.5, -6.0);",
+            f"  rim.position.set({scaled_position(0.5, 4.5, -6.0)});",
             "  lights.add(rim);",
             "  lights.userData.reviewMode = mode;",
             f"  lights.userData.lightingFromPhoto = {json_literal(lighting_from_photo)};",

--- a/forge/stage4_review/admit_dense_influence.py
+++ b/forge/stage4_review/admit_dense_influence.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Create a human-approved, hash-bound dense-evidence influence record."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from forge.stage1_intake.check_dense_evidence import SCOPE_RANK, validate_dense_evidence
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError(f"expected JSON object: {path}")
+    return value
+
+
+def create_admission(
+    evidence_path: Path,
+    visual_review_path: Path,
+    target_spec_path: Path,
+    requested_scope: str,
+    *,
+    approved: bool,
+    component_map_path: Path | None = None,
+) -> dict[str, Any]:
+    evidence = _load(evidence_path)
+    review = _load(visual_review_path)
+    spec = _load(target_spec_path)
+    component_map = _load(component_map_path) if component_map_path else None
+    validation = validate_dense_evidence(evidence, spec, component_map)
+    maximum = str(validation["maximumInfluenceScope"])
+    provenance = evidence.get("provenance", {})
+    glb_hash = provenance.get("glbSha256") if isinstance(provenance, dict) else None
+    if requested_scope not in SCOPE_RANK or requested_scope == "none":
+        return {
+            "schemaVersion": 1,
+            "decision": "DENY",
+            "failureCategory": "influence_scope_exceeded",
+            "reasons": ["requested scope is invalid for an approval"],
+        }
+    if not validation["passed"]:
+        category = (
+            "semantic_boundary_insufficient"
+            if requested_scope == "component-measurements"
+            and maximum != "component-measurements"
+            else str(validation["failureCategories"][0])
+        )
+        return {
+            "schemaVersion": 1,
+            "decision": "DENY",
+            "failureCategory": category,
+            "reasons": validation["errors"],
+        }
+    if SCOPE_RANK[requested_scope] > SCOPE_RANK[maximum]:
+        return {
+            "schemaVersion": 1,
+            "decision": "DENY",
+            "failureCategory": "semantic_boundary_insufficient",
+            "reasons": [f"requested {requested_scope} exceeds {maximum}"],
+        }
+    if review.get("glbSha256") != glb_hash:
+        return {
+            "schemaVersion": 1,
+            "decision": "DENY",
+            "failureCategory": "admission_hash_mismatch",
+            "reasons": ["visual review is bound to another GLB"],
+        }
+    if not approved:
+        return {
+            "schemaVersion": 1,
+            "decision": "NEEDS_USER_ACTION",
+            "failureCategory": "influence_approval_required",
+            "requestedScope": requested_scope,
+            "maximumInfluenceScope": maximum,
+            "reasons": ["explicit --approve-influence is required"],
+        }
+    binding: dict[str, str] = {
+        "glbSha256": str(glb_hash),
+        "evidenceSha256": _sha256_file(evidence_path),
+        "visualReviewSha256": _sha256_file(visual_review_path),
+        "scope": requested_scope,
+        "targetSpecSha256": _sha256_file(target_spec_path),
+    }
+    if component_map_path is not None:
+        binding["componentMapSha256"] = _sha256_file(component_map_path)
+    return {
+        "schemaVersion": 1,
+        "kind": "dense-influence-admission",
+        "decision": "ALLOW",
+        "approvedAt": datetime.now(UTC).isoformat(),
+        "binding": binding,
+        "maximumInfluenceScope": maximum,
+        "approvedInfluenceScope": requested_scope,
+        "extensions": {},
+    }
+
+
+def validate_admission(
+    admission: dict[str, object],
+    evidence_path: Path,
+    visual_review_path: Path,
+    target_spec_path: Path,
+    component_map_path: Path | None = None,
+) -> dict[str, object]:
+    errors: list[str] = []
+    binding = admission.get("binding")
+    evidence = _load(evidence_path)
+    provenance = evidence.get("provenance", {})
+    expected = {
+        "glbSha256": provenance.get("glbSha256") if isinstance(provenance, dict) else None,
+        "evidenceSha256": _sha256_file(evidence_path),
+        "visualReviewSha256": _sha256_file(visual_review_path),
+        "targetSpecSha256": _sha256_file(target_spec_path),
+    }
+    if component_map_path is not None:
+        expected["componentMapSha256"] = _sha256_file(component_map_path)
+    if admission.get("decision") != "ALLOW" or not isinstance(binding, dict):
+        errors.append("admission is not an ALLOW record")
+    else:
+        for field, value in expected.items():
+            if binding.get(field) != value:
+                errors.append(f"{field} mismatch")
+        if binding.get("scope") != admission.get("approvedInfluenceScope"):
+            errors.append("scope mismatch")
+    return {
+        "passed": not errors,
+        "failureCategories": [] if not errors else ["admission_hash_mismatch"],
+        "errors": errors,
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence", type=Path, required=True)
+    parser.add_argument("--visual-review", type=Path, required=True)
+    parser.add_argument("--target-spec", type=Path, required=True)
+    parser.add_argument("--scope", choices=("global-massing", "component-measurements"), required=True)
+    parser.add_argument("--component-map", type=Path)
+    parser.add_argument("--approve-influence", action="store_true")
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        record = create_admission(
+            args.evidence,
+            args.visual_review,
+            args.target_spec,
+            args.scope,
+            approved=args.approve_influence,
+            component_map_path=args.component_map,
+        )
+        if record["decision"] == "ALLOW":
+            args.out.parent.mkdir(parents=True, exist_ok=True)
+            args.out.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps(record, ensure_ascii=False))
+        return 0 if record["decision"] == "ALLOW" else (3 if record["decision"] == "NEEDS_USER_ACTION" else 1)
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/forge/stage4_review/compare_dense_evidence.py
+++ b/forge/stage4_review/compare_dense_evidence.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Dual-baseline gate for dense-evidence-assisted procedural proposals."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+SCOPE_RANK = {"none": 0, "global-massing": 1, "component-measurements": 2}
+REQUIRED_GATES = ("strictQuality", "passOrder", "turntable", "attachment", "intersection")
+FORBIDDEN_RUNTIME_PATTERNS = (
+    ("runtime_mesh_loader", re.compile(r"\bGLTFLoader\b|\bOBJLoader\b")),
+    ("runtime_mesh_asset", re.compile(r"\.(?:glb|obj)(?:['\"?#]|\b)", re.IGNORECASE)),
+    ("provider_endpoint", re.compile(r"trellis-community|stable-fast-3d|huggingface\.co|hf\.space", re.IGNORECASE)),
+    ("signed_url", re.compile(r"[?&](?:X-Amz-Signature|Signature|Expires|token)=", re.IGNORECASE)),
+    ("copied_mesh_payload", re.compile(r"copiedMeshPayload|embeddedMeshPayload", re.IGNORECASE)),
+)
+
+
+def _finite_unit(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    number = float(value)
+    return number if math.isfinite(number) and 0.0 <= number <= 1.0 else None
+
+
+def _hashes_complete(metrics: dict[str, object]) -> bool:
+    hashes = metrics.get("browserHashes")
+    return (
+        isinstance(hashes, dict)
+        and bool(hashes)
+        and all(
+            isinstance(value, str)
+            and len(value) == 64
+            and all(character in "0123456789abcdef" for character in value)
+            for value in hashes.values()
+        )
+    )
+
+
+def _deny(category: str, reasons: list[str], **metrics: object) -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "decision": "DENY",
+        "failureCategory": category,
+        "reasons": reasons,
+        "metrics": metrics,
+    }
+
+
+def compare_dense_evidence(
+    baseline_source: dict[str, object],
+    candidate_source: dict[str, object],
+    baseline_evidence: dict[str, object],
+    candidate_evidence: dict[str, object],
+    deterministic_gates: dict[str, bool],
+    admission: dict[str, object],
+    *,
+    declared_evidence_targets: tuple[str, ...] | None = None,
+) -> dict[str, object]:
+    if not all(
+        _hashes_complete(metrics)
+        for metrics in (
+            baseline_source,
+            candidate_source,
+            baseline_evidence,
+            candidate_evidence,
+        )
+    ):
+        return _deny(
+            "browser_evidence_missing", ["all four browser metric records need complete hashes"]
+        )
+    if admission.get("decision") != "ALLOW":
+        return _deny("influence_not_approved", ["hash-bound ALLOW admission is required"])
+    scope = admission.get("approvedInfluenceScope")
+    maximum = admission.get("maximumInfluenceScope")
+    binding = admission.get("binding")
+    if (
+        scope not in SCOPE_RANK
+        or maximum not in SCOPE_RANK
+        or SCOPE_RANK[str(scope)] > SCOPE_RANK[str(maximum)]
+        or not isinstance(binding, dict)
+        or binding.get("scope") != scope
+    ):
+        return _deny("influence_scope_exceeded", ["approval scope exceeds its evidence ceiling"])
+    missing_gates = [name for name in REQUIRED_GATES if deterministic_gates.get(name) is not True]
+    if missing_gates:
+        return _deny(
+            "deterministic_gate_failed",
+            [f"required gate did not pass: {name}" for name in missing_gates],
+        )
+    baseline_iou = _finite_unit(baseline_source.get("silhouetteIou"))
+    candidate_iou = _finite_unit(candidate_source.get("silhouetteIou"))
+    if baseline_iou is None or candidate_iou is None:
+        return _deny("browser_evidence_missing", ["source silhouette IoU is missing or invalid"])
+    baseline_features = baseline_source.get("criticalFeatures")
+    candidate_features = candidate_source.get("criticalFeatures")
+    if not isinstance(baseline_features, dict) or not isinstance(candidate_features, dict):
+        return _deny("browser_evidence_missing", ["critical feature results are missing"])
+    critical_regressions = sorted(
+        name
+        for name, passed in baseline_features.items()
+        if passed is True and candidate_features.get(name) is not True
+    )
+    source_regression = baseline_iou - candidate_iou
+    if critical_regressions or source_regression > 0.02 + 1e-12:
+        return _deny(
+            "source_fidelity_regression",
+            [
+                *(f"critical feature regressed: {name}" for name in critical_regressions),
+                *(
+                    [f"source silhouette regressed by {source_regression:.6f}, above 0.02"]
+                    if source_regression > 0.02 + 1e-12
+                    else []
+                ),
+            ],
+            sourceRegression=source_regression,
+            criticalRegressions=critical_regressions,
+        )
+    targets = declared_evidence_targets or tuple(
+        sorted(
+            key
+            for key in set(baseline_evidence) & set(candidate_evidence)
+            if key != "browserHashes"
+            and _finite_unit(baseline_evidence.get(key)) is not None
+            and _finite_unit(candidate_evidence.get(key)) is not None
+        )
+    )
+    if not targets:
+        return _deny("browser_evidence_missing", ["no declared evidence target has valid metrics"])
+    improvements = {
+        name: float(candidate_evidence[name]) - float(baseline_evidence[name])
+        for name in targets
+        if _finite_unit(baseline_evidence.get(name)) is not None
+        and _finite_unit(candidate_evidence.get(name)) is not None
+    }
+    if len(improvements) != len(targets):
+        return _deny("browser_evidence_missing", ["a declared evidence target is missing"])
+    best_improvement = max(improvements.values())
+    if best_improvement < 0.01 - 1e-12:
+        return _deny(
+            "fit_no_improvement",
+            [f"best evidence improvement {best_improvement:.6f} is below 0.01"],
+            evidenceImprovements=improvements,
+        )
+    return {
+        "schemaVersion": 1,
+        "decision": "ALLOW",
+        "failureCategory": None,
+        "sourceRegression": source_regression,
+        "criticalRegressions": [],
+        "evidenceImprovements": improvements,
+        "approvedInfluenceScope": scope,
+        "runtimeAuthority": "procedural-typescript-factory",
+    }
+
+
+def scan_runtime_sources(paths: list[Path]) -> dict[str, object]:
+    violations: list[dict[str, str]] = []
+    for path in paths:
+        if path.suffix not in {".ts", ".tsx", ".js", ".mjs"}:
+            violations.append(
+                {"path": str(path), "category": "runtime_source_invalid", "match": path.suffix}
+            )
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as error:
+            violations.append(
+                {"path": str(path), "category": "runtime_source_unreadable", "match": str(error)}
+            )
+            continue
+        for category, pattern in FORBIDDEN_RUNTIME_PATTERNS:
+            match = pattern.search(source)
+            if match:
+                violations.append(
+                    {"path": str(path), "category": category, "match": match.group(0)}
+                )
+                break
+    return {
+        "passed": not violations,
+        "runtimeAuthority": "procedural-typescript-factory",
+        "scanned": [str(path) for path in paths],
+        "violations": violations,
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-source", type=Path, required=True)
+    parser.add_argument("--candidate-source", type=Path, required=True)
+    parser.add_argument("--baseline-evidence", type=Path, required=True)
+    parser.add_argument("--candidate-evidence", type=Path, required=True)
+    parser.add_argument("--deterministic-gates", type=Path, required=True)
+    parser.add_argument("--admission", type=Path, required=True)
+    parser.add_argument("--runtime-source", type=Path, action="append", required=True)
+    parser.add_argument("--evidence-target", action="append")
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        values = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in (
+                args.baseline_source,
+                args.candidate_source,
+                args.baseline_evidence,
+                args.candidate_evidence,
+                args.deterministic_gates,
+                args.admission,
+            )
+        ]
+        report = compare_dense_evidence(
+            *values,
+            declared_evidence_targets=tuple(args.evidence_target) if args.evidence_target else None,
+        )
+        runtime = scan_runtime_sources(args.runtime_source)
+        if not runtime["passed"]:
+            report = _deny("runtime_mesh_dependency", ["candidate runtime is not code-only"], runtime=runtime)
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(json.dumps(report, ensure_ascii=False))
+        return 0 if report["decision"] == "ALLOW" else 1
+    except (OSError, json.JSONDecodeError, TypeError, ValueError) as error:
+        print(str(error), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/forge/state.py
+++ b/forge/state.py
@@ -30,6 +30,7 @@ def build_parser() -> argparse.ArgumentParser:
     init.add_argument("--spec", default="")
     init.add_argument("--max-per-pass", type=int, default=3)
     init.add_argument("--max-total", type=int, default=6)
+    init.add_argument("--dense-evidence", action="store_true")
 
     status = commands.add_parser("status")
     status.add_argument("--state", type=Path, default=Path(".img2threejs/state.json"))
@@ -77,6 +78,7 @@ def main(argv: list[str]) -> int:
                 spec=args.spec,
                 max_per_pass=args.max_per_pass,
                 max_total=args.max_total,
+                dense_evidence=args.dense_evidence,
             )
             save_state(args.state, state)
             print_status(state)

--- a/forge/tests/test_dense_evidence_contract.py
+++ b/forge/tests/test_dense_evidence_contract.py
@@ -1,0 +1,457 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from forge.stage1_intake.check_dense_evidence import validate_dense_evidence
+from forge.stage2_spec.new_component_evidence_map import seed_component_map
+from forge.stage2_spec.apply_dense_evidence import (
+    COMPONENT_NUMERIC_FIELDS,
+    GLOBAL_NUMERIC_FIELDS,
+    apply_reverse_delta,
+    build_proposal,
+)
+from forge.stage4_review.admit_dense_influence import create_admission, validate_admission
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def canonical_sha256(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()
+    ).hexdigest()
+
+
+def valid_spec() -> dict[str, object]:
+    return {
+        "schemaVersion": "2.1",
+        "targetName": "House",
+        "qualityContract": {"denseEvidence": {"maxNumericDeltaFraction": 0.2}},
+        "componentTree": [
+            {
+                "id": "body",
+                "primitive": "box",
+                "topologyClass": "assembled-solid",
+                "topologyRationale": "Observed wall volume with hard assembled seams.",
+                "dimensions": {"width": 2.0, "height": 2.5, "depth": 3.0},
+                "transform": {"position": [0.0, 0.0, 0.0]},
+                "children": [
+                    {
+                        "id": "roof-main",
+                        "primitive": "wedge",
+                        "topologyClass": "assembled-solid",
+                        "topologyRationale": "Observed roof planes meet at a ridge.",
+                        "dimensions": {"width": 2.2, "height": 1.0, "depth": 3.2},
+                        "transform": {"position": [0.0, 1.75, 0.0]},
+                        "children": [],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def valid_evidence(*, maximum_scope: str = "global-massing", multipart: bool = False) -> dict[str, object]:
+    regions = []
+    semantic_status = "insufficient"
+    if multipart:
+        semantic_status = "sufficient"
+        maximum_scope = "component-measurements"
+        regions = [
+            {
+                "regionId": "node:body/geometry:body-mesh",
+                "node": "body",
+                "geometry": "body-mesh",
+                "candidateOnly": True,
+                "semanticLabel": None,
+                "bounds": {"min": [-1.0, -1.0, -1.5], "max": [1.0, 1.0, 1.5], "size": [2.0, 2.0, 3.0]},
+            },
+            {
+                "regionId": "node:roof/geometry:roof-mesh",
+                "node": "roof",
+                "geometry": "roof-mesh",
+                "candidateOnly": True,
+                "semanticLabel": None,
+                "bounds": {"min": [-1.1, 1.0, -1.6], "max": [1.1, 2.0, 1.6], "size": [2.2, 1.0, 3.2]},
+            },
+        ]
+    evidence = {
+        "schemaVersion": 1,
+        "kind": "dense-evidence",
+        "extractorVersion": "dense-evidence-extractor-v1",
+        "createdAt": "2026-09-01T00:00:00+00:00",
+        "provenance": {
+            "providerId": "hf-zerogpu-trellis",
+            "runPath": "/tmp/run",
+            "glbPath": "/tmp/run/normalized/reference.glb",
+            "glbSha256": "a" * 64,
+            "objSha256": "b" * 64,
+            "sourceImageSha256": ["c" * 64],
+            "visualReviewStatus": "retain-as-generative-proxy-only",
+            "alignmentProfileVersion": "source-view-alignment-v1",
+            "alignmentSha256": "d" * 64,
+        },
+        "cache": {"baseExtractionKey": "e" * 64, "measurementConfigSha256": "f" * 64},
+        "admission": {
+            "structuralStatus": "structural-pass-visual-review-required",
+            "semanticStatus": semantic_status,
+            "maximumInfluenceScope": maximum_scope,
+            "approvedInfluenceScope": "none",
+        },
+        "alignment": {
+            "schemaVersion": 1,
+            "profileVersion": "source-view-alignment-v1",
+            "sourceViewTransform": [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            "upAxis": "+Y",
+            "forwardAxis": "+Z",
+            "handedness": "right-handed",
+            "axisOperationAudit": ["identity"],
+            "chiralityStatus": "reviewed",
+            "sourceViewSilhouetteIou": 0.8,
+            "projectedAspectRatioError": 0.05,
+            "browserCaptures": [{"path": "review/preview.png", "sha256": "1" * 64, "view": "source"}],
+        },
+        "globalGeometry": {
+            "bounds": {"min": [-1.0, -1.0, -1.5], "max": [1.0, 2.0, 1.5], "size": [2.0, 3.0, 3.0]},
+            "principalAxes": [
+                {"axis": [1.0, 0.0, 0.0], "variance": 3.0},
+                {"axis": [0.0, 1.0, 0.0], "variance": 2.0},
+                {"axis": [0.0, 0.0, 1.0], "variance": 1.0},
+            ],
+            "occupancyGrid": {"resolution": 24, "occupiedCells": [[0, 0, 0]], "occupiedCellCount": 1},
+            "crossSections": [{"axis": "y", "position": 0.0, "profile": [[-1.0, -1.5], [1.0, 1.5], [0.0, 1.0]]}],
+            "silhouetteViews": [{"view": "source", "path": "review/preview.png", "sha256": "1" * 64, "silhouetteIou": 0.8, "projectedAspectRatioError": 0.05}],
+        },
+        "regions": regions,
+        "uncertainty": {
+            "sourceViewCount": 1,
+            "hiddenSurfacePolicy": "non-authoritative",
+            "rearConfidence": "low",
+            "singleViewLimitations": ["rear is not observed"],
+        },
+        "extensions": {},
+    }
+    evidence["provenance"]["alignmentSha256"] = canonical_sha256(
+        evidence["alignment"]
+    )
+    return evidence
+
+
+def valid_component_map(evidence: dict[str, object], spec: dict[str, object], *, observed: bool = True) -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "kind": "component-evidence-map",
+        "targetSpecSha256": canonical_sha256(spec),
+        "evidenceSha256": canonical_sha256(evidence),
+        "glbSha256": evidence["provenance"]["glbSha256"],
+        "mappings": [
+            {
+                "componentId": "roof-main",
+                "selectors": [{"regionId": "node:roof/geometry:roof-mesh"}],
+                "mappingMethod": "human-reviewed-node-boundary",
+                "evidenceRefs": ["review/semantic-roof.png"],
+                "confidence": 0.86,
+                "permittedFields": ["dimensions.width", "dimensions.height"],
+                "observedSurface": observed,
+                "hiddenLimitations": ["rear slope is non-authoritative"],
+            }
+        ],
+        "extensions": {},
+    }
+
+
+class DenseEvidenceContractTest(unittest.TestCase):
+    def test_valid_global_record_passes_without_optional_dependencies(self) -> None:
+        report = validate_dense_evidence(valid_evidence())
+        self.assertTrue(report["passed"], report["errors"])
+        self.assertEqual(report["maximumInfluenceScope"], "global-massing")
+
+    def test_merged_mesh_component_claim_fails_closed(self) -> None:
+        evidence = valid_evidence()
+        mapping = valid_component_map(evidence, valid_spec())
+        report = validate_dense_evidence(evidence, valid_spec(), mapping)
+        self.assertIn("semantic_boundary_insufficient", report["failureCategories"])
+
+    def test_single_view_hidden_measurement_is_rejected(self) -> None:
+        evidence = valid_evidence(multipart=True)
+        mapping = valid_component_map(evidence, valid_spec(), observed=False)
+        report = validate_dense_evidence(evidence, valid_spec(), mapping)
+        self.assertIn("component_mapping_invalid", report["failureCategories"])
+
+    def test_caps_hashes_and_unknown_fields_fail_closed(self) -> None:
+        evidence = valid_evidence()
+        evidence["globalGeometry"]["occupancyGrid"]["resolution"] = 33
+        evidence["unexpectedAuthority"] = True
+        evidence["provenance"]["glbSha256"] = "bad"
+        report = validate_dense_evidence(evidence)
+        self.assertFalse(report["passed"])
+        self.assertIn("measurement_limit_exceeded", report["failureCategories"])
+        self.assertIn("schema_invalid", report["failureCategories"])
+        self.assertIn("evidence_hash_mismatch", report["failureCategories"])
+
+    def test_alignment_content_is_hash_bound_and_matrix_is_exact(self) -> None:
+        evidence = valid_evidence()
+        evidence["alignment"]["sourceViewTransform"] = [1.0] * 15
+        report = validate_dense_evidence(evidence)
+        self.assertFalse(report["passed"])
+        self.assertIn("evidence_hash_mismatch", report["failureCategories"])
+        self.assertIn("schema_invalid", report["failureCategories"])
+
+
+class ComponentEvidenceMapTest(unittest.TestCase):
+    def test_seed_lists_existing_components_and_candidate_regions_without_mapping_them(self) -> None:
+        result = seed_component_map(valid_spec(), valid_evidence(multipart=True))
+        self.assertEqual(result["mappings"], [])
+        self.assertEqual(result["availableComponentIds"], ["body", "roof-main"])
+        self.assertTrue(all(item["candidateOnly"] for item in result["candidateRegions"]))
+
+    def test_merged_evidence_refuses_component_map_seed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "semantic_boundary_insufficient"):
+            seed_component_map(valid_spec(), valid_evidence())
+
+    def test_mapping_rejects_low_confidence_duplicate_and_unknown_component(self) -> None:
+        evidence = valid_evidence(multipart=True)
+        mapping = valid_component_map(evidence, valid_spec())
+        mapping["mappings"][0]["confidence"] = 0.79
+        duplicate = copy.deepcopy(mapping["mappings"][0])
+        duplicate["componentId"] = "missing"
+        mapping["mappings"].append(duplicate)
+        report = validate_dense_evidence(evidence, valid_spec(), mapping)
+        self.assertIn("component_mapping_invalid", report["failureCategories"])
+
+
+class DenseInfluenceAdmissionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.evidence = self.root / "dense-evidence.v1.json"
+        self.review = self.root / "visual-review.json"
+        self.spec = self.root / "object-sculpt-spec.json"
+        self.evidence.write_text(json.dumps(valid_evidence()), encoding="utf-8")
+        self.review.write_text(
+            json.dumps({"decision": "retain-as-generative-proxy-only", "glbSha256": "a" * 64}),
+            encoding="utf-8",
+        )
+        self.spec.write_text(json.dumps(valid_spec()), encoding="utf-8")
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_approval_is_bound_to_glb_evidence_review_scope_and_spec(self) -> None:
+        record = create_admission(
+            self.evidence, self.review, self.spec, "global-massing", approved=True
+        )
+        self.assertEqual(record["decision"], "ALLOW")
+        self.assertEqual(
+            set(record["binding"]),
+            {"glbSha256", "evidenceSha256", "visualReviewSha256", "scope", "targetSpecSha256"},
+        )
+        self.assertTrue(validate_admission(record, self.evidence, self.review, self.spec)["passed"])
+
+    def test_without_explicit_approval_needs_user_action(self) -> None:
+        record = create_admission(
+            self.evidence, self.review, self.spec, "global-massing", approved=False
+        )
+        self.assertEqual(record["decision"], "NEEDS_USER_ACTION")
+
+    def test_scope_above_evidence_ceiling_is_denied(self) -> None:
+        record = create_admission(
+            self.evidence, self.review, self.spec, "component-measurements", approved=True
+        )
+        self.assertEqual(record["decision"], "DENY")
+        self.assertEqual(record["failureCategory"], "semantic_boundary_insufficient")
+
+    def test_changed_target_or_review_invalidates_approval(self) -> None:
+        record = create_admission(
+            self.evidence, self.review, self.spec, "global-massing", approved=True
+        )
+        self.spec.write_text(json.dumps({**valid_spec(), "targetName": "Changed"}), encoding="utf-8")
+        report = validate_admission(record, self.evidence, self.review, self.spec)
+        self.assertFalse(report["passed"])
+        self.assertIn("admission_hash_mismatch", report["failureCategories"])
+
+
+def direct_admission(
+    spec: dict[str, object], evidence: dict[str, object], scope: str = "global-massing"
+) -> dict[str, object]:
+    return {
+        "schemaVersion": 1,
+        "kind": "dense-influence-admission",
+        "decision": "ALLOW",
+        "approvedInfluenceScope": scope,
+        "binding": {
+            "glbSha256": evidence["provenance"]["glbSha256"],
+            "evidenceSha256": canonical_sha256(evidence),
+            "visualReviewSha256": "9" * 64,
+            "scope": scope,
+            "targetSpecSha256": canonical_sha256(spec),
+        },
+    }
+
+
+def component_signature(spec: dict[str, object]) -> list[tuple[object, ...]]:
+    signature: list[tuple[object, ...]] = []
+
+    def visit(items: object, parent: str | None = None) -> None:
+        if not isinstance(items, list):
+            return
+        for item in items:
+            if isinstance(item, dict):
+                signature.append(
+                    (
+                        item.get("id"),
+                        parent,
+                        item.get("primitive"),
+                        item.get("topologyClass"),
+                        item.get("materialId"),
+                    )
+                )
+                visit(item.get("children"), str(item.get("id")))
+
+    visit(spec.get("componentTree"))
+    return signature
+
+
+class DenseEvidenceProposalTest(unittest.TestCase):
+    def test_global_massing_uses_shape_ratios_independent_of_mesh_unit_scale(self) -> None:
+        accepted = valid_spec()
+        evidence = valid_evidence()
+        evidence["globalGeometry"]["bounds"]["size"] = [2.4, 4.2, 4.0]
+        _, _, normal_fit = build_proposal(
+            accepted, evidence, direct_admission(accepted, evidence)
+        )
+
+        scaled_evidence = copy.deepcopy(evidence)
+        scaled_evidence["globalGeometry"]["bounds"]["size"] = [0.24, 0.42, 0.40]
+        _, _, scaled_fit = build_proposal(
+            accepted,
+            scaled_evidence,
+            direct_admission(accepted, scaled_evidence),
+        )
+
+        for scaled, normal in zip(
+            scaled_fit["parameterVector"], normal_fit["parameterVector"], strict=True
+        ):
+            self.assertAlmostEqual(scaled, normal, places=12)
+        self.assertGreater(len({round(value, 8) for value in normal_fit["parameterVector"]}), 1)
+
+    def test_global_proposal_is_copy_only_and_reversible(self) -> None:
+        accepted = valid_spec()
+        before = copy.deepcopy(accepted)
+        evidence = valid_evidence()
+        evidence["globalGeometry"]["bounds"]["size"] = [2.4, 4.2, 4.0]
+        proposal, delta, fit_plan = build_proposal(
+            accepted, evidence, direct_admission(accepted, evidence)
+        )
+        self.assertEqual(accepted, before)
+        self.assertNotEqual(proposal, accepted)
+        self.assertEqual(apply_reverse_delta(proposal, delta), accepted)
+        self.assertTrue(delta["changes"])
+        self.assertTrue(
+            all(item["scope"] == "global-massing" for item in delta["changes"])
+        )
+        self.assertEqual(fit_plan["minimumEvidenceImprovement"], 0.01)
+        self.assertEqual(fit_plan["maximumSourceSilhouetteRegression"], 0.02)
+
+    def test_forbidden_fields_never_change_and_scale_is_bounded(self) -> None:
+        accepted = valid_spec()
+        evidence = valid_evidence()
+        evidence["globalGeometry"]["bounds"]["size"] = [20.0, 30.0, 30.0]
+        proposal, delta, _ = build_proposal(
+            accepted, evidence, direct_admission(accepted, evidence)
+        )
+        for change in delta["changes"]:
+            self.assertIn(change["field"], GLOBAL_NUMERIC_FIELDS)
+            self.assertLessEqual(change["new"] / change["old"] if change["old"] else 1.0, 1.2 + 1e-9)
+        self.assertEqual(component_signature(proposal), component_signature(accepted))
+
+    def test_component_scope_changes_only_explicit_fields(self) -> None:
+        accepted = valid_spec()
+        evidence = valid_evidence(multipart=True)
+        evidence["regions"][1]["bounds"] = {
+            "min": [-1.32, 1.0, -1.6],
+            "max": [1.32, 2.2, 1.6],
+            "size": [2.64, 1.2, 3.2],
+        }
+        mapping = valid_component_map(evidence, accepted)
+        admission = direct_admission(accepted, evidence, "component-measurements")
+        admission["binding"]["componentMapSha256"] = canonical_sha256(mapping)
+        proposal, delta, _ = build_proposal(accepted, evidence, admission, mapping)
+        self.assertEqual({item["field"] for item in delta["changes"]}, {
+            "dimensions.width", "dimensions.height"
+        })
+        self.assertTrue(all(item["field"] in COMPONENT_NUMERIC_FIELDS for item in delta["changes"]))
+        self.assertEqual(proposal["componentTree"][0]["dimensions"], accepted["componentTree"][0]["dimensions"])
+
+    def test_stale_admission_and_forbidden_component_field_are_rejected(self) -> None:
+        accepted = valid_spec()
+        evidence = valid_evidence(multipart=True)
+        mapping = valid_component_map(evidence, accepted)
+        mapping["mappings"][0]["permittedFields"] = ["geometryDescriptor.profile"]
+        admission = direct_admission(accepted, evidence, "component-measurements")
+        admission["binding"]["componentMapSha256"] = canonical_sha256(mapping)
+        with self.assertRaisesRegex(ValueError, "influence_scope_exceeded"):
+            build_proposal(accepted, evidence, admission, mapping)
+        stale = direct_admission(accepted, evidence)
+        stale["binding"]["targetSpecSha256"] = "0" * 64
+        with self.assertRaisesRegex(ValueError, "admission_hash_mismatch"):
+            build_proposal(accepted, evidence, stale)
+
+
+class DenseEvidenceSchemaFilesTest(unittest.TestCase):
+    def test_schema_files_are_strict_and_versioned(self) -> None:
+        for relative in (
+            "docs/specs/dense-evidence.v1.schema.json",
+            "docs/specs/component-evidence-map.v1.schema.json",
+        ):
+            schema = json.loads((ROOT / relative).read_text(encoding="utf-8"))
+            self.assertEqual(schema["$schema"], "https://json-schema.org/draft/2020-12/schema")
+            self.assertFalse(schema["additionalProperties"])
+
+
+class DenseEvidenceDocumentationTest(unittest.TestCase):
+    def test_docs_define_authority_cost_and_runtime_boundaries(self) -> None:
+        text = (ROOT / "docs/integrations/trellis-dense-evidence.md").read_text(
+            encoding="utf-8"
+        )
+        for phrase in (
+            "source image is authoritative",
+            "maxCostUsd = 0",
+            "offline",
+            "global-massing",
+            "component-measurements",
+            "no provider call",
+            "never shipped at runtime",
+            "proposed-object-sculpt-spec.json",
+        ):
+            self.assertIn(phrase, text)
+
+    def test_every_changed_markdown_starts_with_last_updated(self) -> None:
+        paths = (
+            ROOT / "docs/integrations/trellis-dense-evidence.md",
+            ROOT / "SKILL.md",
+            ROOT / "README.md",
+            ROOT / "ROADMAP.md",
+            ROOT / "CHANGELOG.md",
+        )
+        for path in paths:
+            with self.subTest(path=path):
+                self.assertRegex(
+                    path.read_text(encoding="utf-8").splitlines()[0],
+                    r"^> Last updated: 2026-09-01 \d{2}:\d{2}$",
+                )
+
+    def test_public_docs_do_not_claim_trellis_generates_final_factory(self) -> None:
+        for path in (ROOT / "README.md", ROOT / "ROADMAP.md", ROOT / "CHANGELOG.md"):
+            text = path.read_text(encoding="utf-8")
+            self.assertIn("dense evidence", text.lower())
+            self.assertIn("code-only", text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_dense_evidence_contract.py
+++ b/forge/tests/test_dense_evidence_contract.py
@@ -443,7 +443,9 @@ class DenseEvidenceDocumentationTest(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertRegex(
                     path.read_text(encoding="utf-8").splitlines()[0],
-                    r"^> Last updated: 2026-09-01 \d{2}:\d{2}$",
+                    # the contract is "starts with a dated Last-updated line", not a
+                    # specific day: these files keep being updated after this feature
+                    r"^> Last updated: \d{4}-\d{2}-\d{2} \d{2}:\d{2}$",
                 )
 
     def test_public_docs_do_not_claim_trellis_generates_final_factory(self) -> None:

--- a/forge/tests/test_dense_evidence_review.py
+++ b/forge/tests/test_dense_evidence_review.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from forge.stage4_review.compare_dense_evidence import (
+    compare_dense_evidence,
+    scan_runtime_sources,
+)
+
+
+def clean_gates() -> dict[str, bool]:
+    return {
+        "strictQuality": True,
+        "passOrder": True,
+        "turntable": True,
+        "attachment": True,
+        "intersection": True,
+    }
+
+
+def source_metrics(iou: float, *, roof: bool = True) -> dict[str, object]:
+    return {
+        "silhouetteIou": iou,
+        "criticalFeatures": {"roof": roof},
+        "browserHashes": {"source": "a" * 64, "render": "b" * 64},
+    }
+
+
+def evidence_metrics(score: float) -> dict[str, object]:
+    return {
+        "massingSimilarity": score,
+        "browserHashes": {"provider": "c" * 64, "procedural": "d" * 64},
+    }
+
+
+def valid_admission(*, scope: str = "global-massing", maximum: str = "global-massing") -> dict[str, object]:
+    return {
+        "decision": "ALLOW",
+        "approvedInfluenceScope": scope,
+        "maximumInfluenceScope": maximum,
+        "binding": {"scope": scope},
+    }
+
+
+class DenseEvidenceReviewTest(unittest.TestCase):
+    def test_candidate_needs_source_safety_and_evidence_improvement(self) -> None:
+        report = compare_dense_evidence(
+            baseline_source=source_metrics(0.81),
+            candidate_source=source_metrics(0.80),
+            baseline_evidence=evidence_metrics(0.70),
+            candidate_evidence=evidence_metrics(0.72),
+            deterministic_gates=clean_gates(),
+            admission=valid_admission(),
+        )
+        self.assertEqual(report["decision"], "ALLOW")
+
+    def test_glb_improvement_cannot_hide_source_regression(self) -> None:
+        report = compare_dense_evidence(
+            baseline_source=source_metrics(0.81),
+            candidate_source=source_metrics(0.78),
+            baseline_evidence=evidence_metrics(0.50),
+            candidate_evidence=evidence_metrics(0.95),
+            deterministic_gates=clean_gates(),
+            admission=valid_admission(),
+        )
+        self.assertEqual(report["decision"], "DENY")
+        self.assertEqual(report["failureCategory"], "source_fidelity_regression")
+
+    def test_critical_feature_gate_and_minimum_improvement_are_blocking(self) -> None:
+        critical = compare_dense_evidence(
+            source_metrics(0.81), source_metrics(0.81, roof=False),
+            evidence_metrics(0.70), evidence_metrics(0.90), clean_gates(), valid_admission()
+        )
+        self.assertEqual(critical["failureCategory"], "source_fidelity_regression")
+        flat = compare_dense_evidence(
+            source_metrics(0.81), source_metrics(0.81),
+            evidence_metrics(0.70), evidence_metrics(0.705), clean_gates(), valid_admission()
+        )
+        self.assertEqual(flat["failureCategory"], "fit_no_improvement")
+
+    def test_missing_browser_hash_dirty_gate_and_scope_are_denied(self) -> None:
+        missing = source_metrics(0.81)
+        missing["browserHashes"] = {}
+        report = compare_dense_evidence(
+            missing, source_metrics(0.81), evidence_metrics(0.70), evidence_metrics(0.72),
+            clean_gates(), valid_admission()
+        )
+        self.assertEqual(report["failureCategory"], "browser_evidence_missing")
+        gates = clean_gates()
+        gates["intersection"] = False
+        dirty = compare_dense_evidence(
+            source_metrics(0.81), source_metrics(0.81), evidence_metrics(0.70),
+            evidence_metrics(0.72), gates, valid_admission()
+        )
+        self.assertEqual(dirty["failureCategory"], "deterministic_gate_failed")
+        scope = compare_dense_evidence(
+            source_metrics(0.81), source_metrics(0.81), evidence_metrics(0.70),
+            evidence_metrics(0.72), clean_gates(),
+            valid_admission(scope="component-measurements", maximum="global-massing")
+        )
+        self.assertEqual(scope["failureCategory"], "influence_scope_exceeded")
+
+
+class DenseEvidenceRuntimeGuardTest(unittest.TestCase):
+    def test_code_only_typescript_factory_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            factory = Path(directory) / "createHouseModel.ts"
+            factory.write_text(
+                "import * as THREE from 'three';\nexport function createHouseModel(){return new THREE.Group();}\n",
+                encoding="utf-8",
+            )
+            report = scan_runtime_sources([factory])
+            self.assertTrue(report["passed"], report["violations"])
+
+    def test_runtime_glb_loader_provider_url_and_copied_payload_are_rejected(self) -> None:
+        samples = {
+            "loader.ts": "new GLTFLoader().load('house.glb')",
+            "provider.ts": "fetch('https://trellis-community.example/api')",
+            "payload.ts": "const copiedMeshPayload = [0, 1, 2]",
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            paths = []
+            for name, source in samples.items():
+                path = Path(directory) / name
+                path.write_text(source, encoding="utf-8")
+                paths.append(path)
+            report = scan_runtime_sources(paths)
+            self.assertFalse(report["passed"])
+            self.assertEqual(len(report["violations"]), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_free_generative_assist.py
+++ b/forge/tests/test_free_generative_assist.py
@@ -1,0 +1,645 @@
+from __future__ import annotations
+
+import dataclasses
+import io
+import json
+import os
+import struct
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from integrations.mesh3d.free_assist.model import (
+    AssistFailure,
+    Decision,
+    GenerationRequest,
+    RawGeneration,
+    ZeroSpendPolicy,
+)
+from integrations.mesh3d.free_assist.pipeline import (
+    admit_glb,
+    compute_cache_key,
+    default_metadata_probe,
+    generate,
+    local_capability,
+    local_install_revision,
+    normalize_provider_failure,
+    preflight,
+    resume,
+    sha256_file,
+)
+from integrations.mesh3d.free_assist.registry import (
+    MetadataDecision,
+    UnknownProvider,
+    evaluate_hosted_metadata,
+    provider_spec,
+)
+from integrations.mesh3d.free_assist.security import redact
+from integrations.mesh3d.free_assist.cli import build_parser, main as cli_main
+
+
+def write_triangle_glb(
+    path: Path, *, degenerate: bool = False, with_material: bool = True
+) -> None:
+    positions = struct.pack(
+        "<9f",
+        0.0,
+        0.0,
+        0.0,
+        0.0 if degenerate else 1.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0 if degenerate else 1.0,
+        0.0,
+    )
+    document = {
+        "asset": {"version": "2.0", "generator": "free-assist-test"},
+        "scene": 0,
+        "scenes": [{"nodes": [0]}],
+        "nodes": [{"name": "Root", "mesh": 0}],
+        "meshes": [
+            {
+                "name": "Triangle",
+                "primitives": [{"attributes": {"POSITION": 0}, "material": 0}],
+            }
+        ],
+        "materials": [{"name": "Fixture"}] if with_material else [],
+        "buffers": [{"byteLength": len(positions)}],
+        "bufferViews": [{"buffer": 0, "byteOffset": 0, "byteLength": len(positions)}],
+        "accessors": [
+            {
+                "bufferView": 0,
+                "componentType": 5126,
+                "count": 3,
+                "type": "VEC3",
+                "min": [0.0, 0.0, 0.0],
+                "max": [0.0, 0.0, 0.0] if degenerate else [1.0, 1.0, 0.0],
+            }
+        ],
+    }
+    json_chunk = json.dumps(document, separators=(",", ":")).encode()
+    json_chunk += b" " * ((4 - len(json_chunk) % 4) % 4)
+    binary = positions + b"\0" * ((4 - len(positions) % 4) % 4)
+    total = 12 + 8 + len(json_chunk) + 8 + len(binary)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        struct.pack("<4sII", b"glTF", 2, total)
+        + struct.pack("<II", len(json_chunk), 0x4E4F534A)
+        + json_chunk
+        + struct.pack("<II", len(binary), 0x004E4942)
+        + binary
+    )
+
+
+class PolicyRegistryTest(unittest.TestCase):
+    def test_policy_is_immutable_and_zero_cost(self) -> None:
+        policy = ZeroSpendPolicy()
+        self.assertEqual(policy.max_cost_usd, 0)
+        self.assertFalse(policy.allow_paid_fallback)
+        self.assertFalse(policy.allow_credit_purchase)
+        self.assertFalse(policy.allow_automatic_retry)
+        self.assertFalse(policy.allow_automatic_provider_switch)
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            policy.max_cost_usd = 1  # type: ignore[misc]
+
+    def test_registry_contains_only_reviewed_providers(self) -> None:
+        self.assertEqual(
+            provider_spec("hf-zerogpu-trellis").endpoint, "trellis-community/TRELLIS"
+        )
+        self.assertEqual(
+            provider_spec("hf-zerogpu-sf3d").endpoint, "stabilityai/stable-fast-3d"
+        )
+        self.assertEqual(provider_spec("local-sf3d").endpoint, "local")
+        with self.assertRaises(UnknownProvider):
+            provider_spec("unknown")
+
+    def test_unknown_or_non_zero_hardware_fails_closed(self) -> None:
+        good = {
+            "runtime": {
+                "stage": "RUNNING",
+                "hardware": {"current": "zero-a10g", "requested": "zero-a10g"},
+                "domains": [{"domain": "example.hf.space", "stage": "READY"}],
+                "sha": "abc123",
+            }
+        }
+        self.assertEqual(evaluate_hosted_metadata(good).decision, Decision.ALLOW)
+        for metadata in (
+            {},
+            {
+                "runtime": {
+                    "stage": "RUNNING",
+                    "hardware": {"current": "a10g", "requested": "a10g"},
+                }
+            },
+            {
+                "runtime": {
+                    "stage": "STOPPED",
+                    "hardware": {"current": "zero-a10g", "requested": "zero-a10g"},
+                }
+            },
+        ):
+            self.assertEqual(evaluate_hosted_metadata(metadata).decision, Decision.DENY)
+
+    def test_redaction_removes_tokens_headers_cookies_and_signed_queries(self) -> None:
+        value = {
+            "Authorization": "Bearer hf_TEST-TOKEN-abcdefghijklmnopqrstuvwxyz",
+            "cookie": "session=secret",
+            "url": "https://host/file?token=secret&download=1&X-Amz-Signature=abc",
+            "message": "failed with hf_TEST-TOKEN-abcdefghijklmnopqrstuvwxyz",
+            "generic": "request contained Bearer very-secret-provider-token",
+            "safe": "visible",
+        }
+        result = redact(value)
+        serialized = repr(result)
+        self.assertNotIn("secret", serialized)
+        self.assertNotIn("abcdefghijklmnopqrstuvwxyz", serialized)
+        self.assertNotIn("very-secret-provider-token", serialized)
+        self.assertNotIn("X-Amz-Signature", serialized)
+        self.assertEqual(result["safe"], "visible")
+
+
+class RequestPreflightTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.image = self.root / "front.png"
+        self.image.write_bytes(b"fixture-image")
+        self.metadata = {
+            "runtime": {
+                "stage": "RUNNING",
+                "hardware": {"current": "zero-a10g", "requested": "zero-a10g"},
+                "domains": [
+                    {"domain": "trellis-community-trellis.hf.space", "stage": "READY"}
+                ],
+                "sha": "reviewed-revision",
+            }
+        }
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def request(self, **parameters: object) -> GenerationRequest:
+        return GenerationRequest(
+            images=(self.image,),
+            provider_id="hf-zerogpu-trellis",
+            out_dir=self.root / "artifacts",
+            endpoint_revision="reviewed-revision",
+            parameters=dict(parameters),
+        )
+
+    def test_cache_key_changes_for_input_provider_revision_and_parameters(self) -> None:
+        base = self.request(seed=0)
+        variants = (
+            base,
+            replace(base, provider_id="hf-zerogpu-sf3d"),
+            replace(base, endpoint_revision="another-revision"),
+            replace(base, parameters={"seed": 1}),
+        )
+        self.assertEqual(
+            len({compute_cache_key(item) for item in variants}), len(variants)
+        )
+        self.image.write_bytes(b"different-image")
+        self.assertNotEqual(
+            compute_cache_key(base),
+            compute_cache_key(replace(base, parameters={"seed": 1})),
+        )
+
+    def test_preflight_is_metadata_only_and_requires_upload_approval(self) -> None:
+        calls: list[str] = []
+
+        def probe(endpoint: str) -> dict:
+            calls.append(endpoint)
+            return self.metadata
+
+        report = preflight(self.request(seed=0), metadata_probe=probe)
+        self.assertEqual(report.decision, Decision.NEEDS_USER_ACTION)
+        self.assertEqual(calls, ["trellis-community/TRELLIS"])
+        self.assertEqual(report.upload_files, (str(self.image.resolve()),))
+        saved = json.loads((self.root / "artifacts" / "preflight.json").read_text())
+        self.assertEqual(saved["decision"], "NEEDS_USER_ACTION")
+
+    def test_preflight_denies_non_zero_hardware(self) -> None:
+        metadata = dict(self.metadata)
+        metadata["runtime"] = dict(self.metadata["runtime"])
+        metadata["runtime"]["hardware"] = {"current": "a10g", "requested": "a10g"}
+        report = preflight(
+            self.request(),
+            metadata_probe=lambda _endpoint: metadata,
+            approve_upload=True,
+        )
+        self.assertEqual(report.decision, Decision.DENY)
+
+    def test_metadata_probe_failure_writes_fail_closed_preflight_report(self) -> None:
+        def failing_probe(_endpoint: str) -> dict:
+            raise RuntimeError("metadata network unavailable")
+
+        report = preflight(
+            self.request(), metadata_probe=failing_probe, approve_upload=True
+        )
+        self.assertEqual(report.decision, Decision.DENY)
+        self.assertEqual(report.evidence["failureCategory"], "free_status_unverified")
+        saved = json.loads((self.root / "artifacts" / "preflight.json").read_text())
+        self.assertEqual(saved["decision"], "DENY")
+
+    def test_huggingface_space_runtime_object_uses_raw_metadata(self) -> None:
+        card = SimpleNamespace(to_dict=lambda: {"license": "mit"})
+        info = SimpleNamespace(
+            id="trellis-community/TRELLIS",
+            runtime=SimpleNamespace(raw=self.metadata["runtime"]),
+            card_data=card,
+        )
+        with patch("huggingface_hub.HfApi") as api:
+            api.return_value.space_info.return_value = info
+            result = default_metadata_probe("trellis-community/TRELLIS")
+        self.assertEqual(result["runtime"]["hardware"]["current"], "zero-a10g")
+        self.assertEqual(result["cardData"]["license"], "mit")
+
+    def test_local_capability_enforces_disk_and_memory_and_selects_safe_backend(
+        self,
+    ) -> None:
+        low_disk = local_capability(
+            self.root,
+            system="Darwin",
+            machine="arm64",
+            disk_free_bytes=8 << 30,
+            memory_bytes=64 << 30,
+        )
+        self.assertEqual(low_disk.decision, Decision.UNAVAILABLE)
+        low_memory = local_capability(
+            self.root,
+            system="Darwin",
+            machine="arm64",
+            disk_free_bytes=20 << 30,
+            memory_bytes=8 << 30,
+        )
+        self.assertEqual(low_memory.decision, Decision.UNAVAILABLE)
+        cpu_safe = local_capability(
+            self.root,
+            system="Darwin",
+            machine="arm64",
+            disk_free_bytes=20 << 30,
+            memory_bytes=16 << 30,
+        )
+        self.assertEqual(cpu_safe.decision, Decision.ALLOW)
+        self.assertEqual(cpu_safe.evidence["recommendedBackend"], "cpu")
+        mps = local_capability(
+            self.root,
+            system="Darwin",
+            machine="arm64",
+            disk_free_bytes=20 << 30,
+            memory_bytes=64 << 30,
+        )
+        self.assertEqual(mps.evidence["recommendedBackend"], "mps-experimental")
+
+    def test_local_install_revision_changes_with_fallback_script_content(self) -> None:
+        root = self.root / "sf3d-revision"
+        root.mkdir()
+        script = root / "run.py"
+        script.write_text("first\n", encoding="utf-8")
+        first = local_install_revision(root)
+        script.write_text("second\n", encoding="utf-8")
+        second = local_install_revision(root)
+        self.assertNotEqual(first, second)
+        self.assertTrue(first.startswith("run-py-sha256:"))
+
+
+class _FakeAdapter:
+    def __init__(self, source: Path, failure: Exception | None = None) -> None:
+        self.source = source
+        self.failure = failure
+        self.calls = 0
+
+    def generate(self, request: GenerationRequest, run_dir: Path) -> RawGeneration:
+        self.calls += 1
+        if self.failure:
+            raise self.failure
+        return RawGeneration(
+            self.source, provider_task_id="fixture-task", model_id="fixture-model"
+        )
+
+
+class _CapturingAdapter(_FakeAdapter):
+    captured_request: GenerationRequest | None = None
+
+    def generate(self, request: GenerationRequest, run_dir: Path) -> RawGeneration:
+        self.captured_request = request
+        return super().generate(request, run_dir)
+
+
+class GenerationTest(RequestPreflightTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.source = self.root / "provider-output.glb"
+        write_triangle_glb(self.source)
+
+    def test_generate_requires_exact_upload_approval(self) -> None:
+        adapter = _FakeAdapter(self.source)
+        with self.assertRaises(AssistFailure) as error:
+            generate(
+                self.request(seed=0),
+                approve_upload=False,
+                adapter=adapter,
+                metadata_probe=lambda _: self.metadata,
+            )
+        self.assertEqual(error.exception.category, "upload_not_approved")
+        self.assertEqual(adapter.calls, 0)
+
+    def test_provider_failure_is_not_retried_or_switched(self) -> None:
+        adapter = _FakeAdapter(
+            self.source,
+            RuntimeError("queue failed with hf_TEST-TOKEN-abcdefghijklmnopqrstuvwxyz"),
+        )
+        with self.assertRaises(AssistFailure) as error:
+            generate(
+                self.request(seed=0),
+                approve_upload=True,
+                adapter=adapter,
+                metadata_probe=lambda _: self.metadata,
+            )
+        self.assertEqual(error.exception.category, "provider_unavailable")
+        self.assertEqual(adapter.calls, 1)
+        statuses = list((self.root / "artifacts" / "runs").glob("*/status.json"))
+        self.assertEqual(len(statuses), 1)
+        self.assertNotIn("abcdefghijklmnopqrstuvwxyz", statuses[0].read_text())
+
+    def test_adapter_assist_failure_is_redacted_before_rethrow(self) -> None:
+        adapter = _FakeAdapter(
+            self.source,
+            AssistFailure(
+                "authentication_required",
+                "rejected hf_TEST-TOKEN-abcdefghijklmnopqrstuvwxyz",
+            ),
+        )
+        with self.assertRaises(AssistFailure) as error:
+            generate(
+                self.request(),
+                approve_upload=True,
+                adapter=adapter,
+                metadata_probe=lambda _: self.metadata,
+            )
+        self.assertNotIn("abcdefghijklmnopqrstuvwxyz", str(error.exception))
+        self.assertEqual(error.exception.category, "authentication_required")
+
+    def test_provider_failures_use_normalized_queue_and_quota_categories(self) -> None:
+        self.assertEqual(
+            normalize_provider_failure(TimeoutError("timed out")), "queue_timeout"
+        )
+        self.assertEqual(
+            normalize_provider_failure(RuntimeError("ZeroGPU quota exceeded")),
+            "quota_exhausted",
+        )
+        self.assertEqual(
+            normalize_provider_failure(RuntimeError("service unavailable")),
+            "provider_unavailable",
+        )
+
+    def test_success_persists_immutable_raw_glb_and_receipt(self) -> None:
+        adapter = _FakeAdapter(self.source)
+        run = generate(
+            self.request(seed=7),
+            approve_upload=True,
+            adapter=adapter,
+            metadata_probe=lambda _: self.metadata,
+        )
+        raw = run / "raw" / "reference.glb"
+        self.assertEqual(adapter.calls, 1)
+        self.assertTrue(raw.is_file())
+        self.assertEqual(raw.read_bytes()[:4], b"glTF")
+        receipt = json.loads((run / "provider-receipt.json").read_text())
+        self.assertEqual(receipt["declaredMonetaryCostUsd"], 0)
+        self.assertEqual(receipt["rawSha256"], sha256_file(raw))
+
+    def test_local_cpu_recommendation_is_enforced_on_provider_request(self) -> None:
+        sf3d_root = self.root / "sf3d"
+        sf3d_root.mkdir()
+        (sf3d_root / "run.py").write_text("# fixture\n", encoding="utf-8")
+        request = replace(self.request(seed=0), provider_id="local-sf3d")
+        adapter = _CapturingAdapter(self.source)
+        capability = MetadataDecision(Decision.ALLOW, (), {"recommendedBackend": "cpu"})
+        with (
+            patch.dict(
+                os.environ,
+                {"SF3D_ROOT": str(sf3d_root), "SF3D_MODEL_ACCESS_APPROVED": "1"},
+            ),
+            patch(
+                "integrations.mesh3d.free_assist.pipeline.local_capability",
+                return_value=capability,
+            ),
+        ):
+            generate(request, approve_local_run=True, adapter=adapter)
+        self.assertIsNotNone(adapter.captured_request)
+        self.assertTrue(adapter.captured_request.parameters["forceCpu"])
+
+    def test_local_missing_user_license_acceptance_has_specific_failure(self) -> None:
+        sf3d_root = self.root / "sf3d-no-license"
+        sf3d_root.mkdir()
+        (sf3d_root / "run.py").write_text("# fixture\n", encoding="utf-8")
+        request = replace(self.request(seed=0), provider_id="local-sf3d")
+        capability = MetadataDecision(Decision.ALLOW, (), {"recommendedBackend": "cpu"})
+        environment = {
+            key: value
+            for key, value in os.environ.items()
+            if key != "SF3D_MODEL_ACCESS_APPROVED"
+        }
+        environment["SF3D_ROOT"] = str(sf3d_root)
+        with (
+            patch.dict(os.environ, environment, clear=True),
+            patch(
+                "integrations.mesh3d.free_assist.pipeline.local_capability",
+                return_value=capability,
+            ),
+        ):
+            with self.assertRaises(AssistFailure) as error:
+                generate(
+                    request, approve_local_run=True, adapter=_FakeAdapter(self.source)
+                )
+        self.assertEqual(error.exception.category, "license_acceptance_required")
+
+
+class ResumeAdmissionTest(GenerationTest):
+    @staticmethod
+    def fixture_obj_writer(_glb: Path, obj: Path) -> dict:
+        obj.write_text("v 0 0 0\nv 1 0 0\nv 0 1 0\nf 1 2 3\n", encoding="utf-8")
+        return {
+            "vertices": 3,
+            "triangles": 1,
+            "bbox_min": [0.0, 0.0, 0.0],
+            "bbox_max": [1.0, 1.0, 0.0],
+            "size": [1.0, 1.0, 0.0],
+            "watertight": False,
+        }
+
+    def raw_run(self) -> tuple[Path, _FakeAdapter]:
+        adapter = _FakeAdapter(self.source)
+        run = generate(
+            self.request(seed=7),
+            approve_upload=True,
+            adapter=adapter,
+            metadata_probe=lambda _: self.metadata,
+        )
+        return run, adapter
+
+    def test_normalization_failure_resumes_raw_without_generation(self) -> None:
+        run, adapter = self.raw_run()
+
+        def raising_writer(_glb: Path, _obj: Path) -> dict:
+            raise RuntimeError("local converter failed")
+
+        first = resume(run, obj_writer=raising_writer)
+        self.assertEqual(first["failureCategory"], "normalization_failed")
+        self.assertTrue(first["resumable"])
+        second = resume(run, obj_writer=self.fixture_obj_writer)
+        self.assertEqual(second["status"], "complete")
+        self.assertEqual(adapter.calls, 1)
+        self.assertTrue((run / "normalized" / "reference.obj").is_file())
+
+    def test_invalid_glb_and_degenerate_bounds_fail_admission(self) -> None:
+        bad = self.root / "bad.glb"
+        bad.write_bytes(b"not-a-glb")
+        bad_report = admit_glb(bad)
+        self.assertEqual(bad_report["failureCategory"], "invalid_glb")
+
+        flat = self.root / "degenerate.glb"
+        write_triangle_glb(flat, degenerate=True)
+        flat_report = admit_glb(flat)
+        self.assertEqual(flat_report["failureCategory"], "mesh_admission_failed")
+
+    def test_completed_cache_prevents_second_provider_call(self) -> None:
+        run, first_adapter = self.raw_run()
+        completed = resume(run, obj_writer=self.fixture_obj_writer)
+        self.assertEqual(completed["status"], "complete")
+        second_adapter = _FakeAdapter(self.source)
+
+        def network_forbidden(_endpoint: str) -> dict:
+            raise AssertionError("cache reuse must not probe the network")
+
+        cached = generate(
+            self.request(seed=7),
+            approve_upload=False,
+            adapter=second_adapter,
+            metadata_probe=network_forbidden,
+        )
+        self.assertEqual(cached, run)
+        self.assertEqual(first_adapter.calls, 1)
+        self.assertEqual(second_adapter.calls, 0)
+
+    def test_completed_local_cache_bypasses_install_and_license_checks(self) -> None:
+        sf3d_root = self.root / "sf3d"
+        sf3d_root.mkdir()
+        (sf3d_root / "run.py").write_text("# fixture\n", encoding="utf-8")
+        request = replace(self.request(seed=3), provider_id="local-sf3d")
+        capability = MetadataDecision(Decision.ALLOW, (), {"recommendedBackend": "cpu"})
+        with (
+            patch.dict(
+                os.environ,
+                {"SF3D_ROOT": str(sf3d_root), "SF3D_MODEL_ACCESS_APPROVED": "1"},
+            ),
+            patch(
+                "integrations.mesh3d.free_assist.pipeline.local_capability",
+                return_value=capability,
+            ),
+        ):
+            run = generate(
+                request, approve_local_run=True, adapter=_FakeAdapter(self.source)
+            )
+        self.assertEqual(
+            resume(run, obj_writer=self.fixture_obj_writer)["status"], "complete"
+        )
+        with patch.dict(os.environ, {}, clear=True):
+            cached = generate(request, adapter=_FakeAdapter(self.root / "missing.glb"))
+        self.assertEqual(cached, run)
+
+
+class CliTest(RequestPreflightTest):
+    def test_help_has_no_token_spend_retry_or_endpoint_override(self) -> None:
+        help_text = build_parser().format_help()
+        for forbidden in (
+            "--hf-token",
+            "--token",
+            "max-cost",
+            "paid-fallback",
+            "--retry",
+            "--space",
+        ):
+            self.assertNotIn(forbidden, help_text)
+
+    def test_generate_without_approval_never_constructs_provider(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with redirect_stdout(stdout), redirect_stderr(stderr):
+            code = cli_main(
+                [
+                    "generate",
+                    str(self.image),
+                    "--provider",
+                    "hf-zerogpu-trellis",
+                    "--out-dir",
+                    str(self.root / "cli-artifacts"),
+                ],
+                metadata_probe=lambda _endpoint: self.metadata,
+            )
+        self.assertEqual(code, 3)
+        self.assertIn("upload_not_approved", stderr.getvalue())
+        self.assertFalse((self.root / "cli-artifacts" / "runs").exists())
+
+    def test_preflight_prints_machine_readable_decision(self) -> None:
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            code = cli_main(
+                [
+                    "preflight",
+                    str(self.image),
+                    "--provider",
+                    "hf-zerogpu-trellis",
+                    "--out-dir",
+                    str(self.root / "cli-artifacts"),
+                ],
+                metadata_probe=lambda _endpoint: self.metadata,
+            )
+        self.assertEqual(code, 3)
+        self.assertEqual(json.loads(stdout.getvalue())["decision"], "NEEDS_USER_ACTION")
+
+
+class DocumentationTest(unittest.TestCase):
+    DOC = (
+        Path(__file__).resolve().parents[2]
+        / "docs"
+        / "integrations"
+        / "free-generative-assist.md"
+    )
+    PROJECT = (
+        Path(__file__).resolve().parents[2]
+        / "integrations"
+        / "mesh3d"
+        / "pyproject.toml"
+    )
+
+    def test_docs_state_free_limits_and_manual_live_gate(self) -> None:
+        text = self.DOC.read_text(encoding="utf-8")
+        for phrase in (
+            "maxCostUsd = 0",
+            "ZeroGPU",
+            "--approve-upload",
+            "resume",
+            "no automatic retry",
+            "separate live acceptance",
+            "Tripo",
+            "Meshy",
+            "SF3D_MODEL_ACCESS_APPROVED",
+        ):
+            self.assertIn(phrase, text)
+        self.assertTrue(text.startswith("> Last updated: 2026-09-01"))
+
+    def test_optional_integration_declares_provider_dependencies(self) -> None:
+        text = self.PROJECT.read_text(encoding="utf-8")
+        for package in ("gradio-client", "huggingface-hub", "trimesh"):
+            self.assertIn(package, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_free_generative_assist.py
+++ b/forge/tests/test_free_generative_assist.py
@@ -637,7 +637,7 @@ class DocumentationTest(unittest.TestCase):
 
     def test_optional_integration_declares_provider_dependencies(self) -> None:
         text = self.PROJECT.read_text(encoding="utf-8")
-        for package in ("gradio-client", "huggingface-hub", "trimesh"):
+        for package in ("gradio-client", "huggingface-hub", "trimesh", "scipy"):
             self.assertIn(package, text)
 
 

--- a/forge/tests/test_instanced_cluster_tessellation.py
+++ b/forge/tests/test_instanced_cluster_tessellation.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Instanced repetition-system geometry must use the LOW tessellation tier.
+
+An instanced micro-part (curb stone, eave tile, fastener) never deforms and is
+never subdivided, so hero-tier segment counts are pure waste multiplied by the
+instance count: measured on the whimsical-hearth-house, a 26-stone curb ring of
+hero-tier boxes cost 44,928 triangles — half the diorama's 90k target budget
+spent on cubes.
+
+Pure Python 3.10+ stdlib. No pip installs.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def import_generator():
+    module_names = ("generate_threejs_factory", "validate_sculpt_spec")
+    original_modules = {name: sys.modules.pop(name, None) for name in module_names}
+    original_path = sys.path[:]
+    sys.path[:0] = [str(ROOT / "stage2_spec"), str(ROOT / "stage3_build")]
+    try:
+        import generate_threejs_factory
+    finally:
+        sys.path[:] = original_path
+        for name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+    return generate_threejs_factory
+
+
+GEN = import_generator()
+
+CLUSTER_SPEC = {
+    "targetName": "Cluster Tessellation Fixture",
+    "schemaVersion": "2.1",
+    "suitability": "pass",
+    "coordinateFrame": {},
+    "silhouette": {},
+    "proceduralStrategy": [],
+    "materials": [{"id": "clay"}],
+    "componentTree": [
+        {
+            "id": "base",
+            "name": "Base",
+            "level": "macro",
+            "role": "body",
+            "primitive": "box",
+            "parent": None,
+            "material": "clay",
+            "transform": {"position": [0, 0, 0], "rotation": [0, 0, 0], "scale": [4, 1, 4]},
+        },
+    ],
+    "repetitionSystems": [
+        {
+            "id": "stud-ring",
+            "level": "meso",
+            "parent": "base",
+            "count": 12,
+            "primitive": "box",
+            "material": "clay",
+            "instanceScale": [0.2, 0.2, 0.2],
+            "placement": {"mode": "radial", "axis": [0, 1, 0], "radius": 4.0},
+        }
+    ],
+}
+
+
+class InstancedClusterTessellationTest(unittest.TestCase):
+    def test_cluster_geometry_uses_low_tier(self) -> None:
+        generated = GEN.generate(CLUSTER_SPEC, "form-refinement")
+        cluster_block = generated[generated.index("repetition system: stud-ring"):]
+        geo_line = next(
+            line for line in cluster_block.splitlines() if "const geo =" in line
+        )
+        low_n = GEN.TESSELLATION_TIERS["low"]["BOX_SEGMENTS"]
+        self.assertIn(
+            f"new THREE.BoxGeometry(1, 1, 1, {low_n}, {low_n}, {low_n})",
+            geo_line,
+            f"instanced cluster must use the low tier, got: {geo_line.strip()}",
+        )
+
+    def test_component_geometry_keeps_the_model_tier(self) -> None:
+        generated = GEN.generate(CLUSTER_SPEC, "form-refinement")
+        hero_n = GEN.TESSELLATION_TIERS[GEN.DEFAULT_TESSELLATION_TIER]["BOX_SEGMENTS"]
+        self.assertIn(
+            f"new THREE.BoxGeometry(1, 1, 1, {hero_n}, {hero_n}, {hero_n})",
+            generated,
+            "component geometry must still use the model's own tier",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_lookdev_shadow_bounds.py
+++ b/forge/tests/test_lookdev_shadow_bounds.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Look-dev shadow camera must cover the model it lights.
+
+The whimsical-hearth-house incident: the emitted rig hardcoded a +-2.6
+orthographic shadow camera sized for a character-scale asset, so a ~5.3-radius
+garden diorama's contact shadow could never land past its own base — the
+"missing contact shadow" mustAvoid of the lighting contract was structurally
+unavoidable for any larger model. The generator now sizes the shadow camera
+and light positions from the spec's estimated world radius.
+
+Pure Python 3.10+ stdlib. No pip installs.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def import_generator():
+    module_names = ("generate_threejs_factory", "validate_sculpt_spec")
+    original_modules = {name: sys.modules.pop(name, None) for name in module_names}
+    original_path = sys.path[:]
+    sys.path[:0] = [str(ROOT / "stage2_spec"), str(ROOT / "stage3_build")]
+    try:
+        import generate_threejs_factory
+    finally:
+        sys.path[:] = original_path
+        for name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+    return generate_threejs_factory
+
+
+GEN = import_generator()
+
+
+def component(component_id: str, parent: str | None, position: list[float], dims: tuple[float, float, float]) -> dict:
+    return {
+        "id": component_id,
+        "parent": parent,
+        "dimensions": {"width": dims[0], "height": dims[1], "depth": dims[2]},
+        "transform": {"position": list(position), "rotation": [0, 0, 0], "scale": [1, 1, 1]},
+    }
+
+
+class EstimateModelRadiusTest(unittest.TestCase):
+    def test_accumulates_parent_chain_and_half_extents(self) -> None:
+        spec = {
+            "componentTree": [
+                component("root", None, [0, 0, 0], (1, 1, 1)),
+                component("base", "root", [0, 0.2, 0], (10, 0.5, 8)),
+                component("tower", "base", [3.0, 2.5, 0], (2.4, 5.2, 2.4)),
+            ]
+        }
+        radius = GEN.estimate_model_radius(spec)
+        # base alone reaches |0| + 10/2 = 5.0; the tower reaches 2.7 + 2.6 = 5.3 in y
+        self.assertGreaterEqual(radius, 5.0)
+
+    def test_falls_back_to_character_scale_without_dimensions(self) -> None:
+        self.assertEqual(GEN.estimate_model_radius({"componentTree": []}), 2.0)
+
+
+class ShadowCameraBoundsTest(unittest.TestCase):
+    def emitted_rig(self, base_half: float) -> str:
+        spec = {
+            "componentTree": [
+                component("root", None, [0, 0, 0], (1, 1, 1)),
+                component("base", "root", [0, 0.2, 0], (base_half * 2, 0.5, base_half * 2)),
+            ]
+        }
+        radius = GEN.estimate_model_radius(spec)
+        half = round(max(2.6, radius * 1.4), 2)
+        return radius, half
+
+    def test_large_model_gets_covering_bounds(self) -> None:
+        radius, half = self.emitted_rig(5.3)
+        self.assertGreaterEqual(half, radius, "shadow half-extent must cover the model radius")
+
+    def test_small_model_keeps_character_scale_floor(self) -> None:
+        _, half = self.emitted_rig(0.5)
+        self.assertEqual(half, 2.6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_rebase_component_frames.py
+++ b/forge/tests/test_rebase_component_frames.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Parent-local frame contract: the rebase converter and the frame-sanity gate.
+
+The whimsical-hearth-house incident: a machine-authored spec placed every
+child's `transform.position` (and `attachment.localStart/localEnd`) in
+object-frame absolute coordinates. The generator correctly applies positions
+as parent-local (grimoire/readiness/joint_attachment.md), so every child was
+displaced by its parent's own offset and the model rendered as floating
+parts — while `validate_sculpt_spec.py --strict-quality` passed the spec.
+
+Two defenses under test:
+- `rebase_component_frames.py` converts an object-frame spec to the
+  parent-local contract (never in place, refuses rotated parents, reports
+  every changed field).
+- `validate_component_frame_sanity` flags implausible parent-local offsets as
+  `quality:` warnings so --strict-quality catches the next object-frame spec
+  at validation time, not at render time.
+
+Pure Python 3.10+ stdlib. No pip installs.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+if __package__:
+    from .showcase_test_support import showcase_root
+else:
+    from showcase_test_support import showcase_root
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def import_frame_modules():
+    module_names = ("rebase_component_frames", "validate_sculpt_spec")
+    original_modules = {name: sys.modules.pop(name, None) for name in module_names}
+    original_path = sys.path[:]
+    sys.path[:0] = [str(ROOT / "stage2_spec")]
+    try:
+        import rebase_component_frames
+        import validate_sculpt_spec
+    finally:
+        sys.path[:] = original_path
+        for name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+    return rebase_component_frames, validate_sculpt_spec
+
+
+REBASE, VALIDATE = import_frame_modules()
+
+
+def component(
+    component_id: str,
+    parent: str | None,
+    position: list[float],
+    dims: tuple[float, float, float],
+    *,
+    primitive: str = "box",
+    rotation: list[float] | None = None,
+    attachment: dict | None = None,
+) -> dict:
+    return {
+        "id": component_id,
+        "parent": parent,
+        "primitive": primitive,
+        "dimensions": {"width": dims[0], "height": dims[1], "depth": dims[2]},
+        "transform": {
+            "position": list(position),
+            "rotation": rotation or [0.0, 0.0, 0.0],
+            "scale": [1, 1, 1],
+        },
+        **({"attachment": attachment} if attachment else {}),
+    }
+
+
+def object_frame_spec() -> dict:
+    """base at y 0.25 carrying a body at y 2.5 carrying a cap at y 5.2 —
+    all three authored in object-frame absolute coordinates."""
+    return {
+        "targetId": "frame-fixture",
+        "componentTree": [
+            component("root", None, [0, 0, 0], (1, 1, 1)),
+            component("base", "root", [0, 0.25, 0], (10, 0.5, 8)),
+            component(
+                "body",
+                "base",
+                [0, 2.5, 0],
+                (4, 4, 4),
+                attachment={
+                    "parentSocket": "base-surface",
+                    "localStart": [0, 2.5, 0],
+                    "localEnd": [0, 2.54, 0],
+                },
+            ),
+            component("cap", "body", [0, 5.2, 0], (1, 1, 1)),
+        ],
+    }
+
+
+class RebaseComponentFramesTest(unittest.TestCase):
+    def test_rebases_positions_and_attachments_to_parent_local(self) -> None:
+        rebased, report = REBASE.rebase_component_frames(object_frame_spec())
+        by_id = {c["id"]: c for c in rebased["componentTree"]}
+        # child of root: unchanged (root sits at the origin)
+        self.assertEqual(by_id["base"]["transform"]["position"], [0, 0.25, 0])
+        # each deeper child loses exactly its parent's object-frame offset
+        self.assertEqual(by_id["body"]["transform"]["position"], [0.0, 2.25, 0.0])
+        self.assertEqual(by_id["cap"]["transform"]["position"], [0.0, 2.7, 0.0])
+        self.assertEqual(by_id["body"]["attachment"]["localStart"], [0.0, 2.25, 0.0])
+        self.assertEqual(by_id["body"]["attachment"]["localEnd"], [0.0, 2.29, 0.0])
+        changed = {(change["componentId"], change["field"]) for change in report["changes"]}
+        self.assertIn(("body", "transform.position"), changed)
+        self.assertIn(("body", "attachment.localStart"), changed)
+        self.assertIn(("cap", "transform.position"), changed)
+
+    def test_input_spec_is_not_mutated(self) -> None:
+        spec = object_frame_spec()
+        snapshot = json.dumps(spec, sort_keys=True)
+        REBASE.rebase_component_frames(spec)
+        self.assertEqual(json.dumps(spec, sort_keys=True), snapshot)
+
+    def test_refuses_rotated_parent(self) -> None:
+        spec = object_frame_spec()
+        spec["componentTree"][2]["transform"]["rotation"] = [0.0, 0.4, 0.0]
+        with self.assertRaisesRegex(ValueError, "non-zero rotation"):
+            REBASE.rebase_component_frames(spec)
+
+    def test_refuses_unknown_parent(self) -> None:
+        spec = object_frame_spec()
+        spec["componentTree"][3]["parent"] = "missing"
+        with self.assertRaisesRegex(ValueError, "unknown parent"):
+            REBASE.rebase_component_frames(spec)
+
+    def test_cli_refuses_in_place_rewrite(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            spec_path = Path(tmp) / "spec.json"
+            spec_path.write_text(json.dumps(object_frame_spec()), encoding="utf-8")
+            exit_code = REBASE.main(
+                [
+                    "--input",
+                    str(spec_path),
+                    "--output",
+                    str(spec_path),
+                    "--report",
+                    str(Path(tmp) / "report.json"),
+                ]
+            )
+        self.assertEqual(exit_code, 2)
+
+
+class FrameSanityGateTest(unittest.TestCase):
+    def frame_warnings(self, spec: dict) -> list[str]:
+        warnings: list[str] = []
+        VALIDATE.validate_component_frame_sanity(spec, warnings)
+        return warnings
+
+    def test_object_frame_spec_is_flagged(self) -> None:
+        warnings = self.frame_warnings(object_frame_spec())
+        self.assertTrue(warnings, "object-frame cap offset must be flagged")
+        self.assertTrue(all(w.startswith("quality: frame-sanity:") for w in warnings))
+        self.assertIn("rebase_component_frames.py", warnings[0])
+        self.assertIn("'cap'", warnings[0])
+
+    def test_strict_quality_escalates_the_warning(self) -> None:
+        # the quality: prefix is the contract that --strict-quality escalates
+        errors, warnings = VALIDATE.validate_spec(object_frame_spec())
+        self.assertTrue(any(w.startswith("quality: frame-sanity:") for w in warnings))
+
+    def test_rebased_spec_is_clean(self) -> None:
+        rebased, _ = REBASE.rebase_component_frames(object_frame_spec())
+        self.assertEqual(self.frame_warnings(rebased), [])
+
+    def test_children_of_the_root_container_are_exempt(self) -> None:
+        # the unitless 1x1x1 root must not make every top-level part a finding
+        spec = {
+            "componentTree": [
+                component("root", None, [0, 0, 0], (1, 1, 1)),
+                component("base", "root", [0, 40.0, 0], (10, 0.5, 8)),
+            ]
+        }
+        self.assertEqual(self.frame_warnings(spec), [])
+
+    def test_base_pivot_parent_allows_full_extent_reach(self) -> None:
+        # a cone capping a 5.2-tall cylinder: the cylinder's pivot sits at its
+        # attachment localStart (its base), so the cone's legitimate local
+        # offset is the tower's FULL height plus its own half extent.
+        spec = {
+            "componentTree": [
+                component("root", None, [0, 0, 0], (1, 1, 1)),
+                component("island", "root", [0, 0.2, 0], (10, 0.5, 8), primitive="cylinder"),
+                component("tower", "island", [2.9, 2.5, 0.2], (2.4, 5.2, 2.4), primitive="cylinder"),
+                component("tower-roof", "tower", [0, 6.2, 0], (3.0, 2.4, 3.0), primitive="cone"),
+            ]
+        }
+        self.assertEqual(self.frame_warnings(spec), [])
+        # ...but a center-pivoted box parent with the same offset is flagged
+        spec["componentTree"][2]["primitive"] = "box"
+        self.assertTrue(self.frame_warnings(spec))
+
+    def test_missing_dimensions_are_skipped(self) -> None:
+        spec = object_frame_spec()
+        del spec["componentTree"][3]["dimensions"]
+        offenders = [w for w in self.frame_warnings(spec) if "'cap'" in w]
+        self.assertEqual(offenders, [])
+
+
+class ShippedSpecsStayGreenTest(unittest.TestCase):
+    def test_shipped_showcase_specs_have_no_frame_sanity_findings(self) -> None:
+        root = showcase_root()
+        spec_paths = sorted(root.glob("src/demos/*/object-sculpt-spec.json"))
+        if not spec_paths:
+            raise unittest.SkipTest("showcase checkout has no object-sculpt-spec.json demos")
+        for spec_path in spec_paths:
+            spec = json.loads(spec_path.read_text(encoding="utf-8"))
+            warnings: list[str] = []
+            VALIDATE.validate_component_frame_sanity(spec, warnings)
+            self.assertEqual(
+                warnings, [], f"conforming shipped spec regressed: {spec_path.parent.name}"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_reference_map_url.py
+++ b/forge/tests/test_reference_map_url.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""A reference map backs a texture only through a servable `url`, never a `path`.
+
+The extractor records where it wrote each map on the authoring machine
+(`path`) and, optionally, where the showcase serves it (`url`). The emitted
+runtime used to fall back to `path` when `url` was absent, so a spec whose
+maps were kept out of the shipped tree (the code-only contract) produced
+textures that never loaded and every material rendered white — colour forced
+to 0xffffff with roughness 1, waiting on maps that could not arrive. A map
+with a path and no url is a deliberately unshipped map: the runtime must take
+the procedural route instead.
+
+Pure Python 3.10+ stdlib. No pip installs.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def import_generator():
+    module_names = ("generate_threejs_factory", "validate_sculpt_spec")
+    original_modules = {name: sys.modules.pop(name, None) for name in module_names}
+    original_path = sys.path[:]
+    sys.path[:0] = [str(ROOT / "stage2_spec"), str(ROOT / "stage3_build")]
+    try:
+        import generate_threejs_factory
+    finally:
+        sys.path[:] = original_path
+        for name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+    return generate_threejs_factory
+
+
+GEN = import_generator()
+
+SPEC = {
+    "targetName": "Map Url Fixture",
+    "schemaVersion": "2.1",
+    "suitability": "pass",
+    "coordinateFrame": {},
+    "silhouette": {},
+    "proceduralStrategy": [],
+    "materials": [{"id": "clay"}],
+    "componentTree": [
+        {
+            "id": "body",
+            "name": "Body",
+            "level": "macro",
+            "role": "body",
+            "primitive": "box",
+            "parent": None,
+            "material": "clay",
+            "transform": {"position": [0, 0, 0], "rotation": [0, 0, 0], "scale": [1, 1, 1]},
+        },
+    ],
+}
+
+
+class ReferenceMapUrlTest(unittest.TestCase):
+    def test_emitted_resolver_never_falls_back_to_path(self) -> None:
+        generated = GEN.generate(SPEC, "material-pass")
+        start = generated.index("function referenceMapUrl(")
+        body = generated[start:generated.index("\n}\n", start)]
+        self.assertIn("record.url", body)
+        self.assertNotIn(
+            "record.path",
+            body,
+            "referenceMapUrl must not treat an authoring-machine path as a loadable URL",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/forge/tests/test_workflow_state.py
+++ b/forge/tests/test_workflow_state.py
@@ -22,6 +22,59 @@ from workflow_state import (  # noqa: E402
 
 
 class WorkflowStateTest(unittest.TestCase):
+    def test_dense_evidence_step_is_absent_by_default(self):
+        state = new_state("reference.png")
+        ids = [item["id"] for item in state["checklist"]]
+        self.assertNotIn("dense-evidence-admission", ids)
+        self.assertFalse(state["artifacts"].get("denseEvidenceSelected", False))
+
+    def test_dense_evidence_route_adds_ordered_optional_gate(self):
+        state = new_state(
+            "reference.png", spec="object-sculpt-spec.json", dense_evidence=True
+        )
+        ids = [item["id"] for item in state["checklist"]]
+        self.assertLess(
+            ids.index("reference-admission"), ids.index("dense-evidence-admission")
+        )
+        self.assertLess(
+            ids.index("dense-evidence-admission"), ids.index("strict-validation")
+        )
+        command = next(
+            item["command"]
+            for item in state["checklist"]
+            if item["id"] == "dense-evidence-admission"
+        )
+        self.assertIn("check_dense_evidence.py", command)
+        self.assertTrue(state["artifacts"]["denseEvidenceSelected"])
+
+    def test_dense_evidence_route_rejects_character_and_cs2_profiles(self):
+        for profile in ("character", "cs2"):
+            with self.subTest(profile=profile), self.assertRaisesRegex(
+                WorkflowStateError, "dense evidence.*generic"
+            ):
+                new_state("reference.png", profile=profile, dense_evidence=True)
+
+    def test_state_cli_accepts_dense_evidence_only_for_generic(self):
+        with tempfile.TemporaryDirectory() as directory:
+            state_path = Path(directory) / "state.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "forge" / "state.py"),
+                    "init",
+                    "--state",
+                    str(state_path),
+                    "--reference",
+                    "reference.png",
+                    "--dense-evidence",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            self.assertTrue(state["artifacts"]["denseEvidenceSelected"])
+
     def test_generic_state_starts_with_mandatory_image_analysis(self):
         state = new_state("reference.png")
         payload = status_payload(state)

--- a/integrations/mesh3d/__init__.py
+++ b/integrations/mesh3d/__init__.py
@@ -1,0 +1,1 @@
+"""Optional reference-mesh integrations for img2threejs."""

--- a/integrations/mesh3d/dense_evidence/__init__.py
+++ b/integrations/mesh3d/dense_evidence/__init__.py
@@ -1,0 +1,7 @@
+"""Offline bridge from reviewed generative meshes to bounded evidence JSON."""
+
+from .model import DenseEvidenceError, InfluenceScope, ProviderRun
+
+EXTRACTOR_VERSION = "dense-evidence-extractor-v1"
+
+__all__ = ["DenseEvidenceError", "EXTRACTOR_VERSION", "InfluenceScope", "ProviderRun"]

--- a/integrations/mesh3d/dense_evidence/__main__.py
+++ b/integrations/mesh3d/dense_evidence/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/mesh3d/dense_evidence/alignment.py
+++ b/integrations/mesh3d/dense_evidence/alignment.py
@@ -1,0 +1,101 @@
+"""Validation for a human-reviewed source-view alignment manifest."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .model import DenseEvidenceError, InfluenceScope, finite_number
+
+
+ALIGNMENT_PROFILE_VERSION = "source-view-alignment-v1"
+MIN_GLOBAL_IOU = 0.65
+MIN_COMPONENT_IOU = 0.75
+MAX_ASPECT_RATIO_ERROR = 0.15
+
+
+@dataclass(frozen=True)
+class ValidatedAlignment:
+    payload: dict[str, Any]
+    transform: tuple[float, ...]
+    maximum_scope: InfluenceScope
+
+
+def _finite_unit(value: object, field: str) -> float:
+    result = finite_number(value, field)
+    if not 0.0 <= result <= 1.0:
+        raise DenseEvidenceError("malformed_input", f"{field} must be in [0, 1]")
+    return result
+
+
+def _maximum_scope(
+    iou: float,
+    aspect_error: float,
+    semantic_status: str,
+    chirality_status: str,
+) -> InfluenceScope:
+    if aspect_error > MAX_ASPECT_RATIO_ERROR or iou < MIN_GLOBAL_IOU:
+        raise DenseEvidenceError(
+            "alignment_failed", "source-view thresholds were not met"
+        )
+    if (
+        semantic_status == "sufficient"
+        and chirality_status == "reviewed"
+        and iou >= MIN_COMPONENT_IOU
+    ):
+        return InfluenceScope.COMPONENT_MEASUREMENTS
+    return InfluenceScope.GLOBAL_MASSING
+
+
+def validate_alignment(
+    alignment: dict[str, object], semantic_status: str
+) -> ValidatedAlignment:
+    if alignment.get("schemaVersion") != 1:
+        raise DenseEvidenceError("malformed_input", "alignment schemaVersion must be 1")
+    if alignment.get("profileVersion") != ALIGNMENT_PROFILE_VERSION:
+        raise DenseEvidenceError("malformed_input", "unsupported alignment profile")
+    transform_value = alignment.get("sourceViewTransform")
+    if not isinstance(transform_value, list) or len(transform_value) != 16:
+        raise DenseEvidenceError(
+            "malformed_input", "sourceViewTransform must contain 16 numbers"
+        )
+    transform = tuple(
+        finite_number(value, f"sourceViewTransform[{index}]")
+        for index, value in enumerate(transform_value)
+    )
+    if alignment.get("upAxis") != "+Y" or alignment.get("forwardAxis") != "+Z":
+        raise DenseEvidenceError("alignment_failed", "canonical axes must be +Y up and +Z forward")
+    if alignment.get("handedness") != "right-handed":
+        raise DenseEvidenceError("alignment_failed", "output must be right-handed")
+    audit = alignment.get("axisOperationAudit")
+    if not isinstance(audit, list) or not audit or not all(
+        isinstance(item, str) and item.strip() for item in audit
+    ):
+        raise DenseEvidenceError("malformed_input", "axisOperationAudit is required")
+    chirality = alignment.get("chiralityStatus")
+    if chirality not in {"reviewed", "ambiguous"}:
+        raise DenseEvidenceError(
+            "malformed_input", "chiralityStatus must be reviewed or ambiguous"
+        )
+    captures = alignment.get("browserCaptures")
+    if not isinstance(captures, list) or not captures:
+        raise DenseEvidenceError("malformed_input", "browserCaptures are required")
+    for capture in captures:
+        if not isinstance(capture, dict):
+            raise DenseEvidenceError("malformed_input", "browser capture must be an object")
+        if not isinstance(capture.get("path"), str) or not isinstance(capture.get("view"), str):
+            raise DenseEvidenceError("malformed_input", "browser capture path and view are required")
+        digest = capture.get("sha256")
+        if not isinstance(digest, str) or len(digest) != 64 or any(
+            character not in "0123456789abcdef" for character in digest
+        ):
+            raise DenseEvidenceError("malformed_input", "browser capture SHA-256 is invalid")
+    iou = _finite_unit(alignment.get("sourceViewSilhouetteIou"), "sourceViewSilhouetteIou")
+    aspect = _finite_unit(
+        alignment.get("projectedAspectRatioError"), "projectedAspectRatioError"
+    )
+    return ValidatedAlignment(
+        payload=dict(alignment),
+        transform=transform,
+        maximum_scope=_maximum_scope(iou, aspect, semantic_status, str(chirality)),
+    )

--- a/integrations/mesh3d/dense_evidence/cache.py
+++ b/integrations/mesh3d/dense_evidence/cache.py
@@ -1,0 +1,46 @@
+"""Content-addressed cache identities for offline dense extraction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .model import canonical_sha256
+
+
+@dataclass(frozen=True)
+class ExtractionCacheInput:
+    glb_sha256: str
+    obj_sha256: str
+    source_image_sha256: tuple[str, ...]
+    extractor_version: str
+    alignment_profile_version: str
+    component_map_sha256: str | None
+    measurement_config_sha256: str
+
+
+def extraction_cache_key(value: ExtractionCacheInput) -> str:
+    return canonical_sha256(
+        {
+            "normalizedGlbSha256": value.glb_sha256,
+            "normalizedObjSha256": value.obj_sha256,
+            "sourceImageSha256": list(value.source_image_sha256),
+            "extractorVersion": value.extractor_version,
+            "alignmentProfileVersion": value.alignment_profile_version,
+            "componentMapSha256": value.component_map_sha256,
+            "measurementConfigSha256": value.measurement_config_sha256,
+        }
+    )
+
+
+def base_extraction_cache_key(value: ExtractionCacheInput) -> str:
+    return extraction_cache_key(
+        ExtractionCacheInput(
+            value.glb_sha256,
+            value.obj_sha256,
+            value.source_image_sha256,
+            value.extractor_version,
+            value.alignment_profile_version,
+            None,
+            value.measurement_config_sha256,
+        )
+    )

--- a/integrations/mesh3d/dense_evidence/cli.py
+++ b/integrations/mesh3d/dense_evidence/cli.py
@@ -1,0 +1,221 @@
+"""Offline-only CLI for dense mesh evidence extraction."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from . import EXTRACTOR_VERSION
+from .alignment import ALIGNMENT_PROFILE_VERSION, validate_alignment
+from .cache import ExtractionCacheInput, base_extraction_cache_key
+from .extract import ExtractionConfig, extract_run
+from .model import (
+    DenseEvidenceError,
+    canonical_sha256,
+    load_json_object,
+    validate_provider_run,
+    write_json_atomic,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Extract bounded geometric evidence from an existing reviewed mesh run"
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    for name in ("extract", "propose-scope", "verify-cache"):
+        command = commands.add_parser(name)
+        command.add_argument("--run", type=Path, required=True)
+        command.add_argument("--source-image", type=Path, action="append", required=True)
+        command.add_argument("--alignment", type=Path, required=True)
+        if name != "propose-scope":
+            command.add_argument("--out-dir", type=Path, required=True)
+            command.add_argument("--resolution", type=int, default=24)
+            command.add_argument("--sections", type=int, default=16)
+            command.add_argument("--max-section-points", type=int, default=64)
+    return parser
+
+
+def _configuration(args: argparse.Namespace) -> ExtractionConfig:
+    return ExtractionConfig(args.resolution, args.sections, args.max_section_points)
+
+
+def _cache_identity(
+    run: Path,
+    source_images: tuple[Path, ...],
+    alignment_payload: dict[str, Any],
+    config: ExtractionConfig,
+) -> tuple[str, Any, Any]:
+    config.validate()
+    provider_run = validate_provider_run(run, source_images)
+    alignment = validate_alignment(alignment_payload, provider_run.semantic_status)
+    measurement_hash = canonical_sha256(
+        {
+            "resolution": config.resolution,
+            "sections": config.sections,
+            "maxSectionPoints": config.max_section_points,
+            "alignmentSha256": canonical_sha256(alignment_payload),
+        }
+    )
+    cache_input = ExtractionCacheInput(
+        provider_run.glb_sha256,
+        provider_run.obj_sha256,
+        provider_run.source_image_sha256,
+        EXTRACTOR_VERSION,
+        ALIGNMENT_PROFILE_VERSION,
+        None,
+        measurement_hash,
+    )
+    return base_extraction_cache_key(cache_input), provider_run, alignment
+
+
+def _verify_cache(
+    run: Path,
+    sources: tuple[Path, ...],
+    alignment_payload: dict[str, Any],
+    out_dir: Path,
+    config: ExtractionConfig,
+) -> dict[str, Any]:
+    expected_key, provider_run, _ = _cache_identity(
+        run, sources, alignment_payload, config
+    )
+    evidence_path = out_dir.expanduser().resolve() / "dense-evidence.v1.json"
+    if not evidence_path.is_file():
+        return {"cacheHit": False, "reason": "evidence_missing", "expectedKey": expected_key}
+    evidence = load_json_object(evidence_path, "cache_invalid")
+    provenance = evidence.get("provenance")
+    cache = evidence.get("cache")
+    hit = (
+        isinstance(provenance, dict)
+        and isinstance(cache, dict)
+        and cache.get("baseExtractionKey") == expected_key
+        and provenance.get("glbSha256") == provider_run.glb_sha256
+        and provenance.get("objSha256") == provider_run.obj_sha256
+        and provenance.get("sourceImageSha256") == list(provider_run.source_image_sha256)
+        and provenance.get("alignmentSha256") == canonical_sha256(alignment_payload)
+    )
+    return {
+        "cacheHit": hit,
+        "reason": "complete" if hit else "authoritative_hash_mismatch",
+        "expectedKey": expected_key,
+        "evidence": str(evidence_path),
+    }
+
+
+def _write_status(out_dir: Path, **values: object) -> None:
+    write_json_atomic(
+        out_dir.expanduser().resolve() / "status.json",
+        {"schemaVersion": 1, "updatedAt": datetime.now(UTC).isoformat(), **values},
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    sources = tuple(args.source_image)
+    out_dir = getattr(args, "out_dir", None)
+    try:
+        alignment_payload = load_json_object(args.alignment, "malformed_input")
+        if args.command == "propose-scope":
+            provider_run = validate_provider_run(args.run, sources)
+            alignment = validate_alignment(alignment_payload, provider_run.semantic_status)
+            print(
+                json.dumps(
+                    {
+                        "decision": "ALLOW",
+                        "maximumInfluenceScope": alignment.maximum_scope.value,
+                        "approvedInfluenceScope": "none",
+                        "semanticStatus": provider_run.semantic_status,
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            return 0
+
+        config = _configuration(args)
+        cache_report = _verify_cache(
+            args.run, sources, alignment_payload, out_dir, config
+        )
+        if args.command == "verify-cache":
+            print(json.dumps(cache_report, ensure_ascii=False))
+            return 0 if cache_report["cacheHit"] else 1
+        if cache_report["cacheHit"]:
+            _write_status(
+                out_dir,
+                status="complete",
+                cacheHit=True,
+                lastDurableArtifact="dense-evidence.v1.json",
+                resumable=True,
+            )
+            print(json.dumps(cache_report, ensure_ascii=False))
+            return 0
+        request = {
+            "schemaVersion": 1,
+            "run": str(args.run.expanduser().resolve()),
+            "sourceImages": [str(item.expanduser().resolve()) for item in sources],
+            "alignmentSha256": canonical_sha256(alignment_payload),
+            "measurementConfig": {
+                "resolution": config.resolution,
+                "sections": config.sections,
+                "maxSectionPoints": config.max_section_points,
+            },
+        }
+        write_json_atomic(out_dir / "extraction-request.json", request)
+        write_json_atomic(out_dir / "alignment.json", alignment_payload)
+        evidence = extract_run(args.run, sources, alignment_payload, out_dir, config)
+        # Use the CLI identity, which binds the exact alignment as well as numeric caps.
+        expected_key, _, _ = _cache_identity(args.run, sources, alignment_payload, config)
+        evidence["cache"]["baseExtractionKey"] = expected_key
+        evidence["cache"]["measurementConfigSha256"] = canonical_sha256(
+            {**request["measurementConfig"], "alignmentSha256": request["alignmentSha256"]}
+        )
+        write_json_atomic(out_dir / "dense-evidence.v1.json", evidence)
+        _write_status(
+            out_dir,
+            status="complete",
+            cacheHit=False,
+            lastDurableArtifact="dense-evidence.v1.json",
+            resumable=True,
+        )
+        print(
+            json.dumps(
+                {
+                    "status": "complete",
+                    "cacheHit": False,
+                    "evidence": str((out_dir / "dense-evidence.v1.json").resolve()),
+                },
+                ensure_ascii=False,
+            )
+        )
+        return 0
+    except DenseEvidenceError as error:
+        if out_dir is not None:
+            _write_status(
+                out_dir,
+                status="failed",
+                failureCategory=error.category,
+                message=str(error),
+                lastDurableArtifact="normalized/reference.glb",
+                resumable=True,
+            )
+        print(str(error), file=sys.stderr)
+        return 1 if error.category in {"evidence_hash_mismatch", "cache_invalid"} else 2
+    except (OSError, ValueError) as error:
+        if out_dir is not None:
+            _write_status(
+                out_dir,
+                status="failed",
+                failureCategory="local_execution_error",
+                message=str(error),
+                lastDurableArtifact="normalized/reference.glb",
+                resumable=True,
+            )
+        print(f"local_execution_error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/mesh3d/dense_evidence/extract.py
+++ b/integrations/mesh3d/dense_evidence/extract.py
@@ -1,0 +1,242 @@
+"""Bounded offline extraction from normalized GLB geometry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import trimesh
+
+from . import EXTRACTOR_VERSION
+from .alignment import ALIGNMENT_PROFILE_VERSION, ValidatedAlignment, validate_alignment
+from .cache import ExtractionCacheInput, base_extraction_cache_key
+from .model import (
+    DenseEvidenceError,
+    canonical_sha256,
+    validate_provider_run,
+    write_json_atomic,
+)
+from .regions import inventory_boundaries
+
+
+MAX_OCCUPANCY_RESOLUTION = 32
+MAX_CROSS_SECTIONS = 32
+MAX_CROSS_SECTION_POINTS = 64
+
+
+@dataclass(frozen=True)
+class ExtractionConfig:
+    resolution: int = 24
+    sections: int = 16
+    max_section_points: int = 64
+
+    def validate(self) -> None:
+        if not 1 <= self.resolution <= MAX_OCCUPANCY_RESOLUTION:
+            raise DenseEvidenceError(
+                "measurement_limit_exceeded", "occupancy resolution exceeds 32"
+            )
+        if not 1 <= self.sections <= MAX_CROSS_SECTIONS:
+            raise DenseEvidenceError(
+                "measurement_limit_exceeded", "cross-section count exceeds 32"
+            )
+        if not 3 <= self.max_section_points <= MAX_CROSS_SECTION_POINTS:
+            raise DenseEvidenceError(
+                "measurement_limit_exceeded", "cross-section points exceed 64"
+            )
+
+
+def _load_scene(path: Path) -> trimesh.Scene:
+    try:
+        loaded = trimesh.load(path, force="scene", process=False)
+    except Exception as error:  # noqa: BLE001 - optional parser failures are normalized
+        raise DenseEvidenceError("mesh_load_failed", str(error)) from error
+    if not isinstance(loaded, trimesh.Scene) or not loaded.geometry:
+        raise DenseEvidenceError("mesh_load_failed", "GLB contains no scene geometry")
+    return loaded
+
+
+def _world_points(scene: trimesh.Scene, alignment_transform: np.ndarray) -> np.ndarray:
+    groups: list[np.ndarray] = []
+    for node in scene.graph.nodes_geometry:
+        node_transform, geometry_name = scene.graph[node]
+        vertices = np.asarray(scene.geometry[geometry_name].vertices, dtype=float)
+        if vertices.size:
+            groups.append(
+                trimesh.transform_points(vertices, alignment_transform @ node_transform)
+            )
+    if not groups:
+        raise DenseEvidenceError("mesh_load_failed", "GLB contains no vertices")
+    points = np.concatenate(groups, axis=0)
+    if points.ndim != 2 or points.shape[1] != 3 or not np.isfinite(points).all():
+        raise DenseEvidenceError("non_finite_geometry", "mesh vertices must be finite xyz points")
+    return points
+
+
+def _principal_axes(points: np.ndarray) -> list[dict[str, object]]:
+    centered = points - points.mean(axis=0)
+    covariance = np.cov(centered, rowvar=False)
+    values, vectors = np.linalg.eigh(covariance)
+    order = np.argsort(values)[::-1]
+    return [
+        {
+            "axis": vectors[:, index].tolist(),
+            "variance": float(max(values[index], 0.0)),
+        }
+        for index in order
+    ]
+
+
+def _sparse_occupancy(
+    points: np.ndarray, minimum: np.ndarray, size: np.ndarray, resolution: int
+) -> dict[str, object]:
+    scaled = np.floor(((points - minimum) / size) * resolution).astype(int)
+    indices = np.clip(scaled, 0, resolution - 1)
+    occupied = sorted({tuple(int(value) for value in row) for row in indices})
+    return {
+        "resolution": resolution,
+        "occupiedCells": [list(item) for item in occupied],
+        "occupiedCellCount": len(occupied),
+    }
+
+
+def _resample_profile(points: np.ndarray, limit: int) -> list[list[float]]:
+    if len(points) <= limit:
+        chosen = points
+    else:
+        indices = np.linspace(0, len(points) - 1, limit, dtype=int)
+        chosen = points[indices]
+    return [[float(row[0]), float(row[2])] for row in chosen]
+
+
+def _cross_sections(
+    points: np.ndarray,
+    minimum: np.ndarray,
+    maximum: np.ndarray,
+    count: int,
+    limit: int,
+) -> list[dict[str, object]]:
+    centers = np.linspace(minimum[1], maximum[1], count)
+    half_band = max((maximum[1] - minimum[1]) / max(count * 2, 1), 1e-9)
+    records: list[dict[str, object]] = []
+    for center in centers:
+        selected = points[np.abs(points[:, 1] - center) <= half_band]
+        if len(selected) == 0:
+            nearest = np.argsort(np.abs(points[:, 1] - center))[: min(limit, len(points))]
+            selected = points[nearest]
+        records.append(
+            {
+                "axis": "y",
+                "position": float(center),
+                "profile": _resample_profile(selected, limit),
+            }
+        )
+    return records
+
+
+def _geometry_payload(
+    points: np.ndarray, alignment: ValidatedAlignment, config: ExtractionConfig
+) -> dict[str, object]:
+    minimum = points.min(axis=0)
+    maximum = points.max(axis=0)
+    size = maximum - minimum
+    if np.any(size <= 1e-9):
+        raise DenseEvidenceError("degenerate_geometry", "mesh bounds have zero volume")
+    return {
+        "bounds": {
+            "min": minimum.tolist(),
+            "max": maximum.tolist(),
+            "size": size.tolist(),
+        },
+        "principalAxes": _principal_axes(points),
+        "occupancyGrid": _sparse_occupancy(points, minimum, size, config.resolution),
+        "crossSections": _cross_sections(
+            points, minimum, maximum, config.sections, config.max_section_points
+        ),
+        "silhouetteViews": [
+            {
+                "view": capture["view"],
+                "path": capture["path"],
+                "sha256": capture["sha256"],
+                "silhouetteIou": alignment.payload["sourceViewSilhouetteIou"],
+                "projectedAspectRatioError": alignment.payload[
+                    "projectedAspectRatioError"
+                ],
+            }
+            for capture in alignment.payload["browserCaptures"]
+        ],
+    }
+
+
+def extract_run(
+    run: Path,
+    source_images: tuple[Path, ...],
+    alignment_payload: dict[str, object],
+    out_dir: Path,
+    config: ExtractionConfig | None = None,
+) -> dict[str, Any]:
+    selected = config or ExtractionConfig()
+    selected.validate()
+    provider_run = validate_provider_run(run, source_images)
+    alignment = validate_alignment(alignment_payload, provider_run.semantic_status)
+    scene = _load_scene(provider_run.root / "normalized" / "reference.glb")
+    transform = np.asarray(alignment.transform, dtype=float).reshape((4, 4))
+    points = _world_points(scene, transform)
+    measurement_config = {
+        "resolution": selected.resolution,
+        "sections": selected.sections,
+        "maxSectionPoints": selected.max_section_points,
+    }
+    cache_input = ExtractionCacheInput(
+        provider_run.glb_sha256,
+        provider_run.obj_sha256,
+        provider_run.source_image_sha256,
+        EXTRACTOR_VERSION,
+        ALIGNMENT_PROFILE_VERSION,
+        None,
+        canonical_sha256(measurement_config),
+    )
+    evidence: dict[str, Any] = {
+        "schemaVersion": 1,
+        "kind": "dense-evidence",
+        "extractorVersion": EXTRACTOR_VERSION,
+        "createdAt": datetime.now(UTC).isoformat(),
+        "provenance": {
+            "providerId": provider_run.provider_id,
+            "runPath": str(provider_run.root),
+            "glbPath": str(provider_run.root / "normalized" / "reference.glb"),
+            "glbSha256": provider_run.glb_sha256,
+            "objSha256": provider_run.obj_sha256,
+            "sourceImageSha256": list(provider_run.source_image_sha256),
+            "visualReviewStatus": provider_run.visual_review_status,
+            "alignmentProfileVersion": ALIGNMENT_PROFILE_VERSION,
+            "alignmentSha256": canonical_sha256(alignment_payload),
+        },
+        "cache": {
+            "baseExtractionKey": base_extraction_cache_key(cache_input),
+            "measurementConfigSha256": cache_input.measurement_config_sha256,
+        },
+        "admission": {
+            "structuralStatus": provider_run.structural_status,
+            "semanticStatus": provider_run.semantic_status,
+            "maximumInfluenceScope": alignment.maximum_scope.value,
+            "approvedInfluenceScope": "none",
+        },
+        "alignment": dict(alignment_payload),
+        "globalGeometry": _geometry_payload(points, alignment, selected),
+        "regions": inventory_boundaries(scene, transform),
+        "uncertainty": {
+            "sourceViewCount": len(source_images),
+            "hiddenSurfacePolicy": "non-authoritative",
+            "rearConfidence": "low",
+            "singleViewLimitations": [
+                "rear and occluded geometry are model inventions, not source observations"
+            ],
+        },
+        "extensions": {},
+    }
+    target = out_dir.expanduser().resolve()
+    write_json_atomic(target / "dense-evidence.v1.json", evidence)
+    return evidence

--- a/integrations/mesh3d/dense_evidence/model.py
+++ b/integrations/mesh3d/dense_evidence/model.py
@@ -1,0 +1,181 @@
+"""Immutable dense-evidence records and local provider-run validation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import tempfile
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class InfluenceScope(str, Enum):
+    NONE = "none"
+    GLOBAL_MASSING = "global-massing"
+    COMPONENT_MEASUREMENTS = "component-measurements"
+
+
+SCOPE_RANK = {
+    InfluenceScope.NONE: 0,
+    InfluenceScope.GLOBAL_MASSING: 1,
+    InfluenceScope.COMPONENT_MEASUREMENTS: 2,
+}
+
+
+class DenseEvidenceError(RuntimeError):
+    def __init__(self, category: str, message: str):
+        super().__init__(f"{category}: {message}")
+        self.category = category
+
+
+@dataclass(frozen=True)
+class ProviderRun:
+    root: Path
+    source_image_sha256: tuple[str, ...]
+    glb_sha256: str
+    obj_sha256: str
+    provider_id: str
+    structural_status: str
+    visual_review_status: str
+    semantic_status: str
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_sha256(value: object) -> str:
+    payload = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def write_json_atomic(path: Path, value: object) -> None:
+    target = path.expanduser().resolve()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{target.name}.", suffix=".tmp", dir=target.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, indent=2, ensure_ascii=False, allow_nan=False)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, target)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def load_json_object(path: Path, category: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise DenseEvidenceError(category, f"missing artifact: {path}") from error
+    except (OSError, json.JSONDecodeError) as error:
+        raise DenseEvidenceError(category, f"unreadable artifact: {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise DenseEvidenceError(category, f"artifact must contain a JSON object: {path}")
+    return value
+
+
+def _receipt_source_hashes(receipt: dict[str, Any], request: dict[str, Any]) -> tuple[str, ...]:
+    direct = receipt.get("sourceImageSha256")
+    if isinstance(direct, list) and all(isinstance(item, str) for item in direct):
+        return tuple(direct)
+    images = request.get("images")
+    if isinstance(images, list):
+        hashes = tuple(
+            str(item.get("sha256"))
+            for item in images
+            if isinstance(item, dict) and isinstance(item.get("sha256"), str)
+        )
+        if len(hashes) == len(images):
+            return hashes
+    return ()
+
+
+def _semantic_status(admission: dict[str, Any]) -> str:
+    probe = admission.get("probe")
+    if not isinstance(probe, dict):
+        return "insufficient"
+    scene = probe.get("scene") if isinstance(probe.get("scene"), dict) else probe
+    mesh_count = scene.get("meshCount")
+    primitive_count = scene.get("primitiveCount")
+    explicit = probe.get("semanticStatus")
+    if mesh_count == 1 and primitive_count == 1:
+        return "insufficient"
+    if explicit in {"sufficient", "insufficient"}:
+        return str(explicit)
+    decomposition = probe.get("semanticDecomposition")
+    if isinstance(decomposition, dict) and decomposition.get("status") in {"rich", "sufficient"}:
+        return "sufficient"
+    return "insufficient"
+
+
+def validate_provider_run(run: Path, source_images: tuple[Path, ...]) -> ProviderRun:
+    root = run.expanduser().resolve()
+    receipt = load_json_object(root / "provider-receipt.json", "provider_receipt_missing")
+    admission = load_json_object(root / "review" / "admission.json", "mesh_not_structurally_admitted")
+    visual = load_json_object(root / "review" / "visual-review.json", "visual_review_missing")
+    request_path = root / "request.json"
+    request = load_json_object(request_path, "provider_receipt_missing") if request_path.exists() else {}
+
+    glb = root / "normalized" / "reference.glb"
+    obj = root / "normalized" / "reference.obj"
+    if not glb.is_file() or not obj.is_file():
+        raise DenseEvidenceError("mesh_not_structurally_admitted", "normalized GLB and OBJ are required")
+    glb_hash = sha256_file(glb)
+    obj_hash = sha256_file(obj)
+    source_hashes = tuple(sha256_file(item.expanduser().resolve()) for item in source_images)
+
+    expected_glb = receipt.get("normalizedGlbSha256") or admission.get("glbSha256") or receipt.get("rawSha256")
+    expected_obj = receipt.get("normalizedObjSha256") or admission.get("objSha256")
+    expected_sources = _receipt_source_hashes(receipt, request)
+    visual_glb = visual.get("glbSha256")
+    if expected_glb != glb_hash or (expected_obj is not None and expected_obj != obj_hash):
+        raise DenseEvidenceError("evidence_hash_mismatch", "normalized mesh hash drift")
+    if expected_sources and expected_sources != source_hashes:
+        raise DenseEvidenceError("evidence_hash_mismatch", "source image hash drift")
+    if visual_glb is not None and visual_glb != glb_hash:
+        raise DenseEvidenceError("evidence_hash_mismatch", "visual review is bound to another GLB")
+
+    structural = str(admission.get("status", ""))
+    if structural not in {"pass", "structural-pass-visual-review-required"}:
+        raise DenseEvidenceError("mesh_not_structurally_admitted", f"structural status is {structural!r}")
+    reviewed = visual.get("status") == "reviewed" or bool(visual.get("reviewedAt"))
+    decision = visual.get("decision") or visual.get("verdict")
+    if not reviewed or not isinstance(decision, str):
+        raise DenseEvidenceError("visual_review_missing", "completed visual review is required")
+    for value in (glb_hash, obj_hash, *source_hashes):
+        if len(value) != 64 or not all(character in "0123456789abcdef" for character in value):
+            raise DenseEvidenceError("evidence_hash_mismatch", "invalid SHA-256 value")
+    return ProviderRun(
+        root=root,
+        source_image_sha256=source_hashes,
+        glb_sha256=glb_hash,
+        obj_sha256=obj_hash,
+        provider_id=str(receipt.get("providerId", "unknown")),
+        structural_status=structural,
+        visual_review_status=str(decision),
+        semantic_status=_semantic_status(admission),
+    )
+
+
+def finite_number(value: object, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise DenseEvidenceError("malformed_input", f"{field} must be numeric")
+    result = float(value)
+    if not math.isfinite(result):
+        raise DenseEvidenceError("malformed_input", f"{field} must be finite")
+    return result

--- a/integrations/mesh3d/dense_evidence/regions.py
+++ b/integrations/mesh3d/dense_evidence/regions.py
@@ -1,0 +1,40 @@
+"""Candidate-only region inventory for explicit multipart mesh boundaries."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import trimesh
+
+
+def inventory_boundaries(
+    scene: trimesh.Scene, transform: np.ndarray
+) -> list[dict[str, Any]]:
+    nodes = sorted(str(node) for node in scene.graph.nodes_geometry)
+    if len(nodes) <= 1:
+        return []
+    records: list[dict[str, Any]] = []
+    for node in nodes:
+        node_transform, geometry_name = scene.graph[node]
+        geometry = scene.geometry[geometry_name]
+        points = trimesh.transform_points(
+            np.asarray(geometry.vertices, dtype=float), transform @ node_transform
+        )
+        minimum = points.min(axis=0)
+        maximum = points.max(axis=0)
+        records.append(
+            {
+                "regionId": f"node:{node}/geometry:{geometry_name}",
+                "node": node,
+                "geometry": str(geometry_name),
+                "candidateOnly": True,
+                "semanticLabel": None,
+                "bounds": {
+                    "min": minimum.tolist(),
+                    "max": maximum.tolist(),
+                    "size": (maximum - minimum).tolist(),
+                },
+            }
+        )
+    return records

--- a/integrations/mesh3d/free_assist/__init__.py
+++ b/integrations/mesh3d/free_assist/__init__.py
@@ -1,0 +1,5 @@
+"""Zero-spend, approval-gated generative reference-mesh assistance."""
+
+from .model import Decision, ZeroSpendPolicy
+
+__all__ = ["Decision", "ZeroSpendPolicy"]

--- a/integrations/mesh3d/free_assist/__main__.py
+++ b/integrations/mesh3d/free_assist/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/integrations/mesh3d/free_assist/cli.py
+++ b/integrations/mesh3d/free_assist/cli.py
@@ -1,0 +1,144 @@
+"""Command-line interface for zero-spend generative reference assistance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+from .model import AssistFailure, Decision, GenerationRequest, json_record
+from .pipeline import default_metadata_probe, generate, preflight, resume
+from .registry import PROVIDERS
+from .security import redact
+
+
+def _add_request_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "images", nargs="+", type=Path, help="local reference image files"
+    )
+    parser.add_argument(
+        "--provider",
+        required=True,
+        choices=tuple(PROVIDERS),
+        help="reviewed zero-spend provider",
+    )
+    parser.add_argument("--out-dir", required=True, type=Path, help="artifact root")
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--mesh-simplify", type=float, default=0.95)
+    parser.add_argument("--texture-size", type=int, default=None)
+    parser.add_argument("--foreground-ratio", type=float, default=0.85)
+    parser.add_argument(
+        "--force-cpu",
+        action="store_true",
+        help="force CPU for an already-installed local SF3D",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m integrations.mesh3d.free_assist",
+        description="Zero-spend, approval-gated reference-mesh generation. No automatic retry or fallback.",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    preflight_parser = commands.add_parser(
+        "preflight", help="read-only capability, cost, and cache check"
+    )
+    _add_request_arguments(preflight_parser)
+    generate_parser = commands.add_parser(
+        "generate", help="perform one explicitly approved provider call, then normalize"
+    )
+    _add_request_arguments(generate_parser)
+    generate_parser.add_argument(
+        "--approve-upload",
+        action="store_true",
+        help="approve these exact files for this hosted provider",
+    )
+    generate_parser.add_argument(
+        "--approve-local-run",
+        action="store_true",
+        help="approve one run of an already-installed local SF3D",
+    )
+    resume_parser = commands.add_parser(
+        "resume", help="normalize an already persisted raw GLB without generation"
+    )
+    resume_parser.add_argument(
+        "--run", required=True, type=Path, help="existing runs/<run-id> directory"
+    )
+    return parser
+
+
+def _request(args: argparse.Namespace) -> GenerationRequest:
+    parameters: dict[str, Any] = {
+        "seed": args.seed,
+        "meshSimplify": args.mesh_simplify,
+        "foregroundRatio": args.foreground_ratio,
+        "forceCpu": args.force_cpu,
+    }
+    if args.texture_size is not None:
+        parameters["textureSize"] = args.texture_size
+    return GenerationRequest(
+        tuple(args.images), args.provider, args.out_dir, parameters=parameters
+    )
+
+
+def _print(value: Any, *, stream: Any | None = None) -> None:
+    if stream is None:
+        stream = sys.stdout
+    print(
+        json.dumps(
+            redact(json_record(value)), indent=2, sort_keys=True, ensure_ascii=False
+        ),
+        file=stream,
+    )
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    metadata_probe: Callable[[str], dict[str, Any]] = default_metadata_probe,
+) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "preflight":
+            report = preflight(_request(args), metadata_probe=metadata_probe)
+            _print(report)
+            return 0 if report.decision == Decision.ALLOW else 3
+        if args.command == "generate":
+            request = _request(args)
+            run = generate(
+                request,
+                approve_upload=args.approve_upload,
+                approve_local_run=args.approve_local_run,
+                metadata_probe=metadata_probe,
+            )
+            status = resume(run)
+            _print({"run": str(run), **status})
+            return 0 if status.get("status") == "complete" else 2
+        status = resume(args.run)
+        _print({"run": str(args.run.resolve()), **status})
+        return 0 if status.get("status") == "complete" else 2
+    except AssistFailure as exc:
+        _print(
+            {
+                "status": "blocked",
+                "failureCategory": exc.category,
+                "message": str(exc),
+                "resumable": exc.resumable,
+                "lastDurableArtifact": exc.last_artifact,
+            },
+            stream=sys.stderr,
+        )
+        if exc.category in {
+            "upload_not_approved",
+            "free_status_unverified",
+            "authentication_required",
+            "local_capability_missing",
+        }:
+            return 3
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/integrations/mesh3d/free_assist/model.py
+++ b/integrations/mesh3d/free_assist/model.py
@@ -1,0 +1,82 @@
+"""Shared immutable records for the free generative-assist integration."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+
+class Decision(str, Enum):
+    ALLOW = "ALLOW"
+    NEEDS_USER_ACTION = "NEEDS_USER_ACTION"
+    DENY = "DENY"
+    UNAVAILABLE = "UNAVAILABLE"
+
+
+@dataclass(frozen=True)
+class ZeroSpendPolicy:
+    max_cost_usd: int = field(default=0, init=False)
+    allow_paid_fallback: bool = field(default=False, init=False)
+    allow_credit_purchase: bool = field(default=False, init=False)
+    allow_automatic_retry: bool = field(default=False, init=False)
+    allow_automatic_provider_switch: bool = field(default=False, init=False)
+
+
+@dataclass(frozen=True)
+class GenerationRequest:
+    images: tuple[Path, ...]
+    provider_id: str
+    out_dir: Path
+    endpoint_revision: str = "live"
+    parameters: dict[str, Any] = field(default_factory=dict)
+    policy: ZeroSpendPolicy = field(default_factory=ZeroSpendPolicy)
+
+
+@dataclass(frozen=True)
+class PreflightReport:
+    decision: Decision
+    provider_id: str
+    endpoint: str
+    cache_key: str
+    reasons: tuple[str, ...]
+    evidence: dict[str, Any] = field(default_factory=dict)
+    upload_files: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RawGeneration:
+    source_path: Path
+    provider_task_id: str | None = None
+    model_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+class AssistFailure(RuntimeError):
+    def __init__(
+        self,
+        category: str,
+        message: str,
+        *,
+        resumable: bool = False,
+        last_artifact: str | None = None,
+    ):
+        super().__init__(message)
+        self.category = category
+        self.resumable = resumable
+        self.last_artifact = last_artifact
+
+
+def json_record(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, Path):
+        return str(value)
+    if hasattr(value, "__dataclass_fields__"):
+        return {key: json_record(item) for key, item in asdict(value).items()}
+    if isinstance(value, dict):
+        return {str(key): json_record(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [json_record(item) for item in value]
+    return value

--- a/integrations/mesh3d/free_assist/pipeline.py
+++ b/integrations/mesh3d/free_assist/pipeline.py
@@ -1,0 +1,763 @@
+"""Fail-closed orchestration, cache, normalization, and admission."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+from .model import (
+    AssistFailure,
+    Decision,
+    GenerationRequest,
+    PreflightReport,
+    json_record,
+)
+from .registry import MetadataDecision, evaluate_hosted_metadata, provider_spec
+from .security import redact, write_json_atomic
+
+
+NORMALIZER_VERSION = "free-assist-normalizer-v1"
+MIN_LOCAL_DISK_BYTES = 12 << 30
+MIN_LOCAL_MEMORY_BYTES = 16 << 30
+MPS_RECOMMENDED_MEMORY_BYTES = 32 << 30
+MetadataProbe = Callable[[str], dict[str, Any]]
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+
+
+def compute_cache_key(request: GenerationRequest) -> str:
+    payload = {
+        "imageHashes": [
+            sha256_file(path.expanduser().resolve()) for path in request.images
+        ],
+        "providerId": request.provider_id,
+        "endpointRevision": request.endpoint_revision,
+        "parameters": request.parameters,
+        "normalizerVersion": NORMALIZER_VERSION,
+    }
+    return hashlib.sha256(_canonical_json(payload)).hexdigest()
+
+
+def compute_request_fingerprint(request: GenerationRequest) -> str:
+    payload = {
+        "imageHashes": [
+            sha256_file(path.expanduser().resolve()) for path in request.images
+        ],
+        "providerId": request.provider_id,
+        "parameters": request.parameters,
+        "normalizerVersion": NORMALIZER_VERSION,
+    }
+    return hashlib.sha256(_canonical_json(payload)).hexdigest()
+
+
+def default_metadata_probe(endpoint: str) -> dict[str, Any]:
+    try:
+        from huggingface_hub import HfApi
+
+        info = HfApi().space_info(endpoint)
+        runtime_value = info.runtime
+        runtime = (
+            runtime_value
+            if isinstance(runtime_value, dict)
+            else getattr(runtime_value, "raw", {})
+        )
+        card_value = info.card_data
+        if card_value is None:
+            card_data = {}
+        elif hasattr(card_value, "to_dict"):
+            card_data = card_value.to_dict()
+        elif isinstance(card_value, dict):
+            card_data = card_value
+        else:
+            card_data = {}
+        return {"runtime": runtime, "cardData": card_data, "id": info.id}
+    except Exception as exc:  # noqa: BLE001 - uncertainty must fail closed
+        raise AssistFailure(
+            "free_status_unverified", f"could not verify hosted free status: {exc}"
+        ) from exc
+
+
+def _read_cache_index(out_dir: Path) -> dict[str, Any]:
+    path = out_dir / "cache-index.json"
+    if not path.exists():
+        return {"schemaVersion": 1, "entries": {}, "aliases": {}}
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {"schemaVersion": 1, "entries": {}, "aliases": {}}
+    if not isinstance(value, dict) or not isinstance(value.get("entries"), dict):
+        return {"schemaVersion": 1, "entries": {}, "aliases": {}}
+    if not isinstance(value.get("aliases"), dict):
+        value["aliases"] = {}
+    return value
+
+
+def _cached_run(out_dir: Path, cache_key: str) -> str | None:
+    entry = _read_cache_index(out_dir)["entries"].get(cache_key)
+    if not isinstance(entry, dict) or entry.get("status") != "complete":
+        return None
+    run = out_dir / str(entry.get("run", ""))
+    raw = run / "raw" / "reference.glb"
+    normalized = run / "normalized" / "reference.glb"
+    receipt_path = run / "provider-receipt.json"
+    if raw.is_file() and normalized.is_file() and receipt_path.is_file():
+        try:
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+            if receipt.get("rawSha256") == sha256_file(raw):
+                return str(run)
+        except (OSError, json.JSONDecodeError):
+            pass
+    return None
+
+
+def _cached_run_for_request(request: GenerationRequest) -> tuple[str, str] | None:
+    index = _read_cache_index(request.out_dir)
+    cache_key = index["aliases"].get(compute_request_fingerprint(request))
+    if not isinstance(cache_key, str):
+        return None
+    run = _cached_run(request.out_dir, cache_key)
+    return (run, cache_key) if run else None
+
+
+def _physical_memory_bytes() -> int | None:
+    if platform.system() == "Darwin":
+        completed = subprocess.run(
+            ["sysctl", "-n", "hw.memsize"], text=True, capture_output=True, check=False
+        )
+        if completed.returncode == 0 and completed.stdout.strip().isdigit():
+            return int(completed.stdout.strip())
+    try:
+        pages = int(os.sysconf("SC_PHYS_PAGES"))
+        page_size = int(os.sysconf("SC_PAGE_SIZE"))
+        return pages * page_size
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+
+
+def local_capability(
+    root: Path,
+    *,
+    system: str | None = None,
+    machine: str | None = None,
+    disk_free_bytes: int | None = None,
+    memory_bytes: int | None = None,
+) -> MetadataDecision:
+    system = system or platform.system()
+    machine = machine or platform.machine()
+    if disk_free_bytes is None:
+        try:
+            disk_free_bytes = shutil.disk_usage(root).free
+        except OSError:
+            disk_free_bytes = 0
+    if memory_bytes is None:
+        memory_bytes = _physical_memory_bytes() or 0
+    apple_silicon = system == "Darwin" and machine in {"arm64", "aarch64"}
+    backend = (
+        "mps-experimental"
+        if apple_silicon and memory_bytes >= MPS_RECOMMENDED_MEMORY_BYTES
+        else "cpu"
+    )
+    evidence = {
+        "system": system,
+        "machine": machine,
+        "appleSilicon": apple_silicon,
+        "diskFreeBytes": disk_free_bytes,
+        "memoryBytes": memory_bytes,
+        "minimumDiskBytes": MIN_LOCAL_DISK_BYTES,
+        "minimumMemoryBytes": MIN_LOCAL_MEMORY_BYTES,
+        "recommendedBackend": backend,
+    }
+    reasons: list[str] = []
+    if disk_free_bytes < MIN_LOCAL_DISK_BYTES:
+        reasons.append(
+            "less than 12 GiB free disk is available for the local environment and model"
+        )
+    if memory_bytes < MIN_LOCAL_MEMORY_BYTES:
+        reasons.append("less than 16 GiB physical/unified memory is available")
+    return MetadataDecision(
+        Decision.UNAVAILABLE if reasons else Decision.ALLOW, tuple(reasons), evidence
+    )
+
+
+def local_install_revision(root: Path) -> str:
+    completed = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    revision = completed.stdout.strip()
+    if (
+        completed.returncode == 0
+        and len(revision) == 40
+        and all(character in "0123456789abcdef" for character in revision.lower())
+    ):
+        return f"git:{revision}"
+    script = root / "run.py"
+    return f"run-py-sha256:{sha256_file(script)}"
+
+
+def _local_preflight(
+    request: GenerationRequest, approve_local_run: bool
+) -> PreflightReport:
+    spec = provider_spec(request.provider_id)
+    reasons: list[str] = []
+    root_value = os.environ.get("SF3D_ROOT", "")
+    root = Path(root_value).expanduser().resolve() if root_value else None
+    capability: MetadataDecision | None = None
+    failure_category: str | None = None
+    if root is None or not (root / "run.py").is_file():
+        reasons.append(
+            "SF3D_ROOT does not point to an installed Stable Fast 3D checkout"
+        )
+        failure_category = "local_capability_missing"
+    else:
+        capability = local_capability(root)
+    if os.environ.get("SF3D_MODEL_ACCESS_APPROVED") != "1":
+        reasons.append("model license/access acceptance must be completed by the user")
+        if failure_category is None:
+            failure_category = "license_acceptance_required"
+    if not approve_local_run:
+        reasons.append("local execution approval is missing")
+        if failure_category is None:
+            failure_category = "local_capability_missing"
+    decision = Decision.ALLOW if not reasons else Decision.NEEDS_USER_ACTION
+    if capability is not None and capability.decision == Decision.UNAVAILABLE:
+        decision = Decision.UNAVAILABLE
+        reasons.extend(capability.reasons)
+        failure_category = "local_capability_missing"
+    effective_parameters = dict(request.parameters)
+    if (
+        capability is not None
+        and capability.evidence.get("recommendedBackend") == "cpu"
+    ):
+        effective_parameters["forceCpu"] = True
+    revision = (
+        local_install_revision(root)
+        if root is not None and (root / "run.py").is_file()
+        else "local-install-unverified"
+    )
+    request_for_key = replace(
+        request, endpoint_revision=revision, parameters=effective_parameters
+    )
+    return PreflightReport(
+        decision,
+        request.provider_id,
+        spec.endpoint,
+        compute_cache_key(request_for_key),
+        tuple(reasons),
+        {
+            "platform": platform.platform(),
+            "sf3dRoot": str(root) if root else None,
+            "revision": revision,
+            "monetaryCostUsd": 0,
+            "capability": capability.evidence if capability else None,
+            "effectiveParameters": effective_parameters,
+            "failureCategory": failure_category,
+        },
+        (),
+    )
+
+
+def preflight(
+    request: GenerationRequest,
+    *,
+    metadata_probe: MetadataProbe = default_metadata_probe,
+    approve_upload: bool = False,
+    approve_local_run: bool = False,
+) -> PreflightReport:
+    spec = provider_spec(request.provider_id)
+    if not request.images:
+        raise AssistFailure(
+            "invalid_provider_response", "at least one reference image is required"
+        )
+    missing = [str(path) for path in request.images if not path.expanduser().is_file()]
+    if missing:
+        raise AssistFailure(
+            "invalid_provider_response", f"reference image not found: {missing[0]}"
+        )
+    if request.policy.max_cost_usd != 0 or any(
+        (
+            request.policy.allow_paid_fallback,
+            request.policy.allow_credit_purchase,
+            request.policy.allow_automatic_retry,
+            request.policy.allow_automatic_provider_switch,
+        )
+    ):
+        raise AssistFailure("free_status_unverified", "zero-spend policy is not exact")
+
+    cached_before_probe = _cached_run_for_request(request)
+    if cached_before_probe:
+        cached, cache_key = cached_before_probe
+        report = PreflightReport(
+            Decision.ALLOW,
+            request.provider_id,
+            spec.endpoint,
+            cache_key,
+            (
+                "matching completed generation is cached; no capability probe, upload, or provider call is needed",
+            ),
+            {
+                "cacheHit": True,
+                "cachedRun": cached,
+                "monetaryCostUsd": 0,
+                "policy": json_record(request.policy),
+            },
+            tuple(str(path.expanduser().resolve()) for path in request.images)
+            if spec.hosted
+            else (),
+        )
+        write_json_atomic(request.out_dir / "preflight.json", json_record(report))
+        return report
+
+    if not spec.hosted:
+        report = _local_preflight(request, approve_local_run)
+    else:
+        try:
+            metadata = metadata_probe(spec.endpoint)
+        except Exception as exc:  # noqa: BLE001 - unverified live state is a durable DENY report
+            report = PreflightReport(
+                Decision.DENY,
+                request.provider_id,
+                spec.endpoint,
+                compute_cache_key(replace(request, endpoint_revision="unverified")),
+                (
+                    f"live free-status metadata could not be verified: {redact(str(exc))}",
+                ),
+                {
+                    "cacheHit": False,
+                    "cachedRun": None,
+                    "monetaryCostUsd": 0,
+                    "policy": json_record(request.policy),
+                    "failureCategory": "free_status_unverified",
+                },
+                tuple(str(path.expanduser().resolve()) for path in request.images),
+            )
+            write_json_atomic(request.out_dir / "preflight.json", json_record(report))
+            return report
+        evaluated = evaluate_hosted_metadata(metadata)
+        revision = str(evaluated.evidence.get("revision") or "unverified")
+        keyed_request = replace(request, endpoint_revision=revision)
+        cache_key = compute_cache_key(keyed_request)
+        cached = _cached_run(request.out_dir, cache_key)
+        if evaluated.decision != Decision.ALLOW:
+            decision = Decision.DENY
+            reasons = evaluated.reasons
+        elif cached:
+            decision = Decision.ALLOW
+            reasons = (
+                "matching completed generation is cached; no upload or provider call is needed",
+            )
+        elif not approve_upload:
+            decision = Decision.NEEDS_USER_ACTION
+            reasons = (
+                "exact upload approval is required for the listed files and provider",
+            )
+        else:
+            decision = Decision.ALLOW
+            reasons = (
+                "reviewed ZeroGPU metadata and exact upload approval are present",
+            )
+        evidence = {
+            **evaluated.evidence,
+            "cacheHit": bool(cached),
+            "cachedRun": cached,
+            "monetaryCostUsd": 0,
+            "policy": json_record(request.policy),
+            "failureCategory": (
+                "free_status_unverified"
+                if evaluated.decision != Decision.ALLOW
+                else "upload_not_approved"
+                if not cached and not approve_upload
+                else None
+            ),
+        }
+        report = PreflightReport(
+            decision,
+            request.provider_id,
+            spec.endpoint,
+            cache_key,
+            reasons,
+            evidence,
+            tuple(str(path.expanduser().resolve()) for path in request.images),
+        )
+    write_json_atomic(request.out_dir / "preflight.json", json_record(report))
+    return report
+
+
+def _run_id(cache_key: str, out_dir: Path) -> str:
+    stem = datetime.now(UTC).strftime("%Y%m%dT%H%M%S.%fZ") + "-" + cache_key[:10]
+    candidate = stem
+    suffix = 1
+    while (out_dir / "runs" / candidate).exists():
+        suffix += 1
+        candidate = f"{stem}-{suffix}"
+    return candidate
+
+
+def _failure_status(
+    category: str, message: str, *, resumable: bool, last_artifact: str | None = None
+) -> dict[str, Any]:
+    return {
+        "schemaVersion": 1,
+        "status": "failed",
+        "failureCategory": category,
+        "message": message,
+        "resumable": resumable,
+        "lastDurableArtifact": last_artifact,
+        "updatedAt": datetime.now(UTC).isoformat(),
+    }
+
+
+def normalize_provider_failure(exc: Exception) -> str:
+    message = str(exc).lower()
+    if isinstance(exc, TimeoutError) or "timed out" in message or "timeout" in message:
+        return "queue_timeout"
+    if "quota" in message and (
+        "exhaust" in message or "exceed" in message or "limit" in message
+    ):
+        return "quota_exhausted"
+    return "provider_unavailable"
+
+
+def generate(
+    request: GenerationRequest,
+    *,
+    approve_upload: bool = False,
+    approve_local_run: bool = False,
+    metadata_probe: MetadataProbe = default_metadata_probe,
+    adapter: Any | None = None,
+) -> Path:
+    report = preflight(
+        request,
+        metadata_probe=metadata_probe,
+        approve_upload=approve_upload,
+        approve_local_run=approve_local_run,
+    )
+    spec = provider_spec(request.provider_id)
+    cached = report.evidence.get("cachedRun")
+    if cached:
+        return Path(str(cached))
+    if report.decision != Decision.ALLOW:
+        category = str(
+            report.evidence.get("failureCategory") or "free_status_unverified"
+        )
+        raise AssistFailure(category, "; ".join(report.reasons))
+
+    effective_parameters = report.evidence.get("effectiveParameters")
+    provider_request = (
+        replace(request, parameters=dict(effective_parameters))
+        if isinstance(effective_parameters, dict)
+        else request
+    )
+
+    run_dir = request.out_dir / "runs" / _run_id(report.cache_key, request.out_dir)
+    raw_dir = run_dir / "raw"
+    raw_dir.mkdir(parents=True, exist_ok=False)
+    write_json_atomic(
+        run_dir / "request.json",
+        {
+            "schemaVersion": 1,
+            "providerId": request.provider_id,
+            "endpoint": spec.endpoint,
+            "cacheKey": report.cache_key,
+            "requestFingerprint": compute_request_fingerprint(request),
+            "images": [
+                {"name": path.name, "sha256": sha256_file(path)}
+                for path in request.images
+            ],
+            "parameters": provider_request.parameters,
+            "policy": json_record(request.policy),
+        },
+    )
+    write_json_atomic(
+        run_dir / "status.json",
+        {
+            "schemaVersion": 1,
+            "status": "provider-running",
+            "resumable": False,
+            "updatedAt": datetime.now(UTC).isoformat(),
+        },
+    )
+    if adapter is None:
+        from .providers import provider_adapter
+
+        adapter = provider_adapter(request.provider_id)
+    try:
+        raw_generation = adapter.generate(provider_request, run_dir)
+        source = Path(raw_generation.source_path)
+        if not source.is_file():
+            raise AssistFailure(
+                "invalid_provider_response", "provider returned a missing GLB path"
+            )
+        temporary = raw_dir / "reference.glb.tmp"
+        shutil.copyfile(source, temporary)
+        if temporary.read_bytes()[:4] != b"glTF":
+            temporary.unlink(missing_ok=True)
+            raise AssistFailure(
+                "invalid_glb", "provider output does not start with GLB magic"
+            )
+        raw = raw_dir / "reference.glb"
+        temporary.replace(raw)
+        raw.chmod(0o444)
+        receipt = {
+            "schemaVersion": 1,
+            "providerId": request.provider_id,
+            "endpoint": spec.endpoint,
+            "endpointRevision": report.evidence.get("revision"),
+            "modelId": raw_generation.model_id or spec.model_id,
+            "licenseId": spec.license_id,
+            "providerTaskId": raw_generation.provider_task_id,
+            "parameters": provider_request.parameters,
+            "quotaClass": spec.expected_hardware,
+            "declaredMonetaryCostUsd": 0,
+            "rawSha256": sha256_file(raw),
+            "providerMetadata": raw_generation.metadata,
+            "completedAt": datetime.now(UTC).isoformat(),
+        }
+        write_json_atomic(run_dir / "provider-receipt.json", receipt)
+        write_json_atomic(
+            run_dir / "status.json",
+            {
+                "schemaVersion": 1,
+                "status": "raw-persisted",
+                "resumable": True,
+                "lastDurableArtifact": "raw/reference.glb",
+                "updatedAt": datetime.now(UTC).isoformat(),
+            },
+        )
+        return run_dir
+    except AssistFailure as exc:
+        message = str(redact(str(exc)))
+        status = _failure_status(
+            exc.category,
+            message,
+            resumable=exc.resumable,
+            last_artifact=exc.last_artifact,
+        )
+        write_json_atomic(run_dir / "status.json", status)
+        raise AssistFailure(
+            exc.category,
+            message,
+            resumable=exc.resumable,
+            last_artifact=exc.last_artifact,
+        ) from exc
+    except Exception as exc:  # noqa: BLE001 - provider errors are normalized and never retried
+        message = str(redact(str(exc)))
+        category = normalize_provider_failure(exc)
+        write_json_atomic(
+            run_dir / "status.json", _failure_status(category, message, resumable=False)
+        )
+        raise AssistFailure(category, message) from exc
+
+
+def admit_glb(
+    glb_path: Path,
+    *,
+    obj_info: dict[str, Any] | None = None,
+    max_vertices: int = 2_000_000,
+    max_triangles: int = 4_000_000,
+) -> dict[str, Any]:
+    try:
+        from forge.stage1_intake.probe_glb import parse_glb, probe_glb
+
+        document, _binary, _binary_info = parse_glb(glb_path)
+        probe = probe_glb(glb_path)
+    except Exception as exc:  # noqa: BLE001 - invalid input is a report, not a crash
+        return {
+            "schemaVersion": 1,
+            "status": "reject",
+            "failureCategory": "invalid_glb",
+            "reasons": [str(redact(str(exc)))],
+            "admittedForProceduralInfluence": False,
+        }
+    reasons: list[str] = []
+    scene = probe.get("scene", {})
+    if probe.get("referenceReadiness") != "pass" or int(scene.get("meshCount", 0)) < 1:
+        reasons.append("GLB has no readable mesh and BIN inventory")
+    if int(scene.get("materialCount", 0)) < 1:
+        reasons.append("GLB has no material inventory")
+    bounds = probe.get("bounds")
+    size = bounds.get("size") if isinstance(bounds, dict) else None
+    if (
+        not isinstance(size, list)
+        or len(size) != 3
+        or not all(math.isfinite(float(value)) for value in size)
+    ):
+        reasons.append("GLB bounds are missing or non-finite")
+    elif sum(float(value) > 1e-9 for value in size) < 2:
+        reasons.append("GLB bounds are degenerate")
+    if obj_info:
+        vertices = int(obj_info.get("vertices", 0))
+        triangles = int(obj_info.get("triangles", 0))
+        if vertices <= 0 or vertices > max_vertices:
+            reasons.append(f"vertex count {vertices} is outside 1..{max_vertices}")
+        if triangles <= 0 or triangles > max_triangles:
+            reasons.append(f"triangle count {triangles} is outside 1..{max_triangles}")
+        obj_size = obj_info.get("size")
+        if isinstance(size, list) and isinstance(obj_size, list) and len(obj_size) == 3:
+            glb_scale = max(float(value) for value in size)
+            mismatch = max(abs(float(a) - float(b)) for a, b in zip(size, obj_size))
+            if mismatch > max(1e-4, glb_scale * 0.01):
+                reasons.append("GLB and OBJ bounds disagree by more than one percent")
+    required = (
+        document.get("extensionsRequired", []) if isinstance(document, dict) else []
+    )
+    compressed = any(
+        "draco" in str(item).lower() or "meshopt" in str(item).lower()
+        for item in required
+    )
+    return {
+        "schemaVersion": 1,
+        "status": "reject" if reasons else "structural-pass-visual-review-required",
+        "failureCategory": "mesh_admission_failed" if reasons else None,
+        "reasons": reasons,
+        "probe": probe,
+        "obj": obj_info,
+        "compressed": compressed,
+        "visualReview": {
+            "status": "required",
+            "requirements": [
+                "preview render",
+                "silhouette",
+                "aspect",
+                "scale",
+                "invented hidden surfaces",
+            ],
+        },
+        "admittedForProceduralInfluence": False,
+        "note": "Structural admission is not visual acceptance. The mesh remains a proxy until the review gates pass.",
+    }
+
+
+def _default_obj_writer(glb_path: Path, obj_path: Path) -> dict[str, Any]:
+    from integrations.mesh3d.generate_reference_mesh import write_obj
+
+    return write_obj(glb_path, obj_path)
+
+
+def _write_cache_entry(run_dir: Path, cache_key: str, request_fingerprint: str) -> None:
+    out_dir = run_dir.parent.parent
+    index = _read_cache_index(out_dir)
+    relative = run_dir.relative_to(out_dir)
+    index["entries"][cache_key] = {
+        "status": "complete",
+        "run": str(relative),
+        "updatedAt": datetime.now(UTC).isoformat(),
+    }
+    index["aliases"][request_fingerprint] = cache_key
+    write_json_atomic(out_dir / "cache-index.json", index)
+
+
+def resume(
+    run_dir: Path,
+    *,
+    obj_writer: Callable[[Path, Path], dict[str, Any]] = _default_obj_writer,
+) -> dict[str, Any]:
+    run_dir = run_dir.expanduser().resolve()
+    raw = run_dir / "raw" / "reference.glb"
+    if not raw.is_file():
+        status = _failure_status(
+            "invalid_glb", "raw/reference.glb is missing", resumable=False
+        )
+        write_json_atomic(run_dir / "status.json", status)
+        return status
+    try:
+        receipt = json.loads(
+            (run_dir / "provider-receipt.json").read_text(encoding="utf-8")
+        )
+        expected_hash = receipt.get("rawSha256")
+        if not expected_hash or sha256_file(raw) != expected_hash:
+            raise AssistFailure(
+                "invalid_glb", "raw GLB hash no longer matches its provider receipt"
+            )
+        normalized = run_dir / "normalized"
+        normalized.mkdir(parents=True, exist_ok=True)
+        normalized_glb = normalized / "reference.glb"
+        temporary_glb = normalized / "reference.glb.tmp"
+        shutil.copyfile(raw, temporary_glb)
+        temporary_glb.replace(normalized_glb)
+        obj_path = normalized / "reference.obj"
+        obj_info = obj_writer(normalized_glb, obj_path)
+        admission = admit_glb(normalized_glb, obj_info=obj_info)
+        write_json_atomic(
+            normalized / "reference-mesh.json",
+            {
+                "schemaVersion": 1,
+                "glb": "reference.glb",
+                "obj": "reference.obj",
+                "glbSha256": sha256_file(normalized_glb),
+                **obj_info,
+            },
+        )
+        write_json_atomic(run_dir / "review" / "admission.json", admission)
+        if admission["status"] == "reject":
+            status = _failure_status(
+                "mesh_admission_failed",
+                "; ".join(admission["reasons"]),
+                resumable=True,
+                last_artifact="raw/reference.glb",
+            )
+            write_json_atomic(run_dir / "status.json", status)
+            return status
+        request_record = json.loads(
+            (run_dir / "request.json").read_text(encoding="utf-8")
+        )
+        status = {
+            "schemaVersion": 1,
+            "status": "complete",
+            "resumable": True,
+            "lastDurableArtifact": "raw/reference.glb",
+            "normalizedArtifacts": [
+                "normalized/reference.glb",
+                "normalized/reference.obj",
+                "normalized/reference-mesh.json",
+            ],
+            "visualReviewStatus": "required",
+            "admittedForProceduralInfluence": False,
+            "updatedAt": datetime.now(UTC).isoformat(),
+        }
+        write_json_atomic(run_dir / "status.json", status)
+        _write_cache_entry(
+            run_dir,
+            str(request_record["cacheKey"]),
+            str(request_record["requestFingerprint"]),
+        )
+        return status
+    except AssistFailure as exc:
+        status = _failure_status(
+            exc.category,
+            str(exc),
+            resumable=exc.resumable,
+            last_artifact=exc.last_artifact,
+        )
+    except Exception as exc:  # noqa: BLE001 - local conversion remains resumable from raw
+        status = _failure_status(
+            "normalization_failed",
+            str(redact(str(exc))),
+            resumable=True,
+            last_artifact="raw/reference.glb",
+        )
+    write_json_atomic(run_dir / "status.json", status)
+    return status

--- a/integrations/mesh3d/free_assist/providers.py
+++ b/integrations/mesh3d/free_assist/providers.py
@@ -1,0 +1,209 @@
+"""One-shot provider adapters. No adapter performs routing, retry, or fallback."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Protocol
+
+from .model import AssistFailure, GenerationRequest, RawGeneration
+from .registry import provider_spec
+
+
+class MeshProvider(Protocol):
+    def generate(self, request: GenerationRequest, run_dir: Path) -> RawGeneration: ...
+
+
+def _token() -> str | None:
+    try:
+        from huggingface_hub import get_token
+
+        return get_token()
+    except ImportError as exc:
+        raise AssistFailure(
+            "authentication_required",
+            "huggingface_hub is required; install it and run `hf auth login`",
+        ) from exc
+
+
+def _find_glb(value: Any) -> Path | None:
+    if isinstance(value, (str, Path)):
+        candidate = Path(value)
+        return (
+            candidate
+            if candidate.suffix.lower() == ".glb" and candidate.is_file()
+            else None
+        )
+    if isinstance(value, dict):
+        for key in ("path", "video", "value"):
+            candidate = _find_glb(value.get(key))
+            if candidate:
+                return candidate
+        for item in value.values():
+            candidate = _find_glb(item)
+            if candidate:
+                return candidate
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            candidate = _find_glb(item)
+            if candidate:
+                return candidate
+    return None
+
+
+class TrellisZeroGpuProvider:
+    def generate(self, request: GenerationRequest, run_dir: Path) -> RawGeneration:
+        try:
+            from gradio_client import Client, handle_file
+        except ImportError as exc:
+            raise AssistFailure(
+                "provider_unavailable",
+                "gradio_client is required for hosted generation",
+            ) from exc
+        spec = provider_spec(request.provider_id)
+        client = Client(spec.endpoint, token=_token(), verbose=False)
+        primary = handle_file(str(request.images[0].resolve()))
+        extra = [
+            {"image": handle_file(str(path.resolve())), "caption": None}
+            for path in request.images[1:]
+        ]
+        parameters = {
+            "seed": int(request.parameters.get("seed", 0)),
+            "ss_guidance_strength": float(
+                request.parameters.get("ssGuidanceStrength", 7.5)
+            ),
+            "ss_sampling_steps": int(request.parameters.get("ssSamplingSteps", 12)),
+            "slat_guidance_strength": float(
+                request.parameters.get("slatGuidanceStrength", 3.0)
+            ),
+            "slat_sampling_steps": int(request.parameters.get("slatSamplingSteps", 12)),
+            "multiimage_algo": "stochastic",
+            "mesh_simplify": float(request.parameters.get("meshSimplify", 0.95)),
+            "texture_size": int(request.parameters.get("textureSize", 512)),
+        }
+        client.predict(api_name="/start_session")
+        result = client.predict(
+            image=primary,
+            multiimages=extra,
+            api_name="/generate_and_extract_glb",
+            **parameters,
+        )
+        source = _find_glb(result)
+        if source is None:
+            raise AssistFailure(
+                "invalid_provider_response",
+                "TRELLIS response contains no downloaded GLB",
+            )
+        return RawGeneration(
+            source,
+            model_id=spec.model_id,
+            metadata={"apiName": "/generate_and_extract_glb"},
+        )
+
+
+class Sf3dZeroGpuProvider:
+    def generate(self, request: GenerationRequest, run_dir: Path) -> RawGeneration:
+        if len(request.images) != 1:
+            raise AssistFailure(
+                "invalid_provider_response",
+                "hosted Stable Fast 3D accepts exactly one input image",
+            )
+        try:
+            from gradio_client import Client, handle_file
+        except ImportError as exc:
+            raise AssistFailure(
+                "provider_unavailable",
+                "gradio_client is required for hosted generation",
+            ) from exc
+        spec = provider_spec(request.provider_id)
+        client = Client(spec.endpoint, token=_token(), verbose=False)
+        result = client.predict(
+            input_image=handle_file(str(request.images[0].resolve())),
+            foreground_ratio=float(request.parameters.get("foregroundRatio", 0.85)),
+            remesh_option=str(request.parameters.get("remeshOption", "None")),
+            vertex_count=int(request.parameters.get("vertexCount", -1)),
+            texture_size=int(request.parameters.get("textureSize", 1024)),
+            api_name="/run_button",
+        )
+        source = _find_glb(result)
+        if source is None:
+            raise AssistFailure(
+                "invalid_provider_response",
+                "Stable Fast 3D response contains no downloaded GLB",
+            )
+        return RawGeneration(
+            source, model_id=spec.model_id, metadata={"apiName": "/run_button"}
+        )
+
+
+class LocalSf3dProvider:
+    def generate(self, request: GenerationRequest, run_dir: Path) -> RawGeneration:
+        root_value = os.environ.get("SF3D_ROOT", "")
+        root = (
+            Path(root_value).expanduser().resolve()
+            if root_value
+            else Path("/__missing_sf3d_root__")
+        )
+        script = root / "run.py"
+        if not script.is_file():
+            raise AssistFailure(
+                "local_capability_missing", "SF3D_ROOT/run.py is missing"
+            )
+        output = run_dir / "local-provider-output"
+        output.mkdir(parents=True, exist_ok=False)
+        command = [
+            sys.executable,
+            str(script),
+            *(str(path.resolve()) for path in request.images),
+            "--output-dir",
+            str(output),
+        ]
+        environment = os.environ.copy()
+        if bool(request.parameters.get("forceCpu", False)):
+            environment["SF3D_USE_CPU"] = "1"
+        completed = subprocess.run(
+            command,
+            cwd=root,
+            env=environment,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise AssistFailure(
+                "provider_unavailable",
+                f"local Stable Fast 3D exited {completed.returncode}: {completed.stderr[-1000:]}",
+            )
+        candidates = sorted(output.glob("**/*.glb"))
+        if len(candidates) != 1:
+            raise AssistFailure(
+                "invalid_provider_response",
+                f"local Stable Fast 3D produced {len(candidates)} GLB files",
+            )
+        spec = provider_spec(request.provider_id)
+        return RawGeneration(
+            candidates[0],
+            model_id=spec.model_id,
+            metadata={
+                "command": [
+                    "python",
+                    "run.py",
+                    "<images>",
+                    "--output-dir",
+                    "<run-output>",
+                ]
+            },
+        )
+
+
+def provider_adapter(provider_id: str) -> MeshProvider:
+    if provider_id == "hf-zerogpu-trellis":
+        return TrellisZeroGpuProvider()
+    if provider_id == "hf-zerogpu-sf3d":
+        return Sf3dZeroGpuProvider()
+    if provider_id == "local-sf3d":
+        return LocalSf3dProvider()
+    provider_spec(provider_id)
+    raise AssertionError("unreachable")

--- a/integrations/mesh3d/free_assist/registry.py
+++ b/integrations/mesh3d/free_assist/registry.py
@@ -1,0 +1,103 @@
+"""Reviewed provider registry and fail-closed hosted metadata evaluation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .model import Decision
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    provider_id: str
+    endpoint: str
+    expected_hardware: str
+    hosted: bool
+    model_id: str
+    license_id: str
+
+
+@dataclass(frozen=True)
+class MetadataDecision:
+    decision: Decision
+    reasons: tuple[str, ...]
+    evidence: dict[str, Any]
+
+
+class UnknownProvider(ValueError):
+    pass
+
+
+PROVIDERS = {
+    "hf-zerogpu-trellis": ProviderSpec(
+        "hf-zerogpu-trellis",
+        "trellis-community/TRELLIS",
+        "zero-a10g",
+        True,
+        "microsoft/TRELLIS-image-large",
+        "MIT",
+    ),
+    "hf-zerogpu-sf3d": ProviderSpec(
+        "hf-zerogpu-sf3d",
+        "stabilityai/stable-fast-3d",
+        "zero-a10g",
+        True,
+        "stabilityai/stable-fast-3d",
+        "stabilityai-ai-community",
+    ),
+    "local-sf3d": ProviderSpec(
+        "local-sf3d",
+        "local",
+        "local",
+        False,
+        "stabilityai/stable-fast-3d",
+        "stabilityai-ai-community",
+    ),
+}
+
+
+def provider_spec(provider_id: str) -> ProviderSpec:
+    try:
+        return PROVIDERS[provider_id]
+    except KeyError as exc:
+        raise UnknownProvider(
+            f"provider is not in the reviewed zero-spend registry: {provider_id}"
+        ) from exc
+
+
+def evaluate_hosted_metadata(metadata: dict[str, Any]) -> MetadataDecision:
+    runtime = metadata.get("runtime") if isinstance(metadata, dict) else None
+    runtime = runtime if isinstance(runtime, dict) else {}
+    hardware = (
+        runtime.get("hardware") if isinstance(runtime.get("hardware"), dict) else {}
+    )
+    domains = runtime.get("domains") if isinstance(runtime.get("domains"), list) else []
+    evidence = {
+        "stage": runtime.get("stage"),
+        "hardwareCurrent": hardware.get("current"),
+        "hardwareRequested": hardware.get("requested"),
+        "readyDomains": [
+            item.get("domain")
+            for item in domains
+            if isinstance(item, dict)
+            and item.get("stage") == "READY"
+            and item.get("domain")
+        ],
+        "revision": runtime.get("sha"),
+    }
+    reasons: list[str] = []
+    if evidence["stage"] != "RUNNING":
+        reasons.append("Space runtime is not RUNNING")
+    if (
+        evidence["hardwareCurrent"] != "zero-a10g"
+        or evidence["hardwareRequested"] != "zero-a10g"
+    ):
+        reasons.append(
+            "current and requested hardware are not both the reviewed ZeroGPU class"
+        )
+    if not evidence["readyDomains"]:
+        reasons.append("Space has no READY runtime domain")
+    return MetadataDecision(
+        Decision.DENY if reasons else Decision.ALLOW, tuple(reasons), evidence
+    )

--- a/integrations/mesh3d/free_assist/security.py
+++ b/integrations/mesh3d/free_assist/security.py
@@ -1,0 +1,72 @@
+"""Credential-safe serialization helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+
+_SECRET_KEYS = {
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "hf_token",
+    "hf-token",
+    "token",
+    "access_token",
+}
+_SIGNED_QUERY_KEYS = {
+    "token",
+    "access_token",
+    "signature",
+    "x-amz-signature",
+    "x-amz-credential",
+    "x-amz-security-token",
+}
+_TOKEN_PATTERN = re.compile(r"(?i)(?:Bearer\s+)?hf_[A-Za-z0-9_-]{12,}")
+_BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[^\s,;]+")
+
+
+def _redact_url(value: str) -> str:
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return value
+    if parsed.scheme not in {"http", "https"}:
+        return value
+    safe_query = [
+        (key, "[REDACTED]" if key.lower() in _SIGNED_QUERY_KEYS else item)
+        for key, item in parse_qsl(parsed.query, keep_blank_values=True)
+        if key.lower() not in _SIGNED_QUERY_KEYS
+    ]
+    return urlunsplit(
+        (parsed.scheme, parsed.netloc, parsed.path, urlencode(safe_query), "")
+    )
+
+
+def redact(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): "[REDACTED]" if str(key).lower() in _SECRET_KEYS else redact(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [redact(item) for item in value]
+    if isinstance(value, str):
+        return _TOKEN_PATTERN.sub(
+            "[REDACTED]", _BEARER_PATTERN.sub("[REDACTED]", _redact_url(value))
+        )
+    return value
+
+
+def write_json_atomic(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(redact(value), indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)

--- a/integrations/mesh3d/pyproject.toml
+++ b/integrations/mesh3d/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "img2threejs-mesh3d"
+version = "0.1.0"
+description = "Optional zero-spend hosted/local reference mesh adapters for img2threejs"
+requires-python = ">=3.11,<3.14"
+dependencies = [
+  "gradio-client>=2,<3",
+  "huggingface-hub>=0.36,<1",
+  "trimesh>=4,<5",
+]
+
+[tool.uv]
+package = false

--- a/integrations/mesh3d/pyproject.toml
+++ b/integrations/mesh3d/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.11,<3.14"
 dependencies = [
   "gradio-client>=2,<3",
   "huggingface-hub>=0.36,<1",
+  "scipy>=1.14,<2",
   "trimesh>=4,<5",
 ]
 

--- a/integrations/mesh3d/tests/__init__.py
+++ b/integrations/mesh3d/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for optional mesh integrations."""

--- a/integrations/mesh3d/tests/test_dense_evidence.py
+++ b/integrations/mesh3d/tests/test_dense_evidence.py
@@ -1,0 +1,412 @@
+from __future__ import annotations
+
+import dataclasses
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import numpy as np
+import trimesh
+
+from integrations.mesh3d.dense_evidence.cache import (
+    ExtractionCacheInput,
+    extraction_cache_key,
+)
+from integrations.mesh3d.dense_evidence.model import (
+    canonical_sha256,
+    DenseEvidenceError,
+    InfluenceScope,
+    sha256_file,
+    validate_provider_run,
+    write_json_atomic,
+)
+from integrations.mesh3d.dense_evidence.alignment import validate_alignment
+from integrations.mesh3d.dense_evidence.extract import ExtractionConfig, extract_run
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def make_completed_run(
+    root: Path,
+    source: Path,
+    *,
+    reviewed: bool = True,
+    multipart: bool = False,
+    degenerate: bool = False,
+) -> Path:
+    run = root / "run"
+    normalized = run / "normalized"
+    review = run / "review"
+    normalized.mkdir(parents=True)
+    review.mkdir(parents=True)
+    glb = normalized / "reference.glb"
+    obj = normalized / "reference.obj"
+    extents = (1.0, 0.0, 1.0) if degenerate else (2.0, 3.0, 4.0)
+    primary = trimesh.creation.box(extents=extents)
+    scene = trimesh.Scene()
+    scene.add_geometry(primary, node_name="body", geom_name="body-mesh")
+    if multipart:
+        roof = trimesh.creation.box(extents=(1.5, 0.5, 2.0))
+        roof.apply_translation((0.0, 1.75, 0.0))
+        scene.add_geometry(roof, node_name="roof", geom_name="roof-mesh")
+    glb.write_bytes(scene.export(file_type="glb"))
+    obj.write_text(scene.export(file_type="obj"), encoding="utf-8")
+    _write_json(
+        run / "provider-receipt.json",
+        {
+            "providerId": "trellis-zerogpu",
+            "sourceImageSha256": [sha256_file(source)],
+            "normalizedGlbSha256": sha256_file(glb),
+            "normalizedObjSha256": sha256_file(obj),
+        },
+    )
+    _write_json(
+        review / "admission.json",
+        {
+            "status": "pass",
+            "glbSha256": sha256_file(glb),
+            "objSha256": sha256_file(obj),
+            "probe": {
+                "scene": {
+                    "meshCount": 2 if multipart else 1,
+                    "primitiveCount": 2 if multipart else 1,
+                },
+                "semanticStatus": "sufficient" if multipart else "insufficient",
+            },
+        },
+    )
+    if reviewed:
+        _write_json(
+            review / "visual-review.json",
+            {
+                "status": "reviewed",
+                "verdict": "retain-as-generative-proxy-only",
+                "glbSha256": sha256_file(glb),
+            },
+        )
+    return run
+
+
+def valid_alignment(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schemaVersion": 1,
+        "profileVersion": "source-view-alignment-v1",
+        "sourceViewTransform": np.eye(4).reshape(-1).tolist(),
+        "upAxis": "+Y",
+        "forwardAxis": "+Z",
+        "handedness": "right-handed",
+        "axisOperationAudit": ["identity; no reflection applied"],
+        "chiralityStatus": "reviewed",
+        "sourceViewSilhouetteIou": 0.80,
+        "projectedAspectRatioError": 0.05,
+        "browserCaptures": [
+            {"path": "review/preview.png", "sha256": "f" * 64, "view": "source"}
+        ],
+    }
+    value.update(overrides)
+    return value
+
+
+def _valid_spec() -> dict[str, object]:
+    return {
+        "schemaVersion": "2.1",
+        "targetName": "Fixture House",
+        "qualityContract": {"denseEvidence": {"maxNumericDeltaFraction": 0.2}},
+        "componentTree": [
+            {
+                "id": "body",
+                "primitive": "box",
+                "topologyClass": "assembled-solid",
+                "topologyRationale": "Observed wall volume.",
+                "dimensions": {"width": 1.5, "height": 2.0, "depth": 3.0},
+                "transform": {"position": [0.0, 0.0, 0.0]},
+                "children": [],
+            }
+        ],
+    }
+
+
+def _hash_tree(*roots: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in sorted(item for item in root.rglob("*") if item.is_file()):
+            result[str(path.relative_to(root.parent))] = sha256_file(path)
+    return result
+
+
+def run_cli(*arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "integrations.mesh3d.dense_evidence", *arguments],
+        cwd=Path(__file__).resolve().parents[3],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class DenseEvidenceModelTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.source = self.root / "source.png"
+        self.source.write_bytes(b"image")
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_scope_enum_contains_only_three_deny_by_default_values(self) -> None:
+        self.assertEqual(
+            [item.value for item in InfluenceScope],
+            ["none", "global-massing", "component-measurements"],
+        )
+
+    def test_run_validation_rejects_hash_drift_and_unreviewed_mesh(self) -> None:
+        run = make_completed_run(self.root, self.source)
+        validated = validate_provider_run(run, (self.source,))
+        self.assertEqual(validated.glb_sha256, sha256_file(run / "normalized/reference.glb"))
+        (run / "normalized/reference.glb").write_bytes(b"changed")
+        with self.assertRaisesRegex(DenseEvidenceError, "evidence_hash_mismatch"):
+            validate_provider_run(run, (self.source,))
+
+        unreviewed_root = self.root / "unreviewed"
+        unreviewed_root.mkdir()
+        unreviewed = make_completed_run(unreviewed_root, self.source, reviewed=False)
+        with self.assertRaisesRegex(DenseEvidenceError, "visual_review_missing"):
+            validate_provider_run(unreviewed, (self.source,))
+
+    def test_atomic_json_write_leaves_complete_record(self) -> None:
+        target = self.root / "dense-evidence" / "status.json"
+        write_json_atomic(target, {"status": "complete"})
+        self.assertEqual(json.loads(target.read_text(encoding="utf-8")), {"status": "complete"})
+        self.assertEqual(list(target.parent.glob("*.tmp")), [])
+
+    def test_cache_key_changes_for_every_authoritative_input(self) -> None:
+        base = ExtractionCacheInput(
+            "a" * 64,
+            "b" * 64,
+            ("c" * 64,),
+            "v1",
+            "a1",
+            None,
+            "m1",
+        )
+        keys = {
+            extraction_cache_key(base),
+            extraction_cache_key(dataclasses.replace(base, glb_sha256="d" * 64)),
+            extraction_cache_key(
+                dataclasses.replace(base, source_image_sha256=("e" * 64,))
+            ),
+            extraction_cache_key(
+                dataclasses.replace(base, measurement_config_sha256="m2")
+            ),
+        }
+        self.assertEqual(len(keys), 4)
+
+
+class DenseEvidenceExtractionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.source = self.root / "source.png"
+        self.source.write_bytes(b"image")
+        self.out = self.root / "dense-evidence"
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_merged_glb_is_capped_at_global_massing(self) -> None:
+        run = make_completed_run(self.root, self.source)
+        result = extract_run(run, (self.source,), valid_alignment(), self.out)
+        self.assertEqual(result["admission"]["maximumInfluenceScope"], "global-massing")
+        self.assertEqual(result["admission"]["approvedInfluenceScope"], "none")
+        self.assertEqual(result["regions"], [])
+        self.assertLessEqual(result["globalGeometry"]["occupancyGrid"]["resolution"], 32)
+
+    def test_multipart_boundaries_remain_candidate_only(self) -> None:
+        run = make_completed_run(self.root, self.source, multipart=True)
+        result = extract_run(run, (self.source,), valid_alignment(), self.out)
+        self.assertEqual(result["admission"]["maximumInfluenceScope"], "component-measurements")
+        self.assertGreaterEqual(len(result["regions"]), 2)
+        self.assertTrue(all(item["candidateOnly"] for item in result["regions"]))
+        self.assertTrue(all(item["semanticLabel"] is None for item in result["regions"]))
+
+    def test_threshold_failure_denies_instead_of_relaxing(self) -> None:
+        with self.assertRaisesRegex(DenseEvidenceError, "alignment_failed"):
+            validate_alignment(
+                valid_alignment(sourceViewSilhouetteIou=0.64), "global-massing"
+            )
+
+    def test_chirality_ambiguity_caps_component_scope_at_global(self) -> None:
+        alignment = validate_alignment(
+            valid_alignment(chiralityStatus="ambiguous"), "sufficient"
+        )
+        self.assertEqual(alignment.maximum_scope, InfluenceScope.GLOBAL_MASSING)
+
+    def test_single_view_hidden_surfaces_are_non_authoritative(self) -> None:
+        result = extract_run(
+            make_completed_run(self.root, self.source),
+            (self.source,),
+            valid_alignment(),
+            self.out,
+        )
+        self.assertEqual(result["uncertainty"]["hiddenSurfacePolicy"], "non-authoritative")
+        self.assertEqual(result["uncertainty"]["rearConfidence"], "low")
+
+    def test_caps_and_degenerate_geometry_fail_closed(self) -> None:
+        with self.assertRaisesRegex(DenseEvidenceError, "measurement_limit_exceeded"):
+            extract_run(
+                make_completed_run(self.root / "oversize", self.source),
+                (self.source,),
+                valid_alignment(),
+                self.out,
+                ExtractionConfig(resolution=33),
+            )
+        with self.assertRaisesRegex(DenseEvidenceError, "degenerate_geometry"):
+            extract_run(
+                make_completed_run(self.root / "flat", self.source, degenerate=True),
+                (self.source,),
+                valid_alignment(),
+                self.root / "flat-out",
+            )
+
+
+class DenseEvidenceCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.source = self.root / "source.png"
+        self.source.write_bytes(b"image")
+        self.run = make_completed_run(self.root, self.source)
+        self.alignment = self.root / "reviewed-alignment.json"
+        _write_json(self.alignment, valid_alignment())
+        self.out = self.root / "dense-evidence"
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def test_help_exposes_no_provider_upload_token_or_retry_flags(self) -> None:
+        result = run_cli("--help")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        for forbidden in ("provider", "upload", "token", "retry", "endpoint", "max-cost"):
+            self.assertNotIn(f"--{forbidden}", result.stdout)
+
+    def test_extract_and_verify_cache_are_offline_and_hash_bound(self) -> None:
+        first = run_cli(
+            "extract",
+            "--run",
+            str(self.run),
+            "--source-image",
+            str(self.source),
+            "--alignment",
+            str(self.alignment),
+            "--out-dir",
+            str(self.out),
+        )
+        self.assertEqual(first.returncode, 0, first.stderr)
+        for name in (
+            "extraction-request.json",
+            "alignment.json",
+            "dense-evidence.v1.json",
+            "status.json",
+        ):
+            self.assertTrue((self.out / name).is_file(), name)
+        second = run_cli(
+            "verify-cache",
+            "--run",
+            str(self.run),
+            "--source-image",
+            str(self.source),
+            "--alignment",
+            str(self.alignment),
+            "--out-dir",
+            str(self.out),
+        )
+        self.assertEqual(second.returncode, 0, second.stderr)
+        self.assertTrue(json.loads(second.stdout)["cacheHit"])
+        self.source.write_bytes(b"drift")
+        stale = run_cli(
+            "verify-cache",
+            "--run",
+            str(self.run),
+            "--source-image",
+            str(self.source),
+            "--alignment",
+            str(self.alignment),
+            "--out-dir",
+            str(self.out),
+        )
+        self.assertEqual(stale.returncode, 1)
+
+    def test_import_and_extraction_construct_no_network_or_provider(self) -> None:
+        import socket
+        import urllib.request
+
+        from integrations.mesh3d.dense_evidence import cli
+
+        argv = [
+            "extract",
+            "--run",
+            str(self.run),
+            "--source-image",
+            str(self.source),
+            "--alignment",
+            str(self.alignment),
+            "--out-dir",
+            str(self.out),
+        ]
+        with (
+            mock.patch.object(socket, "socket", side_effect=AssertionError("network")),
+            mock.patch.object(
+                urllib.request, "urlopen", side_effect=AssertionError("network")
+            ),
+        ):
+            self.assertEqual(cli.main(argv), 0)
+        self.assertNotIn("integrations.mesh3d.free_assist.providers", sys.modules)
+
+
+class DenseEvidenceEndToEndTest(unittest.TestCase):
+    def test_cached_run_to_proposed_spec_is_offline_and_preserves_inputs(self) -> None:
+        from forge.stage2_spec.apply_dense_evidence import build_proposal
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source.png"
+            source.write_bytes(b"image")
+            run = make_completed_run(root, source)
+            before = _hash_tree(run / "raw", run / "normalized", run / "review")
+            evidence = extract_run(
+                run, (source,), valid_alignment(), root / "dense-evidence"
+            )
+            spec = _valid_spec()
+            admission = {
+                "decision": "ALLOW",
+                "approvedInfluenceScope": "global-massing",
+                "binding": {
+                    "glbSha256": evidence["provenance"]["glbSha256"],
+                    "evidenceSha256": canonical_sha256(evidence),
+                    "visualReviewSha256": "9" * 64,
+                    "scope": "global-massing",
+                    "targetSpecSha256": canonical_sha256(spec),
+                },
+            }
+            with mock.patch("socket.socket", side_effect=AssertionError("network")):
+                proposal, delta, fit_plan = build_proposal(spec, evidence, admission)
+            self.assertEqual(
+                _hash_tree(run / "raw", run / "normalized", run / "review"), before
+            )
+            self.assertNotEqual(proposal, spec)
+            self.assertTrue(delta["changes"])
+            self.assertEqual(fit_plan["maximumSourceSilhouetteRegression"], 0.02)
+            self.assertNotIn("integrations.mesh3d.free_assist.providers", sys.modules)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/integrations/mesh3d/uv.lock
+++ b/integrations/mesh3d/uv.lock
@@ -1,0 +1,446 @@
+version = 1
+revision = 3
+requires-python = ">=3.11, <3.14"
+resolution-markers = [
+    "python_full_version >= '3.12'",
+    "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/3f/143b048436775b0f76ac3eec145c019e8173ccc2885c8f20319b996d5e83/charset_normalizer-3.5.1.tar.gz", hash = "sha256:6117b84ea48435e5356dc737f5121485c30920ba43375fa7b434fd753df0eac3", size = 171764, upload-time = "2026-08-15T08:20:44.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/b6/034f6802e9c3f6418966cfabb7db8c9252cc2429c5098f41cc43af804149/charset_normalizer-3.5.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:eda059b6bc8bc0812d626fd91a7ce01bf583df0a61296eff390fd94141a34e30", size = 363585, upload-time = "2026-08-15T08:16:46.646Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fa/6a7e2a7c4b5451912b8c417732df79574354443592a88d616de03da66ae5/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa2bb0b37202dca27175591f761108b5d34096ade1191ffe4808bdf6b1571488", size = 251189, upload-time = "2026-08-15T08:16:48.287Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c8/ab42b07cfd82e919f427fcfaa7c41abae8242833ad1aad66d42bae40b669/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b2b1b3fa5670c127b246df1d0c059defd41f689a868a3b9d79df9b1cac42d22", size = 239724, upload-time = "2026-08-15T08:16:49.67Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/80/b9348b5d3041209f98b4cdad7655766369233f1d533f4f4f7558e9717bec/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e5e4d73d588ca5ed09df1b7dcd1b203d1df3c542e3f50d126c947d432b10731", size = 280078, upload-time = "2026-08-15T08:16:51.228Z" },
+    { url = "https://files.pythonhosted.org/packages/82/38/083a24028304bc85bb9e376fed801178423dcbb67495f73b6ea0624e1894/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b54e7e13267d49ffbfe68e25b3cbd774dab38fa37238f71265e91b36146eb21c", size = 276650, upload-time = "2026-08-15T08:16:52.625Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/35/731ac04aa0a097fc1c97f0994c375bdb230c6c96619db794208fe664e9ce/charset_normalizer-3.5.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c7b742bf31c88566b4bb6335a7f393bb322e580b6bb98df7bd0c25e6e3519ce8", size = 262325, upload-time = "2026-08-15T08:16:54.085Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/28/c2028e7021fb89c6e56868ed0e387b8e9aa811abdd2ab3208d6578d2c930/charset_normalizer-3.5.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6ba32c4d2abf1d2fe7cf27d280f4cca5664233b0f885549c7761719eb977f486", size = 261140, upload-time = "2026-08-15T08:16:55.604Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f0/0c0ceec6d98b7daa62e361e418135d59685811d79ba11529aad5cdf15e84/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0722590aabf9dc6a6c0343d523c05458fa2b5047dbe6302fd526bb570600753f", size = 252791, upload-time = "2026-08-15T08:16:57.103Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3e/48f4cd187b1c33189d86039e9cbe4f92c05454175504b44ff81806d4d1bf/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:aa1099b956fb795e686d073568f6dc002a0bb89765ea6d5b055dd7d9bf1b116c", size = 240730, upload-time = "2026-08-15T08:16:58.418Z" },
+    { url = "https://files.pythonhosted.org/packages/42/85/f9e22af69af67c54cce42be9455d9c81294f918b4ccc454db01f66efcac2/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:bd6c173f04743d483881bffa1478d5a4624475b8cd1d2194956a75548e191c18", size = 280791, upload-time = "2026-08-15T08:16:59.918Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4c/9044135f42127630b6fa742feb51256353f6ab87a78f2fdd1de3de955a7f/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:f298e218441525d3794428b4c8b8fb8662c6d3ea79925d4807ee6b9a96a3bca5", size = 259598, upload-time = "2026-08-15T08:17:01.421Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ed/1dd7cfebb4e75812934c49ca3b79757d11948053f7937ab7070c151f3c55/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:6e2912d4babbc65196ac13c2f53468dc57fb8b9c25ef913e8c59ddf7c6dc0e1b", size = 278217, upload-time = "2026-08-15T08:17:02.782Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/eb/239c84503cc9e3ba6eb34686a24bc66e84f3924efdd7e38e751a19f6bc10/charset_normalizer-3.5.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3d27167433c0d5f18dc850f07d0b3816221984fecdc405d6c157a6f0b8f8e9e6", size = 263417, upload-time = "2026-08-15T08:17:04.216Z" },
+    { url = "https://files.pythonhosted.org/packages/37/ab/4e4510e1e288478e2c8333131d1c1382382ba8cd2165053c79e39d1da961/charset_normalizer-3.5.1-cp311-cp311-win32.whl", hash = "sha256:ac00177c4831ffa650f8609e4bdddd5fe09c03b1c0c47acece7e6ea20421598b", size = 181774, upload-time = "2026-08-15T08:17:05.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/57/32f0ccea59e8612057c61d6fd22ef2cb63cca93c9fe594094919696ac170/charset_normalizer-3.5.1-cp311-cp311-win_amd64.whl", hash = "sha256:f9b1e28d0e8dbfa858abdba91d6b547beaf2df1a59bec6da6faae7b96a4991a9", size = 206653, upload-time = "2026-08-15T08:17:07.075Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d4/b65c433fc521e58b5f54293982a5e51c05cb5f2dd3f1c7a6acb65b75324e/charset_normalizer-3.5.1-cp311-cp311-win_arm64.whl", hash = "sha256:ae31a1a1db2ee6cc2942fccaf695c934bc7f3db9f2133a3fef1f367cf1a4ab10", size = 185630, upload-time = "2026-08-15T08:17:08.502Z" },
+    { url = "https://files.pythonhosted.org/packages/30/27/78873dc8b6a56357517b74b6bb9568b80450e7bb4f6ef7e3fa9d22aa0bd7/charset_normalizer-3.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:5b6d1386bf0096d26d3a863dc0a487a5b4eb9aa93cf5ba69683d29dde6b9d60f", size = 344456, upload-time = "2026-08-15T08:17:10.072Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/be49ada26b1f0232d57aa89bbebf997a5cc2332a5616b6eca26ff680044d/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4582c27e8c889d64811987b5967fbd3ae0c823fe1fd933b543d55ac20bb475fa", size = 238530, upload-time = "2026-08-15T08:17:11.563Z" },
+    { url = "https://files.pythonhosted.org/packages/76/84/6f1290fa07ae6978d3960caa3eb1b8019bf9284ab7c2297b00c099ef4250/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1d1c7a53a6c2103925cdd6d7229f8c567379f211c869793df679f2e9f738c369", size = 230200, upload-time = "2026-08-15T08:17:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/a0/47b18adeed31c8f16ba9700f32c1b18594cfa09f47eb672a488c273c22bf/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e6621fb2a4988d6e53eedc455e5903e2679f3967b8acb3d639f1b63c14a2e893", size = 262222, upload-time = "2026-08-15T08:17:14.571Z" },
+    { url = "https://files.pythonhosted.org/packages/38/fe/341861ac118dae06f3ec0eb487488af52128f2ef2faf0b11003944d22259/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c0c10730342b0c9b35dd1d619beb8214e520bd96a1f870f452680b238aab3e0", size = 258951, upload-time = "2026-08-15T08:17:16.158Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/89/bb5108dc6c3651dca963f2b0a3ba19bbcb370c94e1b6d3e0e844a58e6dca/charset_normalizer-3.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9af956078716df40d985fb0dfeb2c2120c5ca92ba4ff4b388acfd01cdc14d08", size = 248801, upload-time = "2026-08-15T08:17:17.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ba/ef83ae3aca816393decfa3530976f38a79812d707b80b580ac33b83f9877/charset_normalizer-3.5.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f9f8405c2c758532c74fed975dbee57be1f31a6e865c031870c79a6ed3212ada", size = 244070, upload-time = "2026-08-15T08:17:19.191Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0b/c5292a2462d69b7378ea89793bbb5b2b6fcf6f7dd6d1667f9619094ad553/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:96fef3e886d6a9874b14f27fc193fbdc69d5d8035783d86aa4e1cea594e695f9", size = 240110, upload-time = "2026-08-15T08:17:20.547Z" },
+    { url = "https://files.pythonhosted.org/packages/46/22/111e5be3b740d5c2a5bfcedb3d237b6591e5c2e82ae9d6ffcb121fe0909c/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5d8531a6569d025f68e2321e7638fb7978f23db58e5f69f56913837aae03816e", size = 232836, upload-time = "2026-08-15T08:17:21.895Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/d2/d2aad6fe0dbb44b194bf3becb60f5a0ac48446ade999a47fe7bb41eb09a7/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:aae2ee51122d3ae968a3837d97dc24a0aeebb0dea23694422cd172bd30017cd6", size = 262712, upload-time = "2026-08-15T08:17:23.727Z" },
+    { url = "https://files.pythonhosted.org/packages/35/5a/337e4663a5eae6de99db940ee8066d4145caafb61327db62deda15313cce/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7235dc28fc6dd9d832ac7c7bce95367dedb85929f17368a0c2bee1e080b9acbf", size = 242977, upload-time = "2026-08-15T08:17:25.157Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/85/f82f8a92e31c7519410e2e1afdc630f28ec47490ce2c09a11c1a43cbb459/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4abdc5f9ad448c1ecbfae2974b820535d6bc6e7eef63babbab3d81cf46968c71", size = 260207, upload-time = "2026-08-15T08:17:26.602Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/52/643d11ffd60e9ac2fd1fb87e167a19285b9eefeff4a40e63c87cbfbeab36/charset_normalizer-3.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ba501e667c17d8411f98e67a022d9604ef179aff0e459b7e292c796837c13573", size = 250562, upload-time = "2026-08-15T08:17:27.971Z" },
+    { url = "https://files.pythonhosted.org/packages/62/16/46556278c2168d12df9da7fede5dc6fc70e60301b26a82bbeec238c9cfe3/charset_normalizer-3.5.1-cp312-cp312-win32.whl", hash = "sha256:cfa1c0cc3a8f9f53f1243a5a99ac36fd003880199383b37672e86ddda9cb07e2", size = 178507, upload-time = "2026-08-15T08:17:29.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/4c6c298171e6b3e745633180ff59350fc0ca0db1ffd28df1e369e0579f71/charset_normalizer-3.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3617ac3cfd8b9888f145ad89dd6e692285834b0201c6074a5eeaad3fd4d668c2", size = 200551, upload-time = "2026-08-15T08:17:30.668Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d7/eb95a042f0dd22e304b0b6472b154f3546a1a039a9ee89ccb2a7f61591fc/charset_normalizer-3.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:88e85ab89cb822c1e635f51d6d32e488f94e002e70e2f492bdb8b945543f345a", size = 180700, upload-time = "2026-08-15T08:17:32.028Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/61/2cb6ad133dbbb449fa2d37ccae973232f4827e799af258d15e589a3d1e9e/charset_normalizer-3.5.1-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:4f298bdadb8f0b9e5672877f647d1be9373ef5320c9e2f049795e26cad28b6a9", size = 211584, upload-time = "2026-08-15T08:17:33.597Z" },
+    { url = "https://files.pythonhosted.org/packages/18/57/a305c968be1ca13f3dd1b32f445877e97addf55d80b65c7cb35fac82b777/charset_normalizer-3.5.1-cp313-cp313-android_24_x86_64.whl", hash = "sha256:88ca277405c2d3b71c4e1c2ee0e7966e807bcba86a69d11e19ba199d18ae4491", size = 223359, upload-time = "2026-08-15T08:17:35.022Z" },
+    { url = "https://files.pythonhosted.org/packages/09/0a/d3646670292ce8d8f8cc11ac067d44885e697a5591f57a9221128da5e7b3/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:9362dd90aa7dab48c0054a21187791ccf05473f7dba5d92b8033ae62164675e7", size = 194464, upload-time = "2026-08-15T08:17:36.452Z" },
+    { url = "https://files.pythonhosted.org/packages/de/93/d51ec556e01042fed6f993ea859311bc7917b466684182fbbceb6ca24762/charset_normalizer-3.5.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:977cdbd483a9cff38179bea4fd754289a6f2195c7abd414aba85410b3e66cc5e", size = 197676, upload-time = "2026-08-15T08:17:37.819Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/a0/562247944386f7d4ef94467e84876600cc1e0f1b93239aaa9213d2bc3cbd/charset_normalizer-3.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:e90251c0c7bdd54a100a0dce3c07b7e637278c93af29dbf78ebb89a58c4bac7d", size = 340473, upload-time = "2026-08-15T08:17:39.303Z" },
+    { url = "https://files.pythonhosted.org/packages/31/e7/1d994be1b93d41e9502b8b0460eaa88a1dd8df335df415db87d6c3e91ab2/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94d78ecec2605a8d0398b0f365d5f12a63248438516f5dac536a5eff7337df4a", size = 240156, upload-time = "2026-08-15T08:17:40.66Z" },
+    { url = "https://files.pythonhosted.org/packages/09/53/27923ce5cc6cbccb832037b27dca98882d9c53e9b69e866bbbef4aae7fc8/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d59b75732e9b6f27388e10c14b0259cc5f2e48c78627d185e6a177b58ad3cffe", size = 228246, upload-time = "2026-08-15T08:17:42.003Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5a97e84d63af1d55c07439cb80e56d99a8efb4295700eb4e18c0d1615d2c/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0d929fc574b4d6fd9e7c0f5c2ede8716a41911923aa7fa5fce38e0818aa4a1ac", size = 263660, upload-time = "2026-08-15T08:17:43.627Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c2/071575791dcc88316c0a9a65ce38897a82e4cfe4a325f0f7fe1b1ac47bcf/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:394fea06235c8543390050ed5f529187074b029fb027213f6c46ac11ab5d950e", size = 260354, upload-time = "2026-08-15T08:17:45.094Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/af/63240b0c0248c075c2535a1f1bd992821d8251b9f173abc13329661d09e4/charset_normalizer-3.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62b55f6722735a6c472f88361cde6640608773d9443cebdbb51abf436a1fcdd3", size = 250638, upload-time = "2026-08-15T08:17:46.496Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/66/70dfad64f15be09c15ccfee81330a7e515895dbe296dd23114e9a231268a/charset_normalizer-3.5.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fa48b1b63d639f9483e0633e092f5851e2348c352f1f9bb6c8182f87884ef876", size = 244583, upload-time = "2026-08-15T08:17:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/24/ef36367d38b9ddd4bccbf72888c342e8de1f5ae506fa0b2dcf970e2732a1/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c71fb0d56c920c269cd3e2e3fe7c610e3f1fdb21a6ce60efa6430ff63676cea6", size = 242038, upload-time = "2026-08-15T08:17:49.481Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ab/55e683ba0fff2e43adafc10daa3001eac90fdaa419a97227d5a7067eedde/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:485a0d363cafefcd2538a73c7c838daa2035f09b2c9f9b5e3133f80c6aeb84c2", size = 233677, upload-time = "2026-08-15T08:17:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/67/0f40eaf8d1b6e7cf15e82382a2965efaca787fc1c2794b7021d37aaf5036/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0ea61a470e070686aa30892fed79e297d2c8d0ab46b8bcdf027d38c51da591", size = 264491, upload-time = "2026-08-15T08:17:52.61Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/64/12b4c2a11ee8df4fcc518c78b0d93e3a92bd3d5253d1617ce74ff0e8c7ef/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90b7481fb62fbe172c558bc6fd1c4c98d82004a54a7551f20e11ac9bf0b8708c", size = 245196, upload-time = "2026-08-15T08:17:54.023Z" },
+    { url = "https://files.pythonhosted.org/packages/37/2e/651d910af6d0fba325eee1cda37ec5443462ed25360e666c144166eb6091/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:35fe081843b35aad20ffeccec3eeffbe637b15d14f3fb22cc1b59cd8ec17e93c", size = 261660, upload-time = "2026-08-15T08:17:55.491Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/b09e05e6db7f64338e0dc067c79577b1138da86c1e38369096851d96be88/charset_normalizer-3.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fd0350afdc3aabd5576f60ea109228bd5538139713c7b094c5cd27c73a98bc6f", size = 252618, upload-time = "2026-08-15T08:17:57.025Z" },
+    { url = "https://files.pythonhosted.org/packages/76/4e/362d4f9fdcdf5556fb2aa3ce7d4a58ebce03ed1ff03aa1d9aca8d02f13f3/charset_normalizer-3.5.1-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:9d9a0dc7cbe9bec24c3f767c9122c41fe5a1bc43f47cd099d00d393e09769de4", size = 140362, upload-time = "2026-08-15T08:17:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/d4/703be739b26acce318bd29eb3b25b7209e1b1f527f9eae3d1f1f01fdde2b/charset_normalizer-3.5.1-cp313-cp313-win32.whl", hash = "sha256:d63600d620ad0064c3a748b950ac5ea38a80190e5498532efefa4b7b3f1da1f3", size = 177755, upload-time = "2026-08-15T08:18:00.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/33/56d97ade41c8db611e727168c52ae46c9224c362ec28d4b65d7e9869e8da/charset_normalizer-3.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:aea996a6aba25260827c9ea511d1addfde2da9eb686ac961838509086188b7e6", size = 199295, upload-time = "2026-08-15T08:18:01.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/75/5b20dd1e6573a01a08158fe104104fa2c8abf941745596954185726cd46c/charset_normalizer-3.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:fd0a274c0e5f9a21565cd9d3dd749b61f96b7aa1e20a93aa1ba4029518f2e5c0", size = 179856, upload-time = "2026-08-15T08:18:02.929Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/97/fb4e82231aba271ffd775a1b4993b0defc4e3059f286ae41d9433409fe85/charset_normalizer-3.5.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:41876ee62a3dddf48ff1121ad8f0798032aa03f2fd35f21f34a4cab14f18d8d2", size = 331467, upload-time = "2026-08-15T08:19:50.959Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2f/fe3f187327aac18e2d54e9d2b08e15d27bf9b642d9e51c219f130fc34d1a/charset_normalizer-3.5.1-cp37-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a6dac12ff6b846103483683f60c5f8fee205121adc58ffd87e90a90a3af69e99", size = 253057, upload-time = "2026-08-15T08:19:52.654Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/c7/9e48cee5c161fe24da823b61bf381921d77cb994a0a4de148e95018c1984/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cee5dd7c6fb5dd52a0fe2a740f9bc6e3593f5f8b1788bde49de02086f30182b2", size = 240930, upload-time = "2026-08-15T08:19:54.163Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/716601f3cc69be7b198951150c75ead1ece33c3c8036ff6ffa46029659a0/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:343fb4f2821043bd87095f7b08a1a181febc8e36ac64212143bbfd0a0e1bc235", size = 230822, upload-time = "2026-08-15T08:19:55.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/05/71bfc5caa0abcc45aea1f6a4d50ac68e59605ddc7666fe8494f4cd229665/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ae4a097991662cd4fff0ddc74e0fe7874f82e00042fa0ea00855645ed0c79598", size = 260037, upload-time = "2026-08-15T08:19:57.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/92/de7e32ed05341e7a9c4c877c318418197b7f2d66a3b68d561bf2ac57ca3e/charset_normalizer-3.5.1-cp37-abi3-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4b599739b93b2cbeded49645ae3c8d1405c29ddfbceac1545c87a3f9580a9e96", size = 255097, upload-time = "2026-08-15T08:19:59.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/7b/ade0a122600319dfa0b1000ab0f9731c94a817904cf3c5de408c73a4ede7/charset_normalizer-3.5.1-cp37-abi3-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b39b69b347e5e47a3b5b8cfc005c68c1ba347474e3960236c4944a8ecd174962", size = 250166, upload-time = "2026-08-15T08:20:00.612Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9c/019fbb9f4834491a160951349b1a3714439376f66e5f7cf18b4f18f0c7aa/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:a2028475ba855475b8b4d3cfeb4994269c967aea8b9892dfba907f4263a863a3", size = 241821, upload-time = "2026-08-15T08:20:02.321Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/11d4840bfc99330cc7fbcc2681ee5a044553a6e77655508d8f9b2bff7b34/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:36047af20e17097c3bb9476c2b7655f2f7aa51322c0ba58c07695bedf755a950", size = 232529, upload-time = "2026-08-15T08:20:04.008Z" },
+    { url = "https://files.pythonhosted.org/packages/18/96/2b3a21492d9f65171ac75d872f5018260013d00bfa0ff70ec9f179148cbd/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_ppc64le.whl", hash = "sha256:4c4fb141a727957c93edfe5c32a26ceb6b5f6461d67146e2d39f51e16170bea8", size = 260348, upload-time = "2026-08-15T08:20:05.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/aa/a69a2028e8bd052476c245460ab19d7de595de084dd968f2d75cd50c3e25/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:2f293479cce755c75f1697e87c409b7ae4c555c7dfecb6e988ad13abba943031", size = 247234, upload-time = "2026-08-15T08:20:07.487Z" },
+    { url = "https://files.pythonhosted.org/packages/35/8a/3d130aeabcaf3d2466af76b7b141c08d9e89c9016ab4b7cdd0f7dc2d1c62/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_s390x.whl", hash = "sha256:3588e376b3ea2eea84976f67273d679f229e24c66dce7b82ae45aef04ff6e072", size = 256917, upload-time = "2026-08-15T08:20:09.142Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c2/a7379b840292d0c1ab9fbd17d1f3967aa81794dc95bc74be8999d7fedcf7/charset_normalizer-3.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e199fb99720074809a7720f1c0b4d919eea8b87e88713e0f8f602f7bef543d9d", size = 254846, upload-time = "2026-08-15T08:20:10.727Z" },
+    { url = "https://files.pythonhosted.org/packages/01/65/d43b714731bb2f40d4053dfa00ecfc1c5a301f8e3316c5db3a09af59fe94/charset_normalizer-3.5.1-cp37-abi3-win32.whl", hash = "sha256:dd732602a7009217f658d5863d12d79d373a4de0eebc111094bcdd3bb8e0a6cc", size = 174216, upload-time = "2026-08-15T08:20:12.334Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4f/b911ed898b26a09789eba9c9200c999aff6c61b4bafaf4838e56d1a1e1a3/charset_normalizer-3.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:70055ff39b97c99e7ae40ea3e393fb62aa2e44dbd9b29f8d14f42fb0025c3959", size = 199764, upload-time = "2026-08-15T08:20:13.908Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a7/920baf467bfd9bf689f3b318340f37aee4572a71f162bd8db51da55ba4fa/charset_normalizer-3.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:87e4f41d375c0b9be2fb5251aee4b8a689169e134535aed81bf085c3b647451e", size = 287318, upload-time = "2026-08-15T08:20:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/61/d01fc49b8dea277640b55a9e15960dbca9fdc8c9fde18e572d39c59f4019/charset_normalizer-3.5.1-py3-none-any.whl", hash = "sha256:6df0ec430f9a831772c23ca5a224cba36517a58a84bb32c32bb59a9fa67c47f6", size = 68658, upload-time = "2026-08-15T08:20:43.306Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.32.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/a0/50c2c0ce5e74d7721bbb1b19a26ebd339aac5878553a6e35308c2f31f935/filelock-3.32.5.tar.gz", hash = "sha256:f6a6a28f743f9b95ce19db5abe0f376f75eb56517dff21e1a4751e2657d3e83d", size = 222838, upload-time = "2026-08-31T18:56:34.729Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/d2/b70a31e13d04456d28493f31d2aa087e99eeb2767ef0293b2625727ccb8c/filelock-3.32.5-py3-none-any.whl", hash = "sha256:142cd9fa77a872c5e78c62329a0d15278fadc686eb89e760017968961a4fd6b2", size = 100003, upload-time = "2026-08-31T18:56:33.078Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
+name = "gradio-client"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fsspec" },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/32/ec28ca6b19b22c7ea7f4232078f856790e565f5e87f32cb15a5e406b0ba1/gradio_client-2.6.1.tar.gz", hash = "sha256:0e605bf8683a27583868b933a083e84706b974404815d9795370ef8a62584f4e", size = 61673, upload-time = "2026-08-24T20:49:48.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/1b/e31b3776a4892fac8e2f980265a462f642df84bf488d5d667ef821a801af/gradio_client-2.6.1-py3-none-any.whl", hash = "sha256:df3752925fbaaa56f7bfeeb0064ae23591ec3976432443748dd663a9729ef23b", size = 62558, upload-time = "2026-08-24T20:49:46.346Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "0.36.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/b7/8cb61d2eece5fb05a83271da168186721c450eb74e3c31f7ef3169fa475b/huggingface_hub-0.36.2.tar.gz", hash = "sha256:1934304d2fb224f8afa3b87007d58501acfda9215b334eed53072dd5e815ff7a", size = 649782, upload-time = "2026-02-06T09:24:13.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/af/48ac8483240de756d2438c380746e7130d1c6f75802ef22f3c6d49982787/huggingface_hub-0.36.2-py3-none-any.whl", hash = "sha256:48f0c8eac16145dfce371e9d2d7772854a4f591bcb56c9cf548accf531d54270", size = 566395, upload-time = "2026-02-06T09:24:11.133Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
+name = "img2threejs-mesh3d"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "gradio-client" },
+    { name = "huggingface-hub" },
+    { name = "trimesh" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "gradio-client", specifier = ">=2,<3" },
+    { name = "huggingface-hub", specifier = ">=0.36,<1" },
+    { name = "trimesh", specifier = ">=4,<5" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/49/ec46835a70be8fa6446c495126ac84fdb28cb2558e1620ffb87a10c8b64c/numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4", size = 16969194, upload-time = "2026-05-18T23:33:13.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0d/f5957185c0ee2f3e12f78715aa9e3b353fd83633316c8532b38faa37e3f6/numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d", size = 14964111, upload-time = "2026-05-18T23:33:17.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/40/40a40ee0ddf7ceb782c49af278894b686e586d65d8c1889c8b5da01a3d7d/numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8", size = 5469159, upload-time = "2026-05-18T23:33:20.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/13/f9a8046535cb21deae82f8d03de9617e08882d274fad2539630761888228/numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538", size = 6798936, upload-time = "2026-05-18T23:33:22.987Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a8/6fa8c1a345a8c85dbb21932c447bee07c30a2c2a3f31e369c0a84b300147/numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47", size = 15966692, upload-time = "2026-05-18T23:33:26.62Z" },
+    { url = "https://files.pythonhosted.org/packages/02/03/74fe2a4cb3817d94d86402f2506554130a2f01414e299b5a843e5a8a957f/numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93", size = 16918164, upload-time = "2026-05-18T23:33:29.955Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/80/3615be3313f7e7696609bc194b9f0101da809df79e859bdb84e0cd043f46/numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8", size = 17322877, upload-time = "2026-05-18T23:33:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/a691e0fe2675e370d0e08ff905adc49a1c8830e8cae03efe4477e92cd55d/numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6", size = 18651487, upload-time = "2026-05-18T23:33:38.217Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a7/9bc1cd626d7bf6869bfedf27b91b6ab5dd607758bf8e959d6fa80c6a59cb/numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8", size = 6233945, upload-time = "2026-05-18T23:33:41.331Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/7fc6239c12bce7e931463251cca4426c465e1876ba3cc785402ef4dd8f4e/numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147", size = 12608406, upload-time = "2026-05-18T23:33:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/27/83/140f85a466595a16382996a1bf06b2b54bcd597488921b0c9daaeeda72af/numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577", size = 10479528, upload-time = "2026-05-18T23:33:50.725Z" },
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/de/12/b422cc84439adc0d00de605bf4a308890ae5c26f2c71fbd73e5d08fbb0dd/numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662", size = 16847511, upload-time = "2026-05-18T23:36:50.673Z" },
+    { url = "https://files.pythonhosted.org/packages/44/53/f481bef68011740f8849418d82db07230e825013f31f4eef5ba5b805316a/numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7", size = 14889064, upload-time = "2026-05-18T23:36:53.879Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/57/42ed575c10ced8af951d426bc4e1f8aff16fd851db33f067036215a7f860/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f", size = 5394157, upload-time = "2026-05-18T23:36:57.194Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ef/f66cc724fcc36c1e364c67f51ae9146090b8b584f27d58b97fdae3edd737/numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c", size = 6708728, upload-time = "2026-05-18T23:36:59.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/72/dccb0aaf40972777283303919f613964227266d0c13adebb79ac124f1c3e/numpy-2.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14e373cfc6387177e8409dac3c7159be8eb05cd77096cd7c950268b86f62831c", size = 16891693, upload-time = "2026-08-09T13:44:51.702Z" },
+    { url = "https://files.pythonhosted.org/packages/60/2e/b5aee50a1f74ac815cf8331812cb8251e29024025de462e0c047641c614c/numpy-2.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbd96c833ecc8cc069ce518078fc8c60cb9cbfb0fea5b7a803ad65035596d03", size = 11903109, upload-time = "2026-08-09T13:44:55.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f4/29e78102a80601cf034d4e9767022cffeca2c3b4c926e1754572ca95593d/numpy-2.5.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:6e8172ddfcf5cf74b811d372b570b83c60bd2de87a6fbfbebdadb4a9bd9c6cbb", size = 5350202, upload-time = "2026-08-09T13:44:58.401Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4b/dcd3b7eadaf4035d2c7a4289d232523a6964f602598ef7674e4bd7291f93/numpy-2.5.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:65f188481f1669e26f62b701e8205d19e460fa4a9b52a1414ba382330e4a3414", size = 6687736, upload-time = "2026-08-09T13:45:00.813Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/21/4947e0e9d6c9fc2e2ff15b8949049ee44f63adb9cacc729ab8793f97e712/numpy-2.5.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ee9c4eeb8454b3660a8b53493563c3e121c2fc94fbd72b848ef814ed7b676a9", size = 15612696, upload-time = "2026-08-09T13:45:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cdec01fa790a186d430433fdd4d4ffb70eed6f0eeb4bf05c8dbe2dce0a9bcb8", size = 16722264, upload-time = "2026-08-09T13:45:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/14/25/3f0be4c1b9fdf5dd5e708a6806978564d7c46a055c000496309ff2a2f8af/numpy-2.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7999d4ddb0c4025018373fd787510d46e04c769467af22869707b3c1cfd459ab", size = 16974396, upload-time = "2026-08-09T13:45:11.316Z" },
+    { url = "https://files.pythonhosted.org/packages/22/72/6262cbdeeb45da9d971e40715f579d791603ba8ec0b5e2db1ac55454421d/numpy-2.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c1f017dc0875c9209d219f97feceb7d54c2661bb243deb4114478e1295808af7", size = 18476044, upload-time = "2026-08-09T13:45:14.869Z" },
+    { url = "https://files.pythonhosted.org/packages/36/33/29208b8b075bde62d26a81d14b358c42b0f69b6cabd98d4ff97f37f22b05/numpy-2.5.2-cp312-cp312-win32.whl", hash = "sha256:d6a48072864e3324e194a8fbb3c657bcc5b5c869dbc64c9537b1d5c862572c0a", size = 6072817, upload-time = "2026-08-09T13:45:17.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/87fea2769fe1c47c1b5b01d8310772c9d1a85d485de7cf386ef7a3332b02/numpy-2.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:28ac63476ec7651484215ee7fa15a1f78b57c14621f01e392afe17b9a1390ce4", size = 12464674, upload-time = "2026-08-09T13:45:20.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/52/032b97e00461ab0809bbe4c588b035620e5a14b8cdee47ecddefc7b17d33/numpy-2.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:27650bb0e7140fa3d37b9923b4803645e0b125d190f326eecfd3f4dad8e8ade1", size = 10397131, upload-time = "2026-08-09T13:45:23.73Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/6b24738a0ef4557d189b150046cd07823c50e4273e8aebd651222e24306f/numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15", size = 16886595, upload-time = "2026-08-09T13:45:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/f2d208d366f263f39c6e69ed309290717aab41078b6d04c9be2a84fa2a07/numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080", size = 11896845, upload-time = "2026-08-09T13:45:31.638Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/81e0bf24f4d020a2b1d5cd297a9f60c3f24eeb116f9bba5870443f7b6a4a/numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740", size = 5343880, upload-time = "2026-08-09T13:45:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/e3141cf06d1a8a2c7e107543fe1269c1d1af760d4d683c0794a4ee1127c2/numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56", size = 6682264, upload-time = "2026-08-09T13:45:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3", size = 15609566, upload-time = "2026-08-09T13:45:39.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/3e54d4ddbc359a1295f8b633e8106bcd4d7d4a206e82df051bdfb3058755/numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59", size = 16972511, upload-time = "2026-08-09T13:45:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/ad6645abc7a3510fe48e8ea1ab4598166f500057ef4ebf38bfad4f1577de/numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4", size = 6070204, upload-time = "2026-08-09T13:45:54.111Z" },
+    { url = "https://files.pythonhosted.org/packages/15/20/f3489f86d81ea460b2bcdceaed094142ca6579f6be0ec527b781d39afe68/numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657", size = 12460532, upload-time = "2026-08-09T13:45:57.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/35b31dde1b283b79de828b80f876afd8c94e28fe1e9c375f89e261cc4c0d/numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2", size = 10396725, upload-time = "2026-08-09T13:46:00.478Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "trimesh"
+version = "4.12.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/37/5cb90f04990260d2caceb6093560c6cefafca1ec522c1e43be01ca658244/trimesh-4.12.2.tar.gz", hash = "sha256:c8ca31571ac00b112e4e160e66a2d4c3491df321f056bd33806be0485d1af9d9", size = 842220, upload-time = "2026-05-01T00:57:43.333Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/98/716a473cfb24750858ddd5d14e6527539dd206583a46408d08eeb2844a75/trimesh-4.12.2-py3-none-any.whl", hash = "sha256:b5b5afa63c5272345f2858f7676bc8c217dc8a89f4fadf6193fe10a81b5ff2aa", size = 741043, upload-time = "2026-05-01T00:57:40.763Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/integrations/mesh3d/uv.lock
+++ b/integrations/mesh3d/uv.lock
@@ -237,6 +237,8 @@ source = { virtual = "." }
 dependencies = [
     { name = "gradio-client" },
     { name = "huggingface-hub" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "trimesh" },
 ]
 
@@ -244,6 +246,7 @@ dependencies = [
 requires-dist = [
     { name = "gradio-client", specifier = ">=2,<3" },
     { name = "huggingface-hub", specifier = ">=0.36,<1" },
+    { name = "scipy", specifier = ">=1.14,<2" },
     { name = "trimesh", specifier = ">=4,<5" },
 ]
 
@@ -400,6 +403,94 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/75/b4ce781849931fef6fd529afa6b63711d5a733065722d0c3e2724af9e40a/scipy-1.17.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:1f95b894f13729334fb990162e911c9e5dc1ab390c58aa6cbecb389c5b5e28ec", size = 31613675, upload-time = "2026-02-23T00:16:00.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/58/bccc2861b305abdd1b8663d6130c0b3d7cc22e8d86663edbc8401bfd40d4/scipy-1.17.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:e18f12c6b0bc5a592ed23d3f7b891f68fd7f8241d69b7883769eb5d5dfb52696", size = 28162057, upload-time = "2026-02-23T00:16:09.456Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ee/18146b7757ed4976276b9c9819108adbc73c5aad636e5353e20746b73069/scipy-1.17.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:a3472cfbca0a54177d0faa68f697d8ba4c80bbdc19908c3465556d9f7efce9ee", size = 20334032, upload-time = "2026-02-23T00:16:17.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e6/cef1cf3557f0c54954198554a10016b6a03b2ec9e22a4e1df734936bd99c/scipy-1.17.1-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:766e0dc5a616d026a3a1cffa379af959671729083882f50307e18175797b3dfd", size = 22709533, upload-time = "2026-02-23T00:16:25.791Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/60/8804678875fc59362b0fb759ab3ecce1f09c10a735680318ac30da8cd76b/scipy-1.17.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:744b2bf3640d907b79f3fd7874efe432d1cf171ee721243e350f55234b4cec4c", size = 33062057, upload-time = "2026-02-23T00:16:36.931Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/af933f0f6e0767995b4e2d705a0665e454d1c19402aa7e895de3951ebb04/scipy-1.17.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43af8d1f3bea642559019edfe64e9b11192a8978efbd1539d7bc2aaa23d92de4", size = 35349300, upload-time = "2026-02-23T00:16:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/7ccbbdcbb54c8fdc20d3b6930137c782a163fa626f0aef920349873421ba/scipy-1.17.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd96a1898c0a47be4520327e01f874acfd61fb48a9420f8aa9f6483412ffa444", size = 35127333, upload-time = "2026-02-23T00:17:01.293Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/19/f926cb11c42b15ba08e3a71e376d816ac08614f769b4f47e06c3580c836a/scipy-1.17.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4eb6c25dd62ee8d5edf68a8e1c171dd71c292fdae95d8aeb3dd7d7de4c364082", size = 37741314, upload-time = "2026-02-23T00:17:12.576Z" },
+    { url = "https://files.pythonhosted.org/packages/95/da/0d1df507cf574b3f224ccc3d45244c9a1d732c81dcb26b1e8a766ae271a8/scipy-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:d30e57c72013c2a4fe441c2fcb8e77b14e152ad48b5464858e07e2ad9fbfceff", size = 36607512, upload-time = "2026-02-23T00:17:23.424Z" },
+    { url = "https://files.pythonhosted.org/packages/68/7f/bdd79ceaad24b671543ffe0ef61ed8e659440eb683b66f033454dcee90eb/scipy-1.17.1-cp311-cp311-win_arm64.whl", hash = "sha256:9ecb4efb1cd6e8c4afea0daa91a87fbddbce1b99d2895d151596716c0b2e859d", size = 24599248, upload-time = "2026-02-23T00:17:34.561Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/b992b488d6f299dbe3f11a20b24d3dda3d46f1a635ede1c46b5b17a7b163/scipy-1.17.1-cp312-cp312-macosx_10_14_x86_64.whl", hash = "sha256:35c3a56d2ef83efc372eaec584314bd0ef2e2f0d2adb21c55e6ad5b344c0dcb8", size = 31610954, upload-time = "2026-02-23T00:17:49.855Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/cf107b01494c19dc100f1d0b7ac3cc08666e96ba2d64db7626066cee895e/scipy-1.17.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:fcb310ddb270a06114bb64bbe53c94926b943f5b7f0842194d585c65eb4edd76", size = 28172662, upload-time = "2026-02-23T00:18:01.64Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/a9/599c28631bad314d219cf9ffd40e985b24d603fc8a2f4ccc5ae8419a535b/scipy-1.17.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cc90d2e9c7e5c7f1a482c9875007c095c3194b1cfedca3c2f3291cdc2bc7c086", size = 20344366, upload-time = "2026-02-23T00:18:12.015Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f5/906eda513271c8deb5af284e5ef0206d17a96239af79f9fa0aebfe0e36b4/scipy-1.17.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:c80be5ede8f3f8eded4eff73cc99a25c388ce98e555b17d31da05287015ffa5b", size = 22704017, upload-time = "2026-02-23T00:18:21.502Z" },
+    { url = "https://files.pythonhosted.org/packages/da/34/16f10e3042d2f1d6b66e0428308ab52224b6a23049cb2f5c1756f713815f/scipy-1.17.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e19ebea31758fac5893a2ac360fedd00116cbb7628e650842a6691ba7ca28a21", size = 32927842, upload-time = "2026-02-23T00:18:35.367Z" },
+    { url = "https://files.pythonhosted.org/packages/01/8e/1e35281b8ab6d5d72ebe9911edcdffa3f36b04ed9d51dec6dd140396e220/scipy-1.17.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:02ae3b274fde71c5e92ac4d54bc06c42d80e399fec704383dcd99b301df37458", size = 35235890, upload-time = "2026-02-23T00:18:49.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/5c/9d7f4c88bea6e0d5a4f1bc0506a53a00e9fcb198de372bfe4d3652cef482/scipy-1.17.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8a604bae87c6195d8b1045eddece0514d041604b14f2727bbc2b3020172045eb", size = 35003557, upload-time = "2026-02-23T00:18:54.74Z" },
+    { url = "https://files.pythonhosted.org/packages/65/94/7698add8f276dbab7a9de9fb6b0e02fc13ee61d51c7c3f85ac28b65e1239/scipy-1.17.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f590cd684941912d10becc07325a3eeb77886fe981415660d9265c4c418d0bea", size = 37625856, upload-time = "2026-02-23T00:19:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/dc08d77fbf3d87d3ee27f6a0c6dcce1de5829a64f2eae85a0ecc1f0daa73/scipy-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:41b71f4a3a4cab9d366cd9065b288efc4d4f3c0b37a91a8e0947fb5bd7f31d87", size = 36549682, upload-time = "2026-02-23T00:19:07.67Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/fe9ae9ffb3b54b62559f52dedaebe204b408db8109a8c66fdd04869e6424/scipy-1.17.1-cp312-cp312-win_arm64.whl", hash = "sha256:f4115102802df98b2b0db3cce5cb9b92572633a1197c77b7553e5203f284a5b3", size = 24547340, upload-time = "2026-02-23T00:19:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/76/27/07ee1b57b65e92645f219b37148a7e7928b82e2b5dbeccecb4dff7c64f0b/scipy-1.17.1-cp313-cp313-macosx_10_14_x86_64.whl", hash = "sha256:5e3c5c011904115f88a39308379c17f91546f77c1667cea98739fe0fccea804c", size = 31590199, upload-time = "2026-02-23T00:19:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/ae/db19f8ab842e9b724bf5dbb7db29302a91f1e55bc4d04b1025d6d605a2c5/scipy-1.17.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6fac755ca3d2c3edcb22f479fceaa241704111414831ddd3bc6056e18516892f", size = 28154001, upload-time = "2026-02-23T00:19:22.241Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/58/3ce96251560107b381cbd6e8413c483bbb1228a6b919fa8652b0d4090e7f/scipy-1.17.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:7ff200bf9d24f2e4d5dc6ee8c3ac64d739d3a89e2326ba68aaf6c4a2b838fd7d", size = 20325719, upload-time = "2026-02-23T00:19:26.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/83/15087d945e0e4d48ce2377498abf5ad171ae013232ae31d06f336e64c999/scipy-1.17.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4b400bdc6f79fa02a4d86640310dde87a21fba0c979efff5248908c6f15fad1b", size = 22683595, upload-time = "2026-02-23T00:19:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6", size = 32896429, upload-time = "2026-02-23T00:19:35.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464", size = 35203952, upload-time = "2026-02-23T00:19:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a5/9afd17de24f657fdfe4df9a3f1ea049b39aef7c06000c13db1530d81ccca/scipy-1.17.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:beeda3d4ae615106d7094f7e7cef6218392e4465cc95d25f900bebabfded0950", size = 34979063, upload-time = "2026-02-23T00:19:47.547Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/88b1d2384b424bf7c924f2038c1c409f8d88bb2a8d49d097861dd64a57b2/scipy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6609bc224e9568f65064cfa72edc0f24ee6655b47575954ec6339534b2798369", size = 37598449, upload-time = "2026-02-23T00:19:53.238Z" },
+    { url = "https://files.pythonhosted.org/packages/35/e5/d6d0e51fc888f692a35134336866341c08655d92614f492c6860dc45bb2c/scipy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:37425bc9175607b0268f493d79a292c39f9d001a357bebb6b88fdfaff13f6448", size = 36510943, upload-time = "2026-02-23T00:20:50.89Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/fd/3be73c564e2a01e690e19cc618811540ba5354c67c8680dce3281123fb79/scipy-1.17.1-cp313-cp313-win_arm64.whl", hash = "sha256:5cf36e801231b6a2059bf354720274b7558746f3b1a4efb43fcf557ccd484a87", size = 24545621, upload-time = "2026-02-23T00:20:55.871Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6b/17787db8b8114933a66f9dcc479a8272e4b4da75fe03b0c282f7b0ade8cd/scipy-1.17.1-cp313-cp313t-macosx_10_14_x86_64.whl", hash = "sha256:d59c30000a16d8edc7e64152e30220bfbd724c9bbb08368c054e24c651314f0a", size = 31936708, upload-time = "2026-02-23T00:19:58.694Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2e/524405c2b6392765ab1e2b722a41d5da33dc5c7b7278184a8ad29b6cb206/scipy-1.17.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:010f4333c96c9bb1a4516269e33cb5917b08ef2166d5556ca2fd9f082a9e6ea0", size = 28570135, upload-time = "2026-02-23T00:20:03.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c3/5bd7199f4ea8556c0c8e39f04ccb014ac37d1468e6cfa6a95c6b3562b76e/scipy-1.17.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:2ceb2d3e01c5f1d83c4189737a42d9cb2fc38a6eeed225e7515eef71ad301dce", size = 20741977, upload-time = "2026-02-23T00:20:07.935Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b8/8ccd9b766ad14c78386599708eb745f6b44f08400a5fd0ade7cf89b6fc93/scipy-1.17.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:844e165636711ef41f80b4103ed234181646b98a53c8f05da12ca5ca289134f6", size = 23029601, upload-time = "2026-02-23T00:20:12.161Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a0/3cb6f4d2fb3e17428ad2880333cac878909ad1a89f678527b5328b93c1d4/scipy-1.17.1-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:158dd96d2207e21c966063e1635b1063cd7787b627b6f07305315dd73d9c679e", size = 33019667, upload-time = "2026-02-23T00:20:17.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/2d834a5ac7bf3a0c806ad1508efc02dda3c8c61472a56132d7894c312dea/scipy-1.17.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74cbb80d93260fe2ffa334efa24cb8f2f0f622a9b9febf8b483c0b865bfb3475", size = 35264159, upload-time = "2026-02-23T00:20:23.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/77/d3ed4becfdbd217c52062fafe35a72388d1bd82c2d0ba5ca19d6fcc93e11/scipy-1.17.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:dbc12c9f3d185f5c737d801da555fb74b3dcfa1a50b66a1a93e09190f41fab50", size = 35102771, upload-time = "2026-02-23T00:20:28.636Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12'",
+]
+dependencies = [
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/74/66de6258867beb2ef08f35f9f2ac017a52cacd5081714d239ff1a442d458/scipy-1.18.1.tar.gz", hash = "sha256:52c4b7422442aba924d03ad4019852b08a92e64ea187b933135687bfe2747307", size = 30781235, upload-time = "2026-08-21T23:28:50.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/f7/240c110c08693826b4513a52f5717d62ec7c7af72f2920821247c03b17b3/scipy-1.18.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:457fd7a2a8edeb044ab6ffbc0aa03ff6cd18491356e5e0c834d76ce621b916d1", size = 31111061, upload-time = "2026-08-21T23:23:44.522Z" },
+    { url = "https://files.pythonhosted.org/packages/05/4a/78c6285577c375e7cf27277ea8ee6961224327f1e1a0c44af5f17f23635c/scipy-1.18.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:e708533e8b2ae2497d65346538a7dcc92814410b25b81432eac66de0f2af8265", size = 28733332, upload-time = "2026-08-21T23:23:50.015Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f6/a5b82f8abbe14d134691b8b903696f701d25a081353a29dc655c364d9e62/scipy-1.18.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:7bbf207c4453ce1ad2e00b17313852b33310b83090c2311bdaf97f93c0380d12", size = 20475078, upload-time = "2026-08-21T23:23:54.138Z" },
+    { url = "https://files.pythonhosted.org/packages/23/22/0858a0bbd6b3e825ceb8cd9baf9eaf3b2f2b1d77727eb6be40500bcdc92f/scipy-1.18.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:78c0665edead396b1abb4897c41a5c1d9bf090c8a637a4c20a61678e0a264e66", size = 23108904, upload-time = "2026-08-21T23:23:57.824Z" },
+    { url = "https://files.pythonhosted.org/packages/75/9a/2e71719f31eaefe0e3a1706c4a1ded94e664bfd95ffca2b219a671faee01/scipy-1.18.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3c085faa2cfa879c5141df483f836f4d691045a078224a670fa570fa01612d89", size = 34025113, upload-time = "2026-08-21T23:24:02.209Z" },
+    { url = "https://files.pythonhosted.org/packages/df/64/ff35eb9e54894cf471ff4716abd3c81eb0a0626869217ce3e6ba4ccf17d7/scipy-1.18.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f55fa87b6c612ecd6b058f167c53231b1d14e412efe361d3d6e38b3631c73218", size = 35344199, upload-time = "2026-08-21T23:24:07.844Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/af/c5538be1792f7034c12c7db6ee67cace58253c7b87b122d68253eaf5de89/scipy-1.18.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c35d74ce0e193ff740c2f2be2ac913ddc232fe6c1ff40b26cfecb9c670c63314", size = 35639587, upload-time = "2026-08-21T23:24:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4c/075e4f66471bac101141ac739e9e135549be1bae584571bd03a530c056e1/scipy-1.18.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d2924a03db38dc2e848bca2fe9f077dafb891480b91a00a0963a8cf86dfc31c1", size = 37480330, upload-time = "2026-08-21T23:24:19.608Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e7/979fd14e75008623df31ba70d6bb144700f68feadcea042021c06a05bf82/scipy-1.18.1-cp312-cp312-win_amd64.whl", hash = "sha256:5e4d44984abc0020154ea81b247adeddcc3ac5527b975ff798bd1ba0adc513c2", size = 36658278, upload-time = "2026-08-21T23:24:25.463Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/e1525354ff9d7d5feb6d1b31af6d14072e5c91e9607b421fa1ec889660b3/scipy-1.18.1-cp312-cp312-win_arm64.whl", hash = "sha256:d65d448389b8436493abcf629cc94ad0cf32aecaf06e1acca1de53cc795f2f12", size = 24400588, upload-time = "2026-08-21T23:24:30.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/4540ee0f9c42a9ad7109d0d1a8cc70de54c3572b01c6693a2b1c70e90ceb/scipy-1.18.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:3ab3523da44749156e1f68b464dc56af11ae4cbc5c739a49d05f32b982eca9f3", size = 31089958, upload-time = "2026-08-21T23:24:35.8Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/f5/769f36d14922b8071a43e95d24d18b6bdafad10d7f5cf647867e1ac052bc/scipy-1.18.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e6fb6a55cc0ba97b59a1f288fb86dc6fce8bdfc0fffcbfd015e3a954bf2a2d93", size = 28715106, upload-time = "2026-08-21T23:24:40.775Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/d7/21d890274f75ea37a8209d5519e72da3da90302e3b9fb8397a0918386a62/scipy-1.18.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:ea324d9dd34c38bfb9bec8ca4d1b407db97dbb74029f566b8e322b1b6fe56fe6", size = 20456846, upload-time = "2026-08-21T23:24:45.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/01/798430ecea2e78ec7c02663d5f71c007bb6abeca931080debd40d7fa55ea/scipy-1.18.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:75b00eb8fb802090aa903f4ea1c7f5a584779f967361e68b7e98e531cc2d7174", size = 23087986, upload-time = "2026-08-21T23:24:49.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5f/4634e9d35c68496e4e34cb6946eafab044458e6cedab42b40b6588e475b6/scipy-1.18.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d416b16cccfd70fbf62400e84d0bb2f4e6af519a45557f1692c749b37f14b315", size = 33998146, upload-time = "2026-08-21T23:24:54.714Z" },
+    { url = "https://files.pythonhosted.org/packages/41/48/6450ed9243315322bbc19ac57b9b70d66a20bf1d38d124c96bc4bf6af9ea/scipy-1.18.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fdaf5ea890a6183d0565f51a61799d67081bd5b1cf03c5f4b3fd3732108625c9", size = 35312578, upload-time = "2026-08-21T23:25:00.44Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bd/bf5a4be6a3525676499f6dff307991739ff6fdcad1481b1aeb6745339f58/scipy-1.18.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c825cef2f49e46753726a7181a8e199804a912b29519ada542c6ebc654951899", size = 35612621, upload-time = "2026-08-21T23:25:06.144Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/4e/3c45c33e00a77996c4b1cb707929f833ba7b1d522ee29f882512c330676d/scipy-1.18.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e3b417bf8c2c7c16e8f58ad91db17783ec911ac16e7b50eb6eab6e809b4f5b07", size = 37457323, upload-time = "2026-08-21T23:25:12.483Z" },
+    { url = "https://files.pythonhosted.org/packages/93/0e/e0348fbc0dbab65c114cf78957e7dfeb49f8e8b556b4d930cc12ff195e18/scipy-1.18.1-cp313-cp313-win_amd64.whl", hash = "sha256:559ed65f60c1af5a03f3912605a1b5114f522c7c32fb23c3376ae8f03219fe28", size = 36622841, upload-time = "2026-08-21T23:25:18.722Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/6a77f5f267c555108f0a864b6db714363dab567a8266422a79a385f9232b/scipy-1.18.1-cp313-cp313-win_arm64.whl", hash = "sha256:cd479fc04dd9401e3b4f49e76518768ef99c4f517a98c284eb091fd725719adf", size = 24399315, upload-time = "2026-08-21T23:25:23.458Z" },
 ]
 
 [[package]]

--- a/specs/free-generative-assist-spec.md
+++ b/specs/free-generative-assist-spec.md
@@ -1,0 +1,387 @@
+> Last updated: 2026-09-01 00:15
+
+# Free Generative Assist Specification
+
+## 1. Summary
+
+Add an explicit, opt-in `generativeAssist` path to img2threejs that can obtain a generated reference mesh without monetary spend. The feature extends the existing hosted TRELLIS proof of concept into a provider-neutral, resumable, quality-gated workflow.
+
+The first implementation supports:
+
+1. `hf-zerogpu-trellis` — preferred hosted provider.
+2. `hf-zerogpu-sf3d` — faster hosted fallback, selected only by the user.
+3. `local-sf3d` — optional Apple Silicon fallback installed and run locally only after a separate license and disk-impact approval.
+
+The monetary budget is immutable: `maxCostUsd = 0`. The feature must fail closed if a provider, account, endpoint, or request could create a charge.
+
+## 2. Problem
+
+The core pipeline reconstructs an object from images as procedural TypeScript and Three.js geometry. This preserves editability and avoids runtime assets, but a single image provides limited evidence for curved surfaces, hidden faces, irregular silhouettes, and dense architectural details.
+
+The repository already contains `integrations/mesh3d/generate_reference_mesh.py`, which can call a hosted TRELLIS Space and emit GLB and OBJ files. It is a standalone external helper rather than a complete pipeline capability. It does not provide:
+
+- a stable provider interface;
+- a strict zero-spend admission gate;
+- reviewable routing and fallback decisions;
+- quota-aware caching and resumability;
+- normalized provenance and failure reports;
+- a Stable Fast 3D fallback;
+- an explicit user approval boundary for uploads and gated licenses.
+
+## 3. Goals
+
+- Generate a GLB/OBJ reference proxy from one or more input images without monetary spend.
+- Reuse the current TRELLIS integration rather than replacing it.
+- Make provider selection explicit, inspectable, and deterministic.
+- Preserve the procedural img2threejs output as the default deliverable.
+- Treat generated meshes as fallible measurement evidence, never as ground truth.
+- Avoid duplicate generation through content-addressed caching.
+- Preserve completed provider output if later conversion, validation, or review fails.
+- Keep credentials out of source files, command arguments, logs, reports, and Git.
+- Work from macOS by using hosted ZeroGPU services; offer local SF3D only where the Mac meets its requirements.
+
+## 4. Non-goals
+
+- Paid Tripo, Meshy, Replicate, Fal, cloud GPU, or Hugging Face upgraded hardware.
+- Automatic credit purchase, automatic refill, subscription activation, or billing setup.
+- Circumventing provider quotas, queues, authentication, license gates, or rate limits.
+- Automatically accepting Hugging Face or Stability AI terms.
+- Training or fine-tuning a 3D model.
+- Running TRELLIS or TRELLIS.2 locally on Apple Silicon.
+- Shipping a downloaded GLB silently in place of the code-only Three.js deliverable.
+- Treating a successful provider response as proof that the visual result is acceptable.
+- Background retry loops that repeatedly consume daily free quota.
+
+## 5. Considered approaches
+
+### A. Keep the standalone TRELLIS script
+
+Smallest change, but it leaves cost admission, provider fallback, caching, provenance, and resumability as manual conventions. This does not meet the zero-spend safety requirement.
+
+### B. Provider-neutral free-assist orchestrator — selected
+
+Wrap the existing TRELLIS logic and a new SF3D adapter behind a narrow provider protocol. A deterministic preflight admits only providers proven to be free for the current request. This adds the required controls without changing the stdlib-only `forge/` core.
+
+### C. Import provider GLBs directly at runtime
+
+Fastest route to visible detail, but it breaks the code-only runtime contract, reduces semantic editability, and makes the application depend on externally generated topology. This remains outside the first implementation.
+
+## 6. Architecture
+
+The integration remains isolated under `integrations/mesh3d/`. The stdlib-only `forge/` pipeline receives only normalized artifacts and reports.
+
+```text
+reference image(s)
+        |
+        v
+free-assist preflight
+  - provider allowlist
+  - live endpoint class
+  - authentication state
+  - zero-cost proof
+  - local capability check
+        |
+        +-- DENY / NEEDS_USER_ACTION --> report, no generation
+        |
+        v
+explicit upload/run approval
+        |
+        v
+one selected provider adapter
+        |
+        v
+immutable raw result + generation receipt
+        |
+        v
+GLB inspection and GLB -> OBJ normalization
+        |
+        v
+img2threejs review gates
+        |
+        v
+procedural TypeScript reconstruction
+```
+
+### 6.1 Provider protocol
+
+Each adapter implements the following conceptual interface:
+
+```python
+class FreeMeshProvider(Protocol):
+    provider_id: str
+
+    def preflight(self, request: GenerationRequest) -> ProviderPreflight: ...
+    def generate(self, request: GenerationRequest, run_dir: Path) -> RawGeneration: ...
+    def normalize(self, raw: RawGeneration, run_dir: Path) -> MeshArtifacts: ...
+```
+
+Adapters must not decide whether another provider should run. Routing belongs exclusively to the orchestrator.
+
+### 6.2 Provider registry
+
+The registry contains only the three provider IDs in this specification. Provider URLs and expected free execution classes are exact allowlisted values, not arbitrary user-controlled endpoints.
+
+An override such as `--space` may select another Hugging Face Space only in developer mode. Developer-mode overrides are always classified `UNVERIFIED` and cannot pass the zero-spend gate without a new reviewed registry entry.
+
+### 6.3 Separation from `forge/`
+
+Third-party dependencies such as `gradio_client`, `huggingface_hub`, `torch`, and SF3D remain in the integration environment. No dependency is added to the stdlib-only `forge/` core.
+
+## 7. Zero-spend contract
+
+Every run has the following immutable policy:
+
+```json
+{
+  "maxCostUsd": 0,
+  "allowPaidFallback": false,
+  "allowCreditPurchase": false,
+  "allowAutomaticRetry": false,
+  "allowAutomaticProviderSwitch": false
+}
+```
+
+There is no command-line flag that raises `maxCostUsd` in this feature. Paid support, if ever desired, requires a separate specification and implementation.
+
+A hosted provider is admitted only when all of these are true:
+
+- its provider ID and endpoint match the checked-in allowlist;
+- its live Hugging Face hardware class is ZeroGPU or another explicitly reviewed free class;
+- the request does not require upgraded hardware, prepaid credits, or a subscription;
+- the client is not configured to extend quota using paid credits;
+- the provider terms do not require an action that the user has not completed;
+- the user has explicitly approved uploading the named source images to that provider;
+- no prior successful result exists for the same cache key.
+
+If live zero-cost status cannot be established, preflight returns `DENY`, not a warning.
+
+## 8. Provider behavior
+
+### 8.1 `hf-zerogpu-trellis`
+
+- Uses the existing `trellis-community/TRELLIS` Space and current session bootstrap sequence.
+- Accepts one primary image and optional additional views.
+- Preserves deterministic seed and mesh simplification settings in the receipt.
+- Requests one generation only.
+- Emits the downloaded GLB as an immutable raw artifact before local conversion.
+- Remains the preferred provider because the current pipeline already understands its response and multi-view input.
+
+### 8.2 `hf-zerogpu-sf3d`
+
+- Uses the official `stabilityai/stable-fast-3d` ZeroGPU Space.
+- Is never invoked automatically after TRELLIS failure.
+- Requires a new user approval because it uploads the images to a different provider surface.
+- Normalizes its output into the same GLB/OBJ/report contract.
+- Records the Stability AI model/license identifier in provenance.
+
+### 8.3 `local-sf3d`
+
+- Is disabled until a local capability preflight passes.
+- Requires Apple Silicon or a supported CPU/GPU path, sufficient free disk, and sufficient memory.
+- Requires the user to review and personally accept the gated model terms; the pipeline must not accept them.
+- Requires a separate installation approval because it downloads model weights and creates an environment.
+- Does not require or use billing credentials.
+- Uses CPU fallback when MPS is unavailable or the configured memory safety threshold rejects MPS.
+
+Local installation is a fallback capability, not part of the hosted-provider MVP acceptance test.
+
+## 9. Routing and user approvals
+
+Preflight returns exactly one of:
+
+- `ALLOW` — the selected provider is proven zero-cost and all non-financial prerequisites are satisfied.
+- `NEEDS_USER_ACTION` — login, email verification, license acceptance, upload approval, or local installation approval is missing.
+- `DENY` — free status is unverified, quota is known exhausted, endpoint class is not allowlisted, or a paid action may occur.
+- `UNAVAILABLE` — endpoint is paused, unhealthy, incompatible, or the local machine lacks required capability.
+
+The orchestrator presents the decision and evidence before any provider call. Confidence or provider availability must never start a job automatically.
+
+Fallback is manual and resumable:
+
+1. A failed TRELLIS run records its receipt and stops.
+2. The user may approve SF3D hosted as a new run.
+3. The user may separately approve local SF3D installation and execution.
+
+## 10. CLI contract
+
+The intended interface is:
+
+```bash
+python -m integrations.mesh3d.free_assist preflight \
+  reference/front.png \
+  --provider hf-zerogpu-trellis \
+  --out-dir artifacts/my-object/free-assist
+
+python -m integrations.mesh3d.free_assist generate \
+  reference/front.png \
+  --provider hf-zerogpu-trellis \
+  --out-dir artifacts/my-object/free-assist \
+  --approve-upload
+
+python -m integrations.mesh3d.free_assist resume \
+  --run artifacts/my-object/free-assist/runs/<run-id>
+```
+
+`generate` refuses to run without a current passing preflight and explicit `--approve-upload`. The approval applies only to the listed files, provider ID, endpoint, parameters, and cache key.
+
+Authentication is discovered through the supported Hugging Face login/token store or `HF_TOKEN`. Tokens are never accepted as CLI values.
+
+## 11. Artifacts and provenance
+
+Each run writes to a unique directory and never overwrites a previous run:
+
+```text
+free-assist/
+  cache-index.json
+  preflight.json
+  runs/<run-id>/
+    request.json
+    provider-receipt.json
+    status.json
+    raw/reference.glb
+    normalized/reference.glb
+    normalized/reference.obj
+    normalized/reference-mesh.json
+    review/admission.json
+    review/preview.png
+```
+
+`request.json` stores hashes and relative artifact paths, not credentials. `provider-receipt.json` records provider, endpoint, model/version when exposed, seed, parameters, timestamps, provider task ID, quota class, and declared monetary cost of zero.
+
+Provider URLs that embed temporary signatures are redacted. Logs and reports must never contain authorization headers, query tokens, cookies, or full environment dumps.
+
+## 12. Cache and quota preservation
+
+The cache key is computed from:
+
+- ordered SHA-256 hashes of all input images;
+- provider ID and reviewed endpoint version;
+- generation parameters;
+- normalizer version.
+
+A successful cached generation is reused without network access. A failed local normalization resumes from `raw/reference.glb`; it must never regenerate the mesh merely because conversion or validation failed.
+
+Provider failures are not automatically retried. Retry requires a new explicit run approval so free daily quota cannot be consumed in a loop.
+
+## 13. Generated-mesh admission
+
+The generated mesh is a proxy, not ground truth. Before it can influence reconstruction, the pipeline checks:
+
+- valid GLB magic and readable JSON chunk;
+- non-empty mesh and material inventory;
+- supported compression or a usable normalized OBJ fallback;
+- finite bounds and non-degenerate scale;
+- triangle and vertex budgets;
+- axis agreement between GLB and OBJ;
+- preview render against the original image;
+- silhouette, aspect, and scale metrics;
+- human review of invented hidden surfaces where relevant.
+
+A provider task marked successful can still fail mesh admission. Failure preserves all evidence and leaves the procedural image-only path available.
+
+## 14. Privacy, licensing, and credentials
+
+- The preflight identifies exactly which files will leave the machine.
+- No upload occurs during preflight or automated tests.
+- Public/free provider outputs must be treated according to their current visibility and license terms.
+- The system records, but does not interpret as legal advice, the provider/model license identifier.
+- Hugging Face and Stability AI terms are presented for user action when required; the pipeline cannot click or accept them.
+- `.env`, shell history, repository configuration, and generated reports must not store tokens.
+- Tests use fake tokens and fixture endpoints only.
+
+## 15. Failure handling
+
+Normalized failure categories are:
+
+- `free_status_unverified`
+- `quota_exhausted`
+- `queue_timeout`
+- `provider_unavailable`
+- `authentication_required`
+- `license_acceptance_required`
+- `upload_not_approved`
+- `local_capability_missing`
+- `invalid_provider_response`
+- `invalid_glb`
+- `normalization_failed`
+- `mesh_admission_failed`
+
+Every failure records whether the run is resumable and the last durable artifact. Raw successful provider output is always a recovery boundary.
+
+## 16. Testing strategy
+
+### Unit tests
+
+- Provider registry admits only reviewed free providers.
+- Any paid, unknown, or overridden endpoint fails closed.
+- `maxCostUsd` is always zero and cannot be raised.
+- Tokens and signed URLs are redacted from reports and exceptions.
+- Cache keys change when inputs, provider, endpoint version, or parameters change.
+- Existing raw GLB output prevents duplicate provider generation.
+- Provider failure never triggers an automatic retry or provider switch.
+
+### Integration tests
+
+- Fixture TRELLIS and SF3D responses normalize to the same artifact contract.
+- Interrupted normalization resumes from the saved raw GLB.
+- Compressed and uncompressed GLBs follow the correct admission paths.
+- A provider success with an invalid GLB is rejected.
+- The procedural image-only pipeline remains usable after every failure category.
+
+### Live acceptance
+
+One user-approved TRELLIS ZeroGPU run is performed with a non-sensitive test image. Acceptance requires:
+
+- a live preflight proving an allowlisted ZeroGPU endpoint;
+- no payment method, subscription, purchased credit, or paid hardware action;
+- exactly one provider generation request;
+- persisted GLB, OBJ, provenance, preview, and admission report;
+- confirmation that no automatic fallback ran;
+- a browser comparison against the input image.
+
+The live run is not part of automated CI because it consumes shared free quota and depends on an external queue.
+
+## 17. Documentation requirements
+
+Documentation must explain:
+
+- what “free” guarantees and what it does not;
+- current ZeroGPU quota and queue caveats without hard-coding them as permanent facts;
+- how to log in through supported Hugging Face tooling;
+- how to inspect a preflight before approving an upload;
+- how to resume without regeneration;
+- why Meshy Free is excluded from API automation;
+- why Tripo Studio Free is a manual option rather than a guaranteed free API provider;
+- why local TRELLIS is excluded on Apple Silicon;
+- Stable Fast 3D license, model-access, memory, and disk prerequisites.
+
+## 18. Acceptance criteria
+
+The feature is complete only when all of the following are true:
+
+- The provider-neutral orchestrator supports the three provider IDs in this specification.
+- Preflight is read-only and performs no image upload.
+- Unknown, paid, or unverifiable providers return `DENY`.
+- No code path can create monetary spend or extend paid quota.
+- Every network generation requires exact provider/file approval.
+- No failure automatically consumes a second generation.
+- Successful raw outputs are cached and resumable.
+- TRELLIS and SF3D hosted outputs normalize to one artifact schema.
+- Credentials are absent from Git, CLI arguments, reports, and captured logs.
+- Generated meshes pass explicit admission before influencing reconstruction.
+- The original procedural pipeline and existing standalone script remain backward compatible.
+- Automated tests use no external quota.
+- A separately approved live ZeroGPU run demonstrates the end-to-end path without monetary spend.
+
+## 19. Explicit exclusions from the first implementation
+
+- Tripo OpenAPI adapter.
+- Meshy API adapter.
+- Paid Hugging Face inference endpoints or upgraded Spaces.
+- TRELLIS.2 local installation.
+- Automatic model ranking based on visual scores.
+- Direct runtime shipping of provider GLBs.
+- Batch generation.
+- Web UI.
+- Provider webhooks.
+

--- a/specs/parent-local-frame-repair-spec.md
+++ b/specs/parent-local-frame-repair-spec.md
@@ -1,0 +1,159 @@
+> Last updated: 2026-09-01 22:30
+
+# Parent-local frame repair — whimsical-hearth-house spec + frame-sanity gate
+
+## Problem
+
+The generated factory for `whimsical-hearth-house` renders with floating parts
+(chimney, roof, finial, door, dormer). Root cause, verified in this session:
+
+- The ObjectSculptSpec contract authors `transform.position` and
+  `attachment.localStart/localEnd` in **parent-local coordinates**
+  (`grimoire/readiness/joint_attachment.md`; the canonical
+  `electric-mouse-mascot` spec follows it — e.g. `head` at `[0, 0.238, 0]`
+  relative to `neck`).
+- The whimsical-hearth-house spec violates the contract: children of
+  `house-main` (chimney `[-2.2, 6.35, -0.3]`, roof-main `[0, 5.45, 0.25]`,
+  front-door, front-dormer, chimney-smoke, …) are authored in **object-frame
+  absolute** coordinates.
+- `generate_threejs_factory.py` is correct: it parents each node under
+  `nodes[parent]` and applies the position as local
+  (`forge/stage3_build/generate_threejs_factory.py:3630-3635`), so every
+  child of `house-main` is displaced by house-main's own offset
+  `(0, 2.65, 0.3)` — chimney lands at world y 9.0 instead of 6.35.
+- `validate_sculpt_spec.py --strict-quality` passes the malformed spec: no
+  gate relates a child's parent-local position to its parent's bounds, so an
+  object-frame spec sails through and the defect only appears at render time.
+
+## Goals
+
+1. Repair the whimsical-hearth-house spec to the parent-local contract and
+   prove the regenerated factory assembles (browser render, no floating
+   parts).
+2. Close the validation gap with a deterministic frame-sanity check so the
+   next object-frame spec is caught at validation time, not at render time.
+3. Re-run the dense-evidence A/B on the repaired baseline. The existing
+   hash-bound admission dies with the spec change **by design** (it binds
+   `targetSpecSha256`); a new admission requires a fresh explicit user
+   approval.
+
+## Non-goals
+
+- Changing the generator's parenting or transform semantics (it follows the
+  contract; changing it would break every conforming spec).
+- Migrating or re-authoring any other shipped spec (mascot and knife specs
+  already conform).
+- Touching the bespoke shipped demo factory.
+
+## Task A — repair the spec
+
+New one-shot converter `forge/stage2_spec/rebase_component_frames.py`:
+
+- Input: a spec whose component positions are object-frame; output: a new
+  spec file (never in place) with, for every component whose parent is not
+  `root`: `position_local = position_object - parent_position_object`
+  (recursive down the tree, rotations are all zero in this spec — the script
+  refuses non-zero parent rotations rather than guessing).
+- Applies the same rebase to `attachment.localStart` / `localEnd`.
+- Emits a JSON report of every changed field (old → new) for review.
+- Run it on `src/demos/whimsical-hearth-house/object-sculpt-spec.json` in the
+  showcase worktree, validate with `--strict-quality`, regenerate the
+  factory, and capture browser renders (front + three-quarter) proving the
+  assembly — the existing mandatory screenshot gate applies.
+
+## Task B — frame-sanity gate in validate_sculpt_spec
+
+New deterministic check (warning by default, failure under
+`--strict-quality`): for each component with a non-root parent that declares
+numeric dimensions on both sides, flag when the child's parent-local
+position magnitude on any axis exceeds `(P + child_half_extent) * 1.5`,
+where `P` is the parent's **full** extent when the parent's primitive is in
+`ATTACHMENT_PRIMITIVES` (its pivot then sits at `attachment.localStart`,
+typically the part's base, so children legitimately reach the far end) and
+the parent's **half** extent for center-pivoted primitives — a child that
+far outside its parent's volume is almost certainly authored in the wrong
+frame. The message names both frames and points at
+`rebase_component_frames.py`.
+
+- Threshold rationale (revised during implementation — the drafted
+  `parent_half * 2.5 + child_half` formula did NOT flag the observed chimney
+  case: 6.35 < 2.4·2.5 + 1.5): with `(P + child_half) * 1.5`, the pre-repair
+  house spec produces 7 findings (roof-main, roof-wing, chimney,
+  front-dormer, front-door, gutter-system, chimney-smoke) while the repaired
+  house spec and every conforming shipped showcase spec stay at zero — the
+  test suite proves both directions.
+- Focused tests in `forge/tests/`: object-frame spec fails strict, conforming
+  specs stay green, warning text names the converter.
+
+## Task A addendum — degenerate attachment segments (found during repair)
+
+The frame rebase alone still rendered five components as ~0.06-radius stubs:
+`garden-base`, `turret`, `turret-roof`, `gutter-system`, `garden-tree`. Their
+primitives are in `ATTACHMENT_PRIMITIVES`, so the generator derives their
+geometry as a strut from `attachment.localStart` to `localEnd` — and the
+machine-authored spec gave every attachment a degenerate 0.04-length marker
+segment. Second repair applied by hand to the same spec:
+
+- Author real segments spanning each part's extent plus `baseRadius` /
+  `endRadius` (island disc r 4.5, tower r 1.175, cone 1.5→0.05, gutter run
+  r 0.08 along x, trunk 0.35→0.2).
+- Because the endpoint branch moves the node pivot to `localStart`, children
+  of `garden-base` needed +0.225 y and `turret-roof` / `garden-tree` needed
+  re-authoring relative to the base pivot.
+
+## Task C — re-run the dense-evidence chain on the repaired baseline
+
+Order (each step is the existing tooling, no new code):
+
+1. `check_dense_evidence.py` against the repaired spec.
+2. New `admit_dense_influence.py` at `global-massing` — **pauses for the
+   user's explicit approval** (hash-bound to the new spec).
+3. `apply_dense_evidence.py` → new proposal/delta/fit-plan.
+4. Regenerate both factories, browser A/B with the same harness method
+   (archived in the run's `dense-evidence/ab/harness/`), metrics, gates,
+   `compare_dense_evidence.py` decision.
+
+Expected: with parts assembled, the turntable/intersection failure mode from
+the first A/B disappears or shrinks to real findings; the source-IoU/massing
+trade-off gets a clean read.
+
+## Acceptance
+
+- Regenerated whimsical factory renders assembled (screenshot evidence read
+  back, no floating parts).
+- `--strict-quality` fails the pre-repair spec with the new frame-sanity
+  category and passes the repaired one.
+- Full forge suite green locally and on GitLab CI.
+- A/B decision recorded; whatever it is, reported honestly.
+
+## Files
+
+- Create: `forge/stage2_spec/rebase_component_frames.py`, tests in
+  `forge/tests/test_rebase_component_frames.py`.
+- Modify: `forge/stage2_spec/validate_sculpt_spec.py`,
+  `forge/tests/test_validate_sculpt_spec.py` (or the existing validator test
+  module), `CHANGELOG.md`.
+- Modify in showcase worktree: `whimsical-hearth-house/object-sculpt-spec.json`
+  (repaired output replaces it only after review of the change report).
+
+## Execution record — 2026-09-01
+
+All three tasks completed; the user explicitly approved the new hash-bound
+admission ("ok decidi te, approvo tutto").
+
+- Task A: 69 fields rebased + 5 degenerate attachment segments re-authored
+  (see addendum). Assembly verified by browser captures, world-space mesh
+  bounds, comparison sheet and tier-1 diagnostics — evidence under the run's
+  `dense-evidence/repair/`.
+- Task B: frame-sanity gate live with the revised `(P + child_half) * 1.5`
+  threshold; 12 focused tests in `forge/tests/test_rebase_component_frames.py`;
+  full forge suite green locally (OK, 4 skips, showcase root set).
+- Task C: second A/B under `dense-evidence/ab2/` → **ALLOW**
+  (sourceRegression −0.024976, massingSimilarity +0.218512, all 5 gates
+  pass). Two first-run gate artifacts were root-caused and fixed in the
+  harness/method, not by relaxing rules: specular bands read as enclosed
+  background (matte override on both variants) and contract seams read as
+  penetrations (differential criterion: baseline authored contacts allowed,
+  candidate-only pairs individually reviewed). The proposal replaced the
+  accepted demo spec; the pre-ALLOW spec and the reversible 131-change delta
+  are preserved in the run.

--- a/specs/trellis-dense-evidence-integration-spec.md
+++ b/specs/trellis-dense-evidence-integration-spec.md
@@ -1,0 +1,563 @@
+> Last updated: 2026-09-01 03:00
+
+# TRELLIS Dense-Evidence Integration Specification
+
+## 1. Summary
+
+Connect an admitted TRELLIS or Stable Fast 3D reference mesh to the native img2threejs reconstruction pipeline as an optional measurement instrument. The provider GLB must improve measurement, fitting, and review without becoming the shipped model.
+
+The final deliverable remains a semantic, editable, code-only TypeScript/Three.js factory. The GLB may influence explicitly approved dimensions and profiles only after structural admission, browser review, semantic-confidence checks, and a human-selected influence scope.
+
+This specification extends `free-generative-assist-spec.md`. It does not change its immutable `maxCostUsd = 0`, upload approval, provider allowlist, retry, fallback, caching, credential, or raw-artifact rules.
+
+## 2. Current gap
+
+The repository currently has three separate capabilities:
+
+1. `integrations/mesh3d/free_assist/` obtains, normalizes, caches, and structurally reviews provider GLBs.
+2. `forge/` converts image evidence and an `ObjectSculptSpec` into a staged procedural Three.js factory.
+3. `integrations/glb_character_pipeline/` can reconstruct a multipart character GLB through cross-sections, SDF sampling, and compact TypeScript encoding, but it is a separate character-specific workflow.
+
+There is no executable generic bridge from a completed `free_assist` run to `ObjectSculptSpec`, parameter fitting, or `generate_threejs_factory.py`. `render_bridge.py` can render a GLB for comparison, but it does not turn that GLB into semantic procedural decisions.
+
+Consequently, the current house acceptance run stops at:
+
+```text
+image -> TRELLIS -> GLB/OBJ -> normalization -> admission -> browser comparison
+```
+
+The required path is:
+
+```text
+image -> TRELLIS -> admitted GLB/OBJ
+                       |
+                       v
+             normalized dense evidence
+                       |
+                       v
+       explicit component/evidence mapping
+                       |
+                       v
+         bounded ObjectSculptSpec proposals
+                       |
+                       v
+     procedural Three.js build and A/B review
+```
+
+## 3. Goals
+
+- Use provider output for measurable global massing, proportions, silhouettes, cross-sections, and component dimensions.
+- Preserve the source image as the visible-identity and appearance authority.
+- Preserve `ObjectSculptSpec` as the semantic authority.
+- Produce only procedural TypeScript/Three.js runtime geometry.
+- Support generic static objects and buildings in the first implementation.
+- Reuse cached `free_assist` GLBs without another provider request.
+- Make every GLB-derived change traceable to a source hash, region, measurement, confidence, and spec field.
+- Restrict merged single-mesh GLBs to global evidence unless an explicit semantic mapping supplies stronger evidence.
+- Compare the evidence-assisted result against the image-only baseline before accepting changes.
+- Reject evidence that worsens source-image fidelity or contradicts critical features.
+- Keep optional third-party mesh dependencies outside the stdlib-only `forge/` core.
+
+## 4. Non-goals
+
+- Shipping the TRELLIS GLB, OBJ, texture, topology, or a renamed copy at runtime.
+- Encoding the full provider mesh as Base64 TypeScript for generic objects.
+- Automatically converting arbitrary triangles into a clean semantic component tree.
+- Treating inferred back, side, bottom, or occluded surfaces from a single image as ground truth.
+- Automatically admitting a provider result because structural checks passed.
+- Automatically rewriting handwritten TypeScript.
+- Replacing the existing character GLB pipeline.
+- Rigging or animation generation in the first generic-object implementation.
+- Retopologizing and exporting the TRELLIS mesh as the final asset.
+- Additional provider calls, automatic retries, provider switching, purchases, or paid inference.
+- Training, fine-tuning, or running TRELLIS locally.
+
+## 5. Considered approaches
+
+### A. Runtime hybrid: GLB base plus semantic Three.js overlays
+
+Keep the provider GLB in the application and add named procedural details around it. This preserves visual density quickly, but it breaks the code-only contract, leaves an opaque merged mesh at the center of the model, and makes editing, interaction, destruction, and rigging inconsistent.
+
+**Decision:** rejected.
+
+### B. Direct mesh post-processing
+
+Run cleanup, decimation, retopology, material repair, and optional rigging directly on the provider mesh. This can produce a better conventional asset, but the output remains provider topology rather than a semantic img2threejs factory. It is a valid future export mode, not the native-pipeline integration requested here.
+
+**Decision:** rejected for this feature.
+
+### C. Dense evidence to semantic procedural fitting
+
+Extract bounded geometric evidence from the admitted GLB, map only reliable regions to existing semantic component IDs, propose spec-level parameter changes, regenerate the procedural factory, and accept changes only through A/B review gates.
+
+**Decision:** selected. It raises the measurement ceiling while preserving editability, provenance, code-only output, and the existing pass system.
+
+## 6. Scope and routing
+
+### 6.1 First implementation
+
+The first implementation supports static `object` and `hybrid` subjects, including buildings, props, furniture, vehicles without articulated rigs, stylized environment pieces, and mechanical objects whose component tree can be authored from image evidence.
+
+### 6.2 Characters
+
+Character requests continue to use the existing image-driven character profile or the separately invoked `integrations/glb_character_pipeline/`. This specification may reuse its measurement ideas, but must not silently route a character into that integration.
+
+### 6.3 Route decision
+
+The route is explicit:
+
+- no admitted GLB: use the normal image-only `forge/` pipeline;
+- admitted merged GLB: allow `global-massing` evidence only;
+- admitted multipart or explicitly mapped GLB: allow reviewed `component-measurements` evidence;
+- character GLB: request the existing character-specific route or continue image-only;
+- rejected or visually unreviewed GLB: preserve it as an artifact but allow no influence.
+
+Availability or confidence must never start evidence extraction, spec mutation, or code generation automatically.
+
+## 7. Authority model
+
+The pipeline uses three authorities with non-overlapping responsibilities:
+
+1. **Source image authority**
+   - visible silhouette, visible feature placement, color, material appearance, lighting evidence, and identity-defining details;
+   - overrides the provider mesh when the two disagree in the observed view.
+2. **ObjectSculptSpec authority**
+   - component IDs, hierarchy, topology classes, pivots, sockets, interactions, repetition systems, materials, and build-pass order;
+   - cannot be invented from an unlabeled merged mesh.
+3. **Generated-mesh evidence authority**
+   - admitted global bounds, coarse occupancy, cross-sections, relative depths, principal directions, and explicitly mapped component measurements;
+   - never owns semantics, appearance, hidden-surface truth, or runtime topology.
+
+Every conflict resolves in that order. A generated mesh is evidence, not a vote with equal authority.
+
+## 8. Architecture
+
+Optional mesh dependencies remain under `integrations/mesh3d/`. The bridge emits versioned JSON and review images that the stdlib-only core can validate and consume.
+
+```text
+free_assist completed run
+  raw/reference.glb
+  normalized/reference.glb
+  normalized/reference.obj
+  review/admission.json
+  review/visual-review.json
+             |
+             v
+integrations/mesh3d/dense_evidence/
+  validate admission and hashes
+  align GLB to source camera/object frame
+  extract global measurements
+  extract candidate regions when justified
+  emit dense-evidence.v1.json
+             |
+             v
+forge/stage1_intake/check_dense_evidence.py
+  stdlib schema, provenance, scope, and confidence gate
+             |
+             v
+explicit component-evidence-map.json
+             |
+             v
+forge/stage2_spec/apply_dense_evidence.py
+  emit proposed-object-sculpt-spec.json
+  emit spec-delta.json
+             |
+             v
+existing strict validation and locked build passes
+             |
+             v
+procedural TypeScript factory
+             |
+             v
+dual-baseline browser comparison
+  source image vs procedural render
+  provider GLB vs procedural geometry passes
+             |
+             v
+accept proposal or retain prior spec
+```
+
+The extractor and the core consumer communicate only through files. `forge/` must not import `trimesh`, SciPy, NumPy, Gradio, Hugging Face, or provider adapters.
+
+## 9. Proposed modules
+
+### 9.1 Optional integration modules
+
+- `integrations/mesh3d/dense_evidence/model.py` — evidence records, enums, and serialization.
+- `integrations/mesh3d/dense_evidence/extract.py` — GLB/OBJ geometry sampling and measurement extraction.
+- `integrations/mesh3d/dense_evidence/alignment.py` — object frame, source-camera, scale, chirality, and orientation alignment.
+- `integrations/mesh3d/dense_evidence/regions.py` — connected-component inventory and explicit semantic-map application.
+- `integrations/mesh3d/dense_evidence/cli.py` — offline `extract`, `propose-scope`, and `verify-cache` commands.
+
+These modules may depend on the existing mesh3d environment. They must never call a provider.
+
+### 9.2 Core modules
+
+- `forge/stage1_intake/check_dense_evidence.py` — pure-stdlib schema and admission validation.
+- `forge/stage2_spec/new_component_evidence_map.py` — seeds an explicit mapping against existing spec component IDs without claiming automatic semantics.
+- `forge/stage2_spec/apply_dense_evidence.py` — produces a new proposed spec and a machine-readable delta; never mutates the accepted spec by default.
+- `forge/stage4_review/compare_dense_evidence.py` — evaluates geometry passes against the GLB baseline and visible passes against the source image.
+- `forge/stage4_review/admit_dense_influence.py` — records the human-approved influence scope and review evidence.
+
+### 9.3 Existing modules reused
+
+- `forge/stage1_intake/probe_glb.py`
+- `forge/stage3_build/generate_threejs_factory.py`
+- `forge/stage3_build/orchestrate_passes.py`
+- `forge/stage4_review/render_bridge.py`
+- `forge/stage4_review/compare_region_passes.py`
+- `forge/stage4_review/fit_params.py`
+- `forge/stage4_review/append_review.py`
+- `forge/stage4_review/turntable_gate.py`
+- `forge/stage4_review/make_comparison_sheet.py`
+
+## 10. Evidence contract
+
+The extractor writes `dense-evidence.v1.json` with:
+
+```json
+{
+  "schemaVersion": 1,
+  "kind": "generated-mesh-dense-evidence",
+  "provenance": {
+    "providerRun": "runs/<run-id>",
+    "providerId": "hf-zerogpu-trellis",
+    "sourceImageSha256": "64-lowercase-hex-characters",
+    "glbSha256": "64-lowercase-hex-characters",
+    "extractorVersion": "dense-evidence-extractor-v1"
+  },
+  "admission": {
+    "structuralStatus": "pass",
+    "visualReviewStatus": "reviewed",
+    "approvedInfluenceScope": "global-massing"
+  },
+  "frame": {
+    "upAxis": "+Y",
+    "forwardAxis": "+Z",
+    "handedness": "right",
+    "sourceViewTransform": [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1],
+    "confidence": 0.91
+  },
+  "globalGeometry": {
+    "bounds": {},
+    "principalAxes": [],
+    "occupancyGrid": {},
+    "crossSections": [],
+    "silhouetteViews": []
+  },
+  "regions": [],
+  "uncertainty": {
+    "observedViews": [],
+    "hiddenSurfacePolicy": "non-authoritative",
+    "warnings": []
+  }
+}
+```
+
+The contract stores bounded measurements, not a full vertex/index copy. Occupancy is capped at `32^3` cells for global fitting in version 1. Cross-sections are capped and resampled to stable point counts. Large dense captures remain local intermediate files and cannot enter the generated factory.
+
+## 11. Semantic mapping
+
+### 11.1 Merged GLBs
+
+A one-node, one-mesh, one-primitive GLB has no reliable semantic boundaries. It may provide only:
+
+- global bounds and aspect ratios;
+- whole-object occupancy and silhouette;
+- coarse cross-sections;
+- source-view depth ordering with explicit monocular uncertainty.
+
+It must not claim that a triangle cluster is a roof, tower, window, wheel, limb, or other semantic part.
+
+### 11.2 Multipart GLBs
+
+Named nodes, separate primitives, materials, and disconnected components are candidate boundaries, not automatic labels. Component-level influence requires a `component-evidence-map.json` entry linking:
+
+- one existing `ObjectSculptSpec` component ID;
+- one or more GLB node, primitive, material, or reviewed region IDs;
+- mapping method and evidence;
+- confidence;
+- permitted measurement fields;
+- observed and hidden-view limitations.
+
+### 11.3 Explicit mapping gate
+
+The mapping validator rejects:
+
+- unknown spec component IDs;
+- overlapping exclusive mappings;
+- mappings derived only from texture color where geometry is claimed;
+- component confidence below `0.80`;
+- hidden-surface measurements from single-view generation;
+- any mapping whose source GLB hash differs from the admitted run.
+
+## 12. Influence scopes
+
+Influence is deny-by-default and has exactly three scopes:
+
+1. `none`
+   - evidence may be rendered and inspected but cannot change the spec.
+2. `global-massing`
+   - may propose object-level width, height, depth, center, orientation, global profile, and coarse silhouette parameters;
+   - cannot add, delete, rename, or reshape semantic components independently.
+3. `component-measurements`
+   - includes global massing;
+   - may propose allowlisted dimensions and geometry-descriptor parameters for explicitly mapped components;
+   - cannot change hierarchy, topology class, materials, pivots, sockets, or interactions without the normal spec review.
+
+There is no `full-mesh`, `copy-topology`, or `automatic` scope.
+
+`admit_dense_influence.py` requires the exact GLB hash, evidence hash, visual-review report, selected scope, and target spec hash. Approval applies only to that tuple and becomes invalid when any member changes.
+
+## 13. Alignment and measurement
+
+Before measurements can influence the spec, the adapter must establish:
+
+- valid glTF right-handed coordinates and declared scale;
+- project coordinate convention: Y up, forward +Z;
+- chirality through asymmetric visible landmarks when available;
+- normalized object center and bounds;
+- source-view camera alignment against the original image;
+- foreground silhouette agreement;
+- evidence for any axis swap, reflection, or rotation.
+
+Alignment may use source-image silhouette and a browser-rendered GLB. It must never choose an orientation solely because it produces a numerically smaller bound.
+
+Initial admission thresholds are versioned configuration, not scattered constants:
+
+- source-view whole-object silhouette IoU at least `0.65` for `global-massing`;
+- source-view silhouette IoU at least `0.75` for `component-measurements`;
+- projected aspect-ratio error at most `15%`;
+- mapping confidence at least `0.80` per influenced component;
+- finite, non-degenerate dimensions and consistent GLB/OBJ axes.
+
+Threshold failure reduces the proposed scope or returns `DENY`; it never silently relaxes a threshold.
+
+## 14. Spec proposal and fitting
+
+`apply_dense_evidence.py` reads an already valid spec and emits:
+
+- `proposed-object-sculpt-spec.json`;
+- `spec-delta.json` containing old value, proposed value, measurement, confidence, source region, and reason;
+- `fit-plan.json` containing the bounded parameter set and review views.
+
+It does not edit the accepted spec in place.
+
+The fitting loop follows these rules:
+
+- fit global massing before component form;
+- fit geometry before materials and lighting;
+- change one component or one correction group per iteration;
+- use only allowlisted numeric fields and compatible geometry descriptors;
+- preserve component hierarchy and topology class;
+- cap each numeric delta according to the spec quality contract;
+- stop on plateau, oscillation, gate regression, or the normal correction-loop budget;
+- regenerate the factory from the proposed spec rather than patching generated TypeScript as the only source of truth.
+
+The provider mesh cannot create a new component. Missing identity-defining components must come from source-image analysis and normal spec authoring.
+
+## 15. Dual-baseline review
+
+The evidence-assisted build must be compared against two different baselines:
+
+### 15.1 Source-image baseline
+
+Authoritative for:
+
+- source-view silhouette;
+- visible feature position and scale;
+- visible component relationships;
+- materials, color, lighting response, and identity.
+
+### 15.2 Provider-GLB baseline
+
+Advisory for:
+
+- coarse three-dimensional massing;
+- admitted source-facing cross-sections and relative depth;
+- explicitly mapped component geometry;
+- orbit-view continuity, with hidden surfaces marked as generated hypotheses.
+
+The candidate is accepted only when:
+
+- no critical source-image feature regresses;
+- source-view silhouette IoU decreases by no more than `0.02` from the image-only baseline;
+- at least one declared evidence-target metric improves by `0.01` or more;
+- turntable, attachment, intersection, strict-quality, and pass-order gates remain clean;
+- the change stays within the approved influence scope;
+- browser evidence and hashes are recorded.
+
+If the provider mesh and source image disagree, improving agreement with the GLB is not success.
+
+## 16. Hidden surfaces and uncertainty
+
+For a single source image:
+
+- only the visible source-facing region can receive high confidence;
+- side confidence is capped at medium unless directly visible;
+- rear, bottom, and occluded surfaces are non-authoritative;
+- invented hidden details cannot add components or override the spec;
+- orbit renders exist to expose provider hallucinations, not validate them as truth.
+
+Multiple independently supplied source views may raise confidence only when their hashes, cameras, and coverage are recorded. Multiple renders generated from the same single-image GLB do not count as independent observations.
+
+## 17. State and artifacts
+
+The bridge adds an evidence directory beside the free-assist run without modifying raw provider artifacts:
+
+```text
+runs/<run-id>/
+  raw/reference.glb
+  normalized/reference.glb
+  normalized/reference.obj
+  review/admission.json
+  review/visual-review.json
+  review/preview.png
+  dense-evidence/
+    extraction-request.json
+    dense-evidence.v1.json
+    alignment.json
+    component-evidence-map.json
+    influence-admission.json
+    spec-delta.json
+    fit-plan.json
+    comparison-manifest.json
+    comparison-sheet.png
+    status.json
+```
+
+The normal `.img2threejs/state.json` receives a new optional `dense-evidence-admission` checklist item only when this route is selected. Image-only projects do not acquire a new mandatory step.
+
+## 18. Cache and resumability
+
+The dense-evidence cache key contains:
+
+- normalized GLB SHA-256;
+- normalized OBJ SHA-256;
+- source image SHA-256 values in order;
+- extractor version;
+- alignment-profile version;
+- component-map hash, when present;
+- measurement configuration hash.
+
+Extraction and fitting never call the provider. A changed component map invalidates only mapping and downstream proposals, not geometry extraction. A failed local fit resumes from persisted evidence and never regenerates the GLB.
+
+## 19. Failure handling
+
+Machine-readable failure categories include:
+
+- `provider_run_incomplete`
+- `mesh_not_structurally_admitted`
+- `visual_review_missing`
+- `influence_not_approved`
+- `evidence_hash_mismatch`
+- `alignment_failed`
+- `chirality_ambiguous`
+- `semantic_boundary_insufficient`
+- `component_mapping_invalid`
+- `influence_scope_exceeded`
+- `fit_no_improvement`
+- `source_fidelity_regression`
+- `strict_quality_failed`
+- `browser_evidence_missing`
+
+Every failure preserves the cached GLB, extracted evidence, previous accepted spec, proposed spec, and comparison artifacts. The image-only path remains available.
+
+## 20. Security, cost, and privacy
+
+- The downstream bridge is offline and has no provider client.
+- It cannot upload images or meshes.
+- It cannot consume ZeroGPU quota.
+- It accepts no API token or credential argument.
+- It inherits the immutable `maxCostUsd = 0` provider contract.
+- Reports store hashes and local artifact references, never tokens or signed provider URLs.
+- Raw provider GLBs remain immutable.
+- Generated evidence is local and is not committed by default.
+
+## 21. Testing strategy
+
+### 21.1 Unit tests
+
+- evidence schema accepts valid records and rejects missing provenance;
+- merged one-mesh GLBs cannot receive component scope;
+- multipart boundaries remain candidates until explicitly mapped;
+- hash drift invalidates admission;
+- hidden surfaces from a single image remain non-authoritative;
+- scope validation blocks forbidden spec fields;
+- spec proposals are non-mutating and produce reversible deltas;
+- cache keys change for every authoritative input.
+
+### 21.2 Offline integration tests
+
+- cached free-assist fixture to global evidence without network access;
+- admitted multipart fixture to mapped component measurements;
+- invalid, mirrored, degenerate, over-budget, and visually rejected fixtures fail closed;
+- proposed spec passes existing validation before factory generation;
+- image-only pipeline output remains unchanged;
+- no test imports or constructs a provider adapter.
+
+### 21.3 Runtime tests
+
+- generate and typecheck the procedural factory in the companion showcase;
+- verify no `GLTFLoader`, `.glb`, `.obj`, binary fetch, or provider URL exists in runtime source;
+- capture source-view and turntable renders through the real Three.js route;
+- compare the image-only baseline, provider reference, and evidence-assisted candidate;
+- verify that rejected proposals leave the accepted spec and factory unchanged.
+
+### 21.4 Live acceptance
+
+Use the already cached whimsical-house TRELLIS run. No new upload or generation is allowed for the first bridge acceptance.
+
+Because that GLB is one merged mesh and its current review retains it as a proxy only, the initial acceptance may exercise extraction and `global-massing` proposal generation but must not approve component influence without a new explicit review decision. The test succeeds when the bridge respects this limitation; it does not need to force a visual improvement from unsuitable evidence.
+
+## 22. Implementation phases
+
+### Phase 1 — Contracts and global evidence
+
+- add schemas, extractor, alignment, cache, core validator, and `global-massing` scope;
+- use merged GLB fixtures and the cached house run;
+- do not mutate specs or generate code yet.
+
+### Phase 2 — Reversible spec proposals
+
+- add spec-delta generation and bounded global fitting;
+- generate a proposed factory through existing strict and pass gates;
+- retain the image-only factory as A/B baseline.
+
+### Phase 3 — Explicit component mapping
+
+- support multipart and reviewed region mappings;
+- add `component-measurements` scope and per-component fitting;
+- keep automatic semantic labeling outside scope.
+
+### Phase 4 — Dual-baseline browser acceptance
+
+- add comparison manifests, source/GLB geometry passes, regression gates, and influence admission;
+- complete the cached-house acceptance without any provider call.
+
+Character generalization, rigging, and direct mesh-export modes require separate specifications.
+
+## 23. Acceptance criteria
+
+The feature is complete only when all of the following are true:
+
+- A completed cached `free_assist` run can produce versioned dense evidence without network access.
+- The raw and normalized provider artifacts are not modified.
+- Merged GLBs are limited to global evidence.
+- Component-level influence requires an exact reviewed mapping and confidence gate.
+- Influence approval is bound to GLB, evidence, review, scope, and target-spec hashes.
+- The accepted `ObjectSculptSpec` is never overwritten by default.
+- Every proposed field change has provenance and a reversible delta.
+- Existing strict-quality and locked-pass gates remain authoritative.
+- The final runtime contains no provider GLB, OBJ, texture, loader, or URL.
+- The generated TypeScript factory remains semantic and editable.
+- A candidate cannot pass by matching the provider while regressing the source image.
+- Hidden surfaces generated from one image remain explicitly non-authoritative.
+- Cache and resume avoid repeated extraction, fitting, and provider generation.
+- Automated tests perform no external calls and consume no quota.
+- The existing image-only and GLB-character routes remain backward compatible.
+- The cached whimsical-house run demonstrates the offline bridge boundary and conservative scope behavior.
+
+## 24. Explicit approval boundary
+
+Approval of this specification authorizes only creation of an implementation plan. It does not authorize code changes, provider calls, new uploads, quota consumption, modification of accepted showcase models, commits, pushes, or deployment.


### PR DESCRIPTION
## Summary

- Adds an offline dense-evidence bridge that turns an already admitted, cached TRELLIS/SF3D GLB into bounded, reversible `ObjectSculptSpec` proposals: content-addressed extraction (`integrations/mesh3d/dense_evidence/`), pure-stdlib validation in `forge/`, deny-by-default influence scopes (`none` / `global-massing` / `component-measurements`) with hash-bound human approval, reversible spec deltas, and a dual-baseline browser comparator that rejects any candidate matching the advisory GLB while regressing the source image.
- Ships machine-readable contracts (`docs/specs/dense-evidence.v1.schema.json`, `component-evidence-map.v1.schema.json`), the operating guide (`docs/integrations/trellis-dense-evidence.md`), optional workflow-state routing (`state.py init --dense-evidence`), and honest README/ROADMAP/CHANGELOG/SKILL updates.
- The runtime stays code-only TypeScript/Three.js: runtime scanning rejects GLB/OBJ loaders, provider URLs, signed URLs, and copied mesh payloads. No provider call, upload, retry, or token argument exists anywhere in the bridge; `maxCostUsd = 0` is untouched.

## Acceptance run (cached whimsical-hearth-house, fully offline)

0 provider calls, $0 spend, immutable inputs hash-verified unchanged. The dual-baseline A/B compared two factories from the same generator (accepted spec vs proposed spec) across five browser views: the candidate improved the declared evidence target (massingSimilarity 0.649 → 0.923) but regressed source silhouette IoU by 0.0211 (cap 0.02) and left turntable/intersection gates dirty, so the comparator returned **DENY — image-only baseline retained**. The conservative boundary held exactly as designed; artifacts live with the cached run, outside this repo.

## Test plan

- `python3 -m unittest discover -s forge/tests -p 'test_*.py'` → 1169 tests OK (29 environment-dependent skips)
- `PYTHONPATH=. uv run --project integrations/mesh3d python -m unittest discover -s integrations/mesh3d/tests -t .` → 14 tests OK
- Credential scan, runtime-source scan, and `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TfH5LfB9uFTWMXEbuo3baX