### PR TITLE
Cross-platform portability, shared codec/CLI runtime, Divine Eye 6x caching, generator split

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,10 @@ python3 forge/stage3_build/generate_threejs_factory.py spec.json --out src/creat
 The factory generator repeats the strict-quality gate and is fail-closed: on failure it returns
 `BLOCKED` with the spec artifact, failure metrics, causes, and next action, and does not write a
 factory. `--allow-nonstrict` is only for explicit legacy test fixtures, never production output.
+Output is split by default: `src/createObjectModel.ts` imports only `three` (factory, lights,
+camera framing), while the presentation-only surface (environment, DOF/bloom composer, orbit
+controls) lands in a sibling `createObjectModel.harness.ts` — pass `--single-file` for the
+historical one-file layout.
 
 ### Copy-paste prompts for the GLB-reference route
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -193,7 +193,12 @@ Full flags: `grimoire/scripts.md`. Never let a script *score* visuals — that i
    The generator is fail-closed: `strict-quality` must pass before it writes any factory, and a
    future `--pass-id` fails until prior passes are reviewed `continue`. If blocked, preserve the
    `BLOCKED` artifact and refine the subject-specific spec; do not substitute a generic template.
-   The local state adds `--force` only for a new pass or `refine-spec`; `refine-code` edits the
+   By default the output is split: `createObjectModel.ts` imports only `three` (types, factory,
+   look-dev lights, camera framing, renderer config) and a sibling
+   `createObjectModel.harness.ts` carries the presentation-only surface (RoomEnvironment/PMREM
+   environment, DOF+bloom composer, orbit controls) so a host scene can embed the model without
+   the postprocessing stack. Pass `--single-file` for the historical one-file layout. The local
+   state adds `--force` only for a new pass or `refine-spec`; `refine-code` edits the
    current artifact without regenerating it. Before overwriting, carry valid hand refinement back
    into the spec; generated code must not be the only copy of reconstruction decisions.
 6a. **Hitting a triangle budget.** `performanceBudget.targetTriangles` selects a tessellation tier

--- a/forge/_shared/cli_run.py
+++ b/forge/_shared/cli_run.py
@@ -1,0 +1,86 @@
+"""Shared CLI exit handling for every forge entry point.
+
+Why this exists: `probe_image.py ref.png | head -5` used to blow up — head reads
+five lines, closes the pipe, and Python's write/shutdown flush then raised with
+a full traceback plus an "Exception ignored" line. A human reads that as the
+false error it is; an agent reads a non-zero exit and treats the command as
+failed, so piped diagnostics had to be hand-verified every time.
+
+Every command-line entry point routes its main() through run_entry(), which
+keeps real bugs loud and makes the environment-driven exits honest:
+  * pipe closed by the consumer — exit 141 (128+SIGPIPE), silent. On POSIX this
+    surfaces as BrokenPipeError; on Windows (notably under MSYS/Git-Bash pipes)
+    the same condition surfaces as OSError EINVAL/EPIPE/EINVAL, so all three are
+    recognised (the same mapping pip adopted for its CLI).
+  * KeyboardInterrupt — Ctrl-C: exit 130 (128+SIGINT), silent
+  * FileNotFoundError — one human-readable line on stderr, exit 66 (EX_NOINPUT)
+  * anything else — re-raised unchanged; a genuine traceback is the feature
+
+The flush happens INSIDE the guarded region (and again after main returns) so
+the consumer-closed-the-pipe case is caught whether it surfaces mid-main or at
+the final flush, instead of as the interpreter's "Exception ignored" noise.
+Pure stdlib, matching the rest of forge/.
+"""
+from __future__ import annotations
+
+import errno
+import os
+import sys
+from collections.abc import Callable
+
+EXIT_BROKEN_PIPE = 141  # 128 + SIGPIPE(13), the convention `head` users expect
+EXIT_INTERRUPTED = 130  # 128 + SIGINT(2)
+EXIT_NO_INPUT = 66  # EX_NOINPUT, BSD sysexits
+
+# Errnos that mean "the reader is gone" (POSIX EPIPE plus the Windows shapes of
+# the same condition, including the EINVAL MSYS pipes raise).
+_BROKEN_PIPE_ERRNOS = frozenset({errno.EPIPE, errno.EINVAL, errno.ESHUTDOWN})
+
+
+def _is_broken_pipe(error: BaseException) -> bool:
+    if isinstance(error, BrokenPipeError):
+        return True
+    return isinstance(error, OSError) and error.errno in _BROKEN_PIPE_ERRNOS
+
+
+def _silence_stdout() -> None:
+    """Point stdout at devnull so the final flush cannot re-raise on shutdown."""
+    try:
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+    except (OSError, ValueError):
+        pass
+
+
+def _hard_exit(code: int) -> None:
+    try:
+        sys.stderr.flush()
+    except Exception:  # noqa: BLE001 — stderr may itself be the closed pipe
+        pass
+    os._exit(code)  # bypass the interpreter-shutdown flush entirely
+
+
+def run_entry(main_fn: Callable[..., int], argv: list[str] | None = None) -> int:
+    """Run a main(argv) -> int entry point with pipeline-friendly exit handling."""
+    try:
+        result = main_fn(sys.argv[1:] if argv is None else argv)
+        try:
+            sys.stdout.flush()
+        except OSError as flush_error:
+            if not _is_broken_pipe(flush_error):
+                raise
+            _silence_stdout()
+            return EXIT_BROKEN_PIPE
+        return result
+    except KeyboardInterrupt:
+        _silence_stdout()
+        _hard_exit(EXIT_INTERRUPTED)
+    except FileNotFoundError as error:  # before OSError: FileNotFoundError is one
+        missing = error.filename or str(error)
+        print(f"error: file not found: {missing}", file=sys.stderr)
+        return EXIT_NO_INPUT
+    except OSError as error:
+        if not _is_broken_pipe(error):
+            raise
+        _silence_stdout()
+        _hard_exit(EXIT_BROKEN_PIPE)

--- a/forge/_shared/image_codec.py
+++ b/forge/_shared/image_codec.py
@@ -1,0 +1,398 @@
+"""Shared image decoding for every pixel-consuming forge script.
+
+One codec, one cache. This replaces the private read_png/load_image copies that
+drifted apart across delight_albedo, extract_landmarks, build_detail_inventory,
+extract_pbr_evidence and make_comparison_sheet — five files, five near-identical
+decoders, each falling back to macOS `sips` for anything that is not PNG.
+
+What lives here:
+  * decode_png_bytes — pure-Python PNG decoder. The 8-bit non-interlaced
+    non-palette path is byte-for-byte the historical fast path. Extended on top:
+    palette (PLTE + tRNS per-index alpha), 1/2/4-bit gray scaling, 16-bit
+    (high byte), tRNS single-color transparency for gray/truecolor, and Adam7
+    interlace. pngquant-compressed screenshots, 16-bit renders and interlaced
+    PNGs decode instead of dying with "unsupported PNG".
+  * decode_jpeg re-export — the pure-Python baseline JPEG decoder (jpeg.py).
+  * external_convert — for formats neither decoder can read, convert via
+    whatever exists on this machine, in order: ImageMagick (magick/convert),
+    ffmpeg, macOS sips, then Pillow if importable. When none is available the
+    error names the whole chain and the fix, so a Linux/Windows user does not
+    conclude the file itself is broken.
+  * decode_image / load_image — the canonical cached entry points, keyed by
+    (resolved path, mtime, size): one decode per file per process, shared by
+    every caller (Divine Eye alone used to decode one reference 6+ times).
+
+Returned pixels are shared between callers — treat them as read-only; no
+pipeline code mutates them. Pure stdlib (Pillow is consulted only if already
+installed; nothing here installs anything).
+"""
+from __future__ import annotations
+
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import zlib
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+__all__ = [
+    "UnsupportedJpeg",
+    "decode_cache_key",
+    "decode_image",
+    "decode_jpeg",
+    "decode_png_bytes",
+    "external_convert",
+    "is_jpeg",
+    "load_image",
+    "read_png",
+]
+
+_PIXEL = tuple[int, int, int, int]
+
+# (resolved path, mtime, size) -> (width, height, pixels, warnings-tuple)
+_DECODE_CACHE: dict[tuple[str, int, int], tuple[int, int, list[_PIXEL], tuple[str, ...]]] = {}
+
+_ADAM7_PASSES = (
+    (0, 0, 8, 8),
+    (4, 0, 8, 8),
+    (0, 4, 4, 8),
+    (2, 0, 4, 4),
+    (0, 2, 2, 4),
+    (1, 0, 2, 2),
+    (0, 1, 1, 2),
+)
+
+
+def decode_cache_key(path: Path) -> tuple[str, int, int]:
+    resolved = path.expanduser().resolve()
+    stat = resolved.stat()
+    return (str(resolved), stat.st_mtime_ns, stat.st_size)
+
+
+def _paeth_predictor(left: int, up: int, up_left: int) -> int:
+    p = left + up - up_left
+    pa = abs(p - left)
+    pb = abs(p - up)
+    pc = abs(p - up_left)
+    if pa <= pb and pa <= pc:
+        return left
+    if pb <= pc:
+        return up
+    return up_left
+
+
+def _unfilter_rows(raw: bytes, width: int, height: int, bpp: int, stride: int) -> list[bytearray]:
+    rows: list[bytearray] = []
+    offset = 0
+    previous = bytearray(stride)
+    for _ in range(height):
+        filter_type = raw[offset]
+        offset += 1
+        row = bytearray(raw[offset : offset + stride])
+        offset += stride
+        for index in range(stride):
+            left = row[index - bpp] if index >= bpp else 0
+            up = previous[index]
+            up_left = previous[index - bpp] if index >= bpp else 0
+            if filter_type == 1:
+                row[index] = (row[index] + left) & 0xFF
+            elif filter_type == 2:
+                row[index] = (row[index] + up) & 0xFF
+            elif filter_type == 3:
+                row[index] = (row[index] + ((left + up) // 2)) & 0xFF
+            elif filter_type == 4:
+                row[index] = (row[index] + _paeth_predictor(left, up, up_left)) & 0xFF
+            elif filter_type != 0:
+                raise ValueError(f"unsupported PNG filter {filter_type}")
+        rows.append(row)
+        previous = row
+    return rows
+
+
+def _sample(row: bytearray, x: int, depth: int, channels: int) -> tuple[int, ...]:
+    """Raw per-channel sample values (no palette/tRNS applied) at pixel x."""
+    if depth == 8:
+        base = x * channels
+        return tuple(row[base + c] for c in range(channels))
+    if depth == 16:
+        base = x * channels * 2
+        return tuple((row[base + 2 * c] << 8) | row[base + 2 * c + 1] for c in range(channels))
+    # 1/2/4-bit: sub-byte samples, most-significant first
+    per_byte = 8 // depth
+    index = x // per_byte
+    shift = 8 - depth * (x % per_byte) - depth
+    mask = (1 << depth) - 1
+    return ((row[index] >> shift) & mask,)
+
+
+def _scale_sample(value: int, depth: int) -> int:
+    """Depth-normalized byte: bit replication for 1/2/4, high byte for 16."""
+    if depth == 16:
+        return value >> 8
+    if depth == 8:
+        return value
+    max_value = (1 << depth) - 1
+    return value * 255 // max_value
+
+
+def _pixel_to_rgba(
+    samples: tuple[int, ...],
+    color_type: int,
+    depth: int,
+    palette: list[tuple[int, int, int]],
+    trns: bytes | None,
+) -> _PIXEL:
+    if color_type == 3:  # palette
+        index = samples[0]
+        if index >= len(palette):
+            raise ValueError("PNG palette index out of range")
+        red, green, blue = palette[index]
+        alpha = trns[index] if trns and index < len(trns) else 255
+        return (red, green, blue, alpha)
+    if color_type == 0:  # grayscale
+        gray = _scale_sample(samples[0], depth)
+        if trns and len(trns) >= 2:
+            key = ((trns[0] << 8) | trns[1]) >> (8 if depth == 16 else 0)
+            if (samples[0] >> 8 if depth == 16 else samples[0]) == key:
+                return (gray, gray, gray, 0)
+        return (gray, gray, gray, 255)
+    if color_type == 2:  # truecolor
+        red, green, blue = (_scale_sample(samples[i], depth) for i in range(3))
+        if trns and len(trns) >= 6:
+            keys = tuple(
+                (((trns[2 * i] << 8) | trns[2 * i + 1]) >> 8 if depth == 16 else (trns[2 * i] << 8) | trns[2 * i + 1])
+                for i in range(3)
+            )
+            raws = tuple(samples[i] >> 8 if depth == 16 else samples[i] for i in range(3))
+            if raws == keys:
+                return (red, green, blue, 0)
+        return (red, green, blue, 255)
+    if color_type == 4:  # gray + alpha
+        gray = _scale_sample(samples[0], depth)
+        alpha = _scale_sample(samples[1], depth)
+        return (gray, gray, gray, alpha)
+    # color_type == 6: RGBA
+    return (
+        _scale_sample(samples[0], depth),
+        _scale_sample(samples[1], depth),
+        _scale_sample(samples[2], depth),
+        _scale_sample(samples[3], depth),
+    )
+
+
+def decode_png_bytes(data: bytes) -> tuple[int, int, list[_PIXEL]]:
+    """Decode a PNG to (width, height, [(r, g, b, a), ...]).
+
+    Supports color types 0/2/3/4/6 at 1/2/4/8/16-bit, tRNS transparency, and
+    Adam7 interlace. The 8-bit non-interlaced path is the historical fast path
+    and produces byte-identical pixels to the previous private decoders.
+    """
+    if not data.startswith(PNG_SIGNATURE):
+        raise ValueError("not a PNG file")
+    cursor = len(PNG_SIGNATURE)
+    width = height = bit_depth = color_type = None
+    interlace = 0
+    idat = bytearray()
+    palette: list[tuple[int, int, int]] = []
+    trns: bytes | None = None
+    while cursor + 8 <= len(data):
+        length = struct.unpack(">I", data[cursor : cursor + 4])[0]
+        chunk_type = data[cursor + 4 : cursor + 8]
+        chunk_data = data[cursor + 8 : cursor + 8 + length]
+        cursor += 12 + length
+        if chunk_type == b"IHDR":
+            width, height, bit_depth, color_type, _, _, interlace = struct.unpack(">IIBBBBB", chunk_data)
+        elif chunk_type == b"IDAT":
+            idat.extend(chunk_data)
+        elif chunk_type == b"PLTE":
+            palette = [
+                (chunk_data[i], chunk_data[i + 1], chunk_data[i + 2])
+                for i in range(0, len(chunk_data) - 2, 3)
+            ]
+        elif chunk_type == b"tRNS":
+            trns = bytes(chunk_data)
+        elif chunk_type == b"IEND":
+            break
+    if width is None or height is None or bit_depth is None or color_type is None:
+        raise ValueError("PNG is missing IHDR")
+    if interlace not in (0, 1):
+        raise ValueError(f"unsupported PNG interlace method {interlace}")
+    channels_by_type = {0: 1, 2: 3, 3: 1, 4: 2, 6: 4}
+    if color_type not in channels_by_type:
+        raise ValueError("unsupported PNG color type; convert to RGB/RGBA first")
+    if color_type == 3 and not palette:
+        raise ValueError("palette PNG is missing its PLTE chunk")
+    if bit_depth not in (1, 2, 4, 8, 16):
+        raise ValueError(f"unsupported PNG bit depth {bit_depth}")
+    if color_type == 3 and bit_depth == 16:
+        raise ValueError("unsupported PNG: palette with 16-bit indices")
+    channels = channels_by_type[color_type]
+    bits_per_pixel = channels * bit_depth
+    bpp = max(1, bits_per_pixel // 8)
+    stride = (width * bits_per_pixel + 7) // 8
+    raw = zlib.decompress(bytes(idat))
+
+    pixels: list[_PIXEL] = []
+    if interlace == 0 and bit_depth == 8 and trns is None and color_type != 3:
+        # Fast path for the overwhelmingly common shape (8-bit, non-interlaced,
+        # no tRNS, not palette): direct expansion, no per-pixel helper calls —
+        # byte-identical to the historical private decoders and just as fast.
+        rows = _unfilter_rows(raw, width, height, bpp, stride)
+        if color_type == 6:
+            for row in rows:
+                for base in range(0, width * 4, 4):
+                    pixels.append((row[base], row[base + 1], row[base + 2], row[base + 3]))
+        elif color_type == 2:
+            for row in rows:
+                for base in range(0, width * 3, 3):
+                    pixels.append((row[base], row[base + 1], row[base + 2], 255))
+        elif color_type == 0:
+            for row in rows:
+                for x in range(width):
+                    gray = row[x]
+                    pixels.append((gray, gray, gray, 255))
+        else:  # color_type == 4 (gray + alpha)
+            for row in rows:
+                for base in range(0, width * 2, 2):
+                    gray = row[base]
+                    pixels.append((gray, gray, gray, row[base + 1]))
+        return width, height, pixels
+
+    if interlace == 0:
+        rows = _unfilter_rows(raw, width, height, bpp, stride)
+        for row in rows:
+            for x in range(width):
+                pixels.append(_pixel_to_rgba(_sample(row, x, bit_depth, channels), color_type, bit_depth, palette, trns))
+        return width, height, pixels
+
+    # Adam7: each pass is an independently filtered sub-image; unfilter it with
+    # its own stride and scatter the samples back to full-resolution positions.
+    grid: list[list[_PIXEL]] = [[(0, 0, 0, 0)] * width for _ in range(height)]
+    offset = 0
+    for x0, y0, dx, dy in _ADAM7_PASSES:
+        pass_width = (width - x0 + dx - 1) // dx if width > x0 else 0
+        pass_height = (height - y0 + dy - 1) // dy if height > y0 else 0
+        if pass_width <= 0 or pass_height <= 0:
+            continue
+        pass_stride = (pass_width * bits_per_pixel + 7) // 8
+        end = offset + pass_height * (1 + pass_stride)
+        rows = _unfilter_rows(raw[offset:end], pass_width, pass_height, bpp, pass_stride)
+        offset = end
+        for py, row in enumerate(rows):
+            y = y0 + py * dy
+            grid_row = grid[y]
+            for px in range(pass_width):
+                x = x0 + px * dx
+                grid_row[x] = _pixel_to_rgba(
+                    _sample(row, px, bit_depth, channels), color_type, bit_depth, palette, trns
+                )
+    if offset != len(raw):
+        raise ValueError("trailing data after Adam7 passes")
+    for row in grid:
+        pixels.extend(row)
+    return width, height, pixels
+
+
+def read_png(path: Path) -> tuple[int, int, list[_PIXEL]]:
+    return decode_png_bytes(path.read_bytes())
+
+
+def external_convert(
+    path: Path,
+    direct_error: Exception,
+    warnings: list[str],
+) -> tuple[int, int, list[_PIXEL]]:
+    """Last resort for formats the pure-Python decoders cannot read.
+
+    Uses whatever converter exists on this machine (ImageMagick, ffmpeg, macOS
+    sips, then Pillow if importable) and fails with an error naming the whole
+    chain and the fix.
+    """
+    tmpdir = tempfile.TemporaryDirectory()
+    try:
+        converted = Path(tmpdir.name) / "converted.png"
+        converters: list[tuple[str, list[str]]] = []
+        magick = shutil.which("magick")
+        if magick:
+            converters.append(("ImageMagick", [magick, str(path), str(converted)]))
+        elif shutil.which("convert") and sys.platform != "win32":
+            # ImageMagick 6's legacy binary name. On Windows, `convert` is the
+            # FAT->NTFS filesystem tool (always on PATH) — invoking it with image
+            # arguments must never happen, so only trust the name elsewhere.
+            converters.append(("ImageMagick", [shutil.which("convert"), str(path), str(converted)]))
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            converters.append(("ffmpeg", [ffmpeg, "-y", "-i", str(path), str(converted)]))
+        sips = shutil.which("sips")
+        if sips:
+            converters.append(("sips", [sips, "-s", "format", "png", str(path), "--out", str(converted)]))
+        if not converters:
+            try:
+                from PIL import Image  # type: ignore[import-not-found]  (optional, not stdlib)
+            except ImportError:
+                raise ValueError(
+                    f"could not decode {path.name}: it is neither a readable PNG nor a readable "
+                    f"baseline JPEG ({direct_error}). No external converter is available either — "
+                    f"tried ImageMagick (magick/convert), ffmpeg, macOS sips and Pillow. Convert "
+                    f"the image to PNG and retry, or install one of those converters."
+                ) from direct_error
+            Image.open(path).convert("RGBA").save(converted, format="PNG")
+            warnings.append("source image was converted to PNG with Pillow before pixel extraction")
+            return read_png(converted)
+        last_error = ""
+        for name, command in converters:
+            result = subprocess.run(command, capture_output=True, text=True, check=False)
+            if result.returncode == 0 and converted.is_file():
+                warnings.append(f"source image was converted to PNG with {name} before pixel extraction")
+                return read_png(converted)
+            last_error = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise ValueError(
+            f"could not decode {path.name}: every available converter failed "
+            f"({', '.join(name for name, _ in converters)}); last error: {last_error}"
+        ) from direct_error
+    finally:
+        tmpdir.cleanup()
+
+
+def decode_image(path: Path) -> tuple[int, int, list[_PIXEL]]:
+    """Canonical cached decode: PNG -> baseline JPEG -> external converter chain."""
+    key = decode_cache_key(path)
+    cached = _DECODE_CACHE.get(key)
+    if cached is not None:
+        return (cached[0], cached[1], cached[2])
+    width, height, pixels, _warnings = _decode_uncached(path)
+    _DECODE_CACHE[key] = (width, height, pixels, tuple(_warnings))
+    return width, height, pixels
+
+
+def load_image(path: Path) -> tuple[int, int, list[_PIXEL], list[str]]:
+    """decode_image plus the extraction warnings (fresh list per call)."""
+    key = decode_cache_key(path)
+    cached = _DECODE_CACHE.get(key)
+    if cached is not None:
+        width, height, pixels, cached_warnings = cached
+        return width, height, pixels, list(cached_warnings)
+    width, height, pixels, warnings = _decode_uncached(path)
+    _DECODE_CACHE[key] = (width, height, pixels, tuple(warnings))
+    return width, height, pixels, list(warnings)
+
+
+def _decode_uncached(path: Path) -> tuple[int, int, list[_PIXEL], list[str]]:
+    warnings: list[str] = []
+    try:
+        return (*decode_png_bytes(path.read_bytes()), warnings)
+    except Exception as direct_error:
+        jpeg_bytes = path.read_bytes()
+        if is_jpeg(jpeg_bytes):
+            try:
+                return (*decode_jpeg(jpeg_bytes), warnings)
+            except UnsupportedJpeg as unsupported:
+                warnings.append(f"{path.name} needs an external converter: {unsupported}")
+        return (*external_convert(path, direct_error, warnings), warnings)

--- a/forge/_shared/image_hash.py
+++ b/forge/_shared/image_hash.py
@@ -56,15 +56,23 @@ def to_grayscale_downsampled(
         return [[0.0] * size for _ in range(size)]
     out = [[0.0] * size for _ in range(size)]
     counts = [[0] * size for _ in range(size)]
-    for idx, (r, g, b, _a) in enumerate(pixels):
-        x = idx % width
-        y = idx // width
-        if y >= height:
-            break
-        sx = min(size - 1, x * size // width)
-        sy = min(size - 1, y * size // height)
-        out[sy][sx] += 0.2126 * r + 0.7152 * g + 0.0722 * b
-        counts[sy][sx] += 1
+    # Row traversal + precomputed cell maps: per-pixel divmod dominated the pHash
+    # profile on full-resolution references. Same cells in the same order, same sums.
+    col_cell = [min(size - 1, x * size // width) for x in range(width)]
+    row_cell = [min(size - 1, y * size // height) for y in range(height)]
+    idx = 0
+    for y in range(height):
+        sy = row_cell[y]
+        out_row = out[sy]
+        count_row = counts[sy]
+        for x in range(width):
+            if idx >= len(pixels):
+                break
+            r, g, b, _a = pixels[idx]
+            idx += 1
+            sx = col_cell[x]
+            out_row[sx] += 0.2126 * r + 0.7152 * g + 0.0722 * b
+            count_row[sx] += 1
     for sy in range(size):
         for sx in range(size):
             c = counts[sy][sx]

--- a/forge/_shared/status_banner.py
+++ b/forge/_shared/status_banner.py
@@ -8,16 +8,24 @@ from typing import Any, TextIO
 
 def _pipeline(spec: dict[str, Any] | None) -> tuple[str, int, str, str]:
     if not isinstance(spec, dict):
-        return "unknown", 0, "spec not loaded", "forge/next.py <spec>"
+        return "unknown", 0, "spec not loaded", _SPEC_IS_OUTPUT_HINT
     pipeline = spec.get("sculptPipeline")
     if not isinstance(pipeline, dict):
-        return "unknown", 0, "sculptPipeline is missing", "forge/next.py <spec>"
+        # Point at the actual first step. "forge/next.py <spec>" here was circular: the
+        # caller IS next.py, and next.py does not author specs — it consumes them.
+        return "unknown", 0, "sculptPipeline is missing", _SPEC_IS_OUTPUT_HINT
     current = str(pipeline.get("currentPass") or "unknown")
     completed = pipeline.get("completedPasses", [])
     count = len(completed) if isinstance(completed, list) else 0
     reason = str(pipeline.get("blockedReason") or "none")
     next_command = "none (pipeline complete)" if current == "complete" else "forge/next.py <spec>"
     return current, count, reason, next_command
+
+
+_SPEC_IS_OUTPUT_HINT = (
+    "the spec is produced by earlier stages, not consumed — start with "
+    "python3 forge/state.py init --reference <image> --profile <generic|character|animated-character|cs2> --spec <path>"
+)
 
 
 def emit_status(spec: dict[str, Any] | None = None, *, next_command: str | None = None, stream: TextIO = sys.stdout) -> None:

--- a/forge/materials/compatibility.py
+++ b/forge/materials/compatibility.py
@@ -103,4 +103,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/next.py
+++ b/forge/next.py
@@ -73,7 +73,14 @@ def main(argv: list[str]) -> int:
 
     if spec_path is None:
         if local_state is None:
-            parser.error("spec is required unless --state points to an initialized pre-spec workflow")
+            # Bare invocation must still be runnable guidance, not an argparse usage
+            # dead end: the spec is an OUTPUT of the earlier stages, not an input, so
+            # say where the pipeline actually starts.
+            print("next.py reports the next command for an existing workflow; you gave neither a spec nor --state.")
+            print("resume an existing checklist:  python3 forge/next.py --state .img2threejs/state.json")
+            print("start a new workflow:           python3 forge/state.py init --reference <image> --profile <generic|character|animated-character|cs2> --spec <path>")
+            print("then run:                       python3 forge/next.py --state .img2threejs/state.json")
+            return 2
         payload = status_payload(local_state)
         emit_local_state(payload)
         return 3 if payload["status"] == "stopped" else 0
@@ -99,6 +106,14 @@ def main(argv: list[str]) -> int:
         return 0
 
     emit_status(spec)
+    if not isinstance(spec.get("sculptPipeline"), dict):
+        # A spec without sculptPipeline is a placeholder, not an authored spec. Reporting a
+        # "current pass" here contradicted the blocked banner above it: one line said the
+        # pipeline is missing, the next said the pass is blockout. The spec is an OUTPUT of
+        # intake/assessment/refine-spec — say that, and point at the actual first step.
+        print("spec has no sculptPipeline: this file is a placeholder, not an authored spec.")
+        print("next command: python3 forge/state.py init --reference <image> --profile <generic|character|animated-character|cs2> --spec <path>")
+        return 2
     if current == "complete":
         print("pipeline: complete")
         return 0
@@ -113,4 +128,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/report.py
+++ b/forge/report.py
@@ -35,4 +35,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/analyze_texture.py
+++ b/forge/stage1_intake/analyze_texture.py
@@ -252,4 +252,19 @@ def main(argv=None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/bind_detail_properties.py
+++ b/forge/stage1_intake/bind_detail_properties.py
@@ -96,4 +96,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/build_detail_inventory.py
+++ b/forge/stage1_intake/build_detail_inventory.py
@@ -13,16 +13,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import struct
-import subprocess
 import sys
-import tempfile
 import zlib
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
-from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+from image_codec import decode_image as load_image  # noqa: E402
 
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
@@ -45,83 +42,8 @@ DEFAULT_COMPONENT_ZONES = [
 ]
 
 
-def paeth_predictor(a: int, b: int, c: int) -> int:
-    p = a + b - c
-    pa = abs(p - a)
-    pb = abs(p - b)
-    pc = abs(p - c)
-    if pa <= pb and pa <= pc:
-        return a
-    if pb <= pc:
-        return b
-    return c
 
 
-def read_png(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
-    data = path.read_bytes()
-    if not data.startswith(PNG_SIGNATURE):
-        raise ValueError("not a PNG file")
-    cursor = len(PNG_SIGNATURE)
-    width = height = bit_depth = color_type = interlace = None
-    idat = bytearray()
-    while cursor + 8 <= len(data):
-        length = struct.unpack(">I", data[cursor : cursor + 4])[0]
-        chunk_type = data[cursor + 4 : cursor + 8]
-        chunk_data = data[cursor + 8 : cursor + 8 + length]
-        cursor += 12 + length
-        if chunk_type == b"IHDR":
-            width, height, bit_depth, color_type, _, _, interlace = struct.unpack(">IIBBBBB", chunk_data)
-        elif chunk_type == b"IDAT":
-            idat.extend(chunk_data)
-        elif chunk_type == b"IEND":
-            break
-    if width is None or height is None or bit_depth != 8 or interlace != 0:
-        raise ValueError("unsupported PNG; expected 8-bit non-interlaced image")
-    channels_by_type = {0: 1, 2: 3, 4: 2, 6: 4}
-    if color_type not in channels_by_type:
-        raise ValueError("unsupported PNG color type; convert to RGB/RGBA first")
-    channels = channels_by_type[color_type]
-    row_bytes = width * channels
-    raw = zlib.decompress(bytes(idat))
-    rows: list[bytearray] = []
-    offset = 0
-    previous = bytearray(row_bytes)
-    for _ in range(height):
-        filter_type = raw[offset]
-        offset += 1
-        row = bytearray(raw[offset : offset + row_bytes])
-        offset += row_bytes
-        for index in range(row_bytes):
-            left = row[index - channels] if index >= channels else 0
-            up = previous[index]
-            up_left = previous[index - channels] if index >= channels else 0
-            if filter_type == 1:
-                row[index] = (row[index] + left) & 0xFF
-            elif filter_type == 2:
-                row[index] = (row[index] + up) & 0xFF
-            elif filter_type == 3:
-                row[index] = (row[index] + ((left + up) // 2)) & 0xFF
-            elif filter_type == 4:
-                row[index] = (row[index] + paeth_predictor(left, up, up_left)) & 0xFF
-            elif filter_type != 0:
-                raise ValueError(f"unsupported PNG filter {filter_type}")
-        rows.append(row)
-        previous = row
-    pixels: list[tuple[int, int, int, int]] = []
-    for row in rows:
-        for x in range(width):
-            base = x * channels
-            if color_type == 0:
-                gray = row[base]
-                pixels.append((gray, gray, gray, 255))
-            elif color_type == 2:
-                pixels.append((row[base], row[base + 1], row[base + 2], 255))
-            elif color_type == 4:
-                gray = row[base]
-                pixels.append((gray, gray, gray, row[base + 1]))
-            elif color_type == 6:
-                pixels.append((row[base], row[base + 1], row[base + 2], row[base + 3]))
-    return width, height, pixels
 
 
 def write_png_rgb(path: Path, width: int, height: int, pixels: list[tuple[int, int, int]]) -> None:
@@ -147,30 +69,6 @@ def write_png_rgb(path: Path, width: int, height: int, pixels: list[tuple[int, i
     )
 
 
-def load_image(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
-    try:
-        return read_png(path)
-    except Exception as direct_error:
-        jpeg_bytes = path.read_bytes()
-        if is_jpeg(jpeg_bytes):
-            try:
-                return decode_jpeg(jpeg_bytes)[:3]
-            except UnsupportedJpeg:
-                pass
-        sips = shutil.which("sips")
-        if not sips:
-            raise ValueError(f"could not decode {path.name} as PNG and sips is unavailable: {direct_error}") from direct_error
-        with tempfile.TemporaryDirectory() as tmpdir:
-            converted = Path(tmpdir) / "converted.png"
-            result = subprocess.run(
-                [sips, "-s", "format", "png", str(path), "--out", str(converted)],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            if result.returncode != 0:
-                raise ValueError(result.stderr.strip() or result.stdout.strip() or "sips conversion failed")
-            return read_png(converted)
 
 
 def composite_over_white(pixel: tuple[int, int, int, int]) -> tuple[int, int, int]:
@@ -346,4 +244,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/check_intake_correctness.py
+++ b/forge/stage1_intake/check_intake_correctness.py
@@ -113,4 +113,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/check_reference_admission.py
+++ b/forge/stage1_intake/check_reference_admission.py
@@ -200,4 +200,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/cs2_manifest.py
+++ b/forge/stage1_intake/cs2_manifest.py
@@ -227,4 +227,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/delight_albedo.py
+++ b/forge/stage1_intake/delight_albedo.py
@@ -17,17 +17,14 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import struct
-import subprocess
 import sys
-import tempfile
 import zlib
 from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
-from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+from image_codec import load_image  # noqa: E402
 
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
@@ -54,85 +51,8 @@ def percentile(values: list[float], fraction: float, fallback: float = 0.0) -> f
     return ordered[index]
 
 
-def paeth_predictor(a: int, b: int, c: int) -> int:
-    p = a + b - c
-    pa = abs(p - a)
-    pb = abs(p - b)
-    pc = abs(p - c)
-    if pa <= pb and pa <= pc:
-        return a
-    if pb <= pc:
-        return b
-    return c
 
 
-def read_png(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
-    data = path.read_bytes()
-    if not data.startswith(PNG_SIGNATURE):
-        raise ValueError("not a PNG file")
-    cursor = len(PNG_SIGNATURE)
-    width = height = bit_depth = color_type = None
-    idat = bytearray()
-    interlace = 0
-    while cursor + 8 <= len(data):
-        length = struct.unpack(">I", data[cursor : cursor + 4])[0]
-        chunk_type = data[cursor + 4 : cursor + 8]
-        chunk_data = data[cursor + 8 : cursor + 8 + length]
-        cursor += 12 + length
-        if chunk_type == b"IHDR":
-            width, height, bit_depth, color_type, _, _, interlace = struct.unpack(">IIBBBBB", chunk_data)
-        elif chunk_type == b"IDAT":
-            idat.extend(chunk_data)
-        elif chunk_type == b"IEND":
-            break
-    if width is None or height is None or bit_depth != 8 or interlace != 0:
-        raise ValueError("unsupported PNG; expected 8-bit non-interlaced image")
-    channels_by_type = {0: 1, 2: 3, 4: 2, 6: 4}
-    if color_type not in channels_by_type:
-        raise ValueError("unsupported PNG color type; convert to RGB/RGBA first")
-    channels = channels_by_type[color_type]
-    row_bytes = width * channels
-    raw = zlib.decompress(bytes(idat))
-    rows: list[bytearray] = []
-    offset = 0
-    previous = bytearray(row_bytes)
-    for _ in range(height):
-        filter_type = raw[offset]
-        offset += 1
-        row = bytearray(raw[offset : offset + row_bytes])
-        offset += row_bytes
-        for index in range(row_bytes):
-            left = row[index - channels] if index >= channels else 0
-            up = previous[index]
-            up_left = previous[index - channels] if index >= channels else 0
-            if filter_type == 1:
-                row[index] = (row[index] + left) & 0xFF
-            elif filter_type == 2:
-                row[index] = (row[index] + up) & 0xFF
-            elif filter_type == 3:
-                row[index] = (row[index] + ((left + up) // 2)) & 0xFF
-            elif filter_type == 4:
-                predictor = paeth_predictor(left, up, up_left)
-                row[index] = (row[index] + predictor) & 0xFF
-            elif filter_type != 0:
-                raise ValueError(f"unsupported PNG filter {filter_type}")
-        rows.append(row)
-        previous = row
-    pixels: list[tuple[int, int, int, int]] = []
-    for row in rows:
-        for x in range(width):
-            base = x * channels
-            if color_type == 0:
-                gray = row[base]
-                pixels.append((gray, gray, gray, 255))
-            elif color_type == 2:
-                pixels.append((row[base], row[base + 1], row[base + 2], 255))
-            elif color_type == 4:
-                gray = row[base]
-                pixels.append((gray, gray, gray, row[base + 1]))
-            elif color_type == 6:
-                pixels.append((row[base], row[base + 1], row[base + 2], row[base + 3]))
-    return width, height, pixels
 
 
 def write_png_rgba(path: Path, width: int, height: int, rgba: bytes) -> None:
@@ -159,31 +79,6 @@ def write_png_rgba(path: Path, width: int, height: int, rgba: bytes) -> None:
     )
 
 
-def load_image(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]], list[str]]:
-    warnings: list[str] = []
-    try:
-        return (*read_png(path), warnings)
-    except Exception as direct_error:
-        jpeg_bytes = path.read_bytes()
-        if is_jpeg(jpeg_bytes):
-            try:
-                return (*decode_jpeg(jpeg_bytes), warnings)
-            except UnsupportedJpeg as unsupported:
-                warnings.append(f"{path.name} needs an external converter: {unsupported}")
-        sips = shutil.which("sips")
-        if not sips:
-            raise ValueError(
-                f"could not decode {path.name} as PNG and macOS sips is unavailable: {direct_error}"
-            ) from direct_error
-        with tempfile.TemporaryDirectory() as tmpdir:
-            converted = Path(tmpdir) / "converted.png"
-            command = [sips, "-s", "format", "png", str(path), "--out", str(converted)]
-            result = subprocess.run(command, capture_output=True, text=True, check=False)
-            if result.returncode != 0:
-                raise ValueError(result.stderr.strip() or result.stdout.strip() or "sips conversion failed")
-            warnings.append("source image was converted to PNG with macOS sips before pixel extraction")
-            width, height, pixels = read_png(converted)
-            return width, height, pixels, warnings
 
 
 def blur_scalar(values: list[float], width: int, height: int, radius: int) -> list[float]:
@@ -349,4 +244,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/detect_cs2.py
+++ b/forge/stage1_intake/detect_cs2.py
@@ -273,4 +273,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/detect_reference_effects.py
+++ b/forge/stage1_intake/detect_reference_effects.py
@@ -272,4 +272,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/extract_cs2_textures.py
+++ b/forge/stage1_intake/extract_cs2_textures.py
@@ -123,4 +123,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/extract_gradient_stops.py
+++ b/forge/stage1_intake/extract_gradient_stops.py
@@ -146,4 +146,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/extract_hair_evidence.py
+++ b/forge/stage1_intake/extract_hair_evidence.py
@@ -382,4 +382,19 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/extract_landmarks.py
+++ b/forge/stage1_intake/extract_landmarks.py
@@ -13,16 +13,13 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import struct
-import subprocess
 import sys
-import tempfile
 import zlib
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
-from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+from image_codec import decode_image as load_image  # noqa: E402
 
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
@@ -60,83 +57,8 @@ FONT_3X5 = {
 }
 
 
-def paeth_predictor(a: int, b: int, c: int) -> int:
-    p = a + b - c
-    pa = abs(p - a)
-    pb = abs(p - b)
-    pc = abs(p - c)
-    if pa <= pb and pa <= pc:
-        return a
-    if pb <= pc:
-        return b
-    return c
 
 
-def read_png(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
-    data = path.read_bytes()
-    if not data.startswith(PNG_SIGNATURE):
-        raise ValueError("not a PNG file")
-    cursor = len(PNG_SIGNATURE)
-    width = height = bit_depth = color_type = interlace = None
-    idat = bytearray()
-    while cursor + 8 <= len(data):
-        length = struct.unpack(">I", data[cursor : cursor + 4])[0]
-        chunk_type = data[cursor + 4 : cursor + 8]
-        chunk_data = data[cursor + 8 : cursor + 8 + length]
-        cursor += 12 + length
-        if chunk_type == b"IHDR":
-            width, height, bit_depth, color_type, _, _, interlace = struct.unpack(">IIBBBBB", chunk_data)
-        elif chunk_type == b"IDAT":
-            idat.extend(chunk_data)
-        elif chunk_type == b"IEND":
-            break
-    if width is None or height is None or bit_depth != 8 or interlace != 0:
-        raise ValueError("unsupported PNG; expected 8-bit non-interlaced image")
-    channels_by_type = {0: 1, 2: 3, 4: 2, 6: 4}
-    if color_type not in channels_by_type:
-        raise ValueError("unsupported PNG color type; convert to RGB/RGBA first")
-    channels = channels_by_type[color_type]
-    row_bytes = width * channels
-    raw = zlib.decompress(bytes(idat))
-    rows: list[bytearray] = []
-    offset = 0
-    previous = bytearray(row_bytes)
-    for _ in range(height):
-        filter_type = raw[offset]
-        offset += 1
-        row = bytearray(raw[offset : offset + row_bytes])
-        offset += row_bytes
-        for index in range(row_bytes):
-            left = row[index - channels] if index >= channels else 0
-            up = previous[index]
-            up_left = previous[index - channels] if index >= channels else 0
-            if filter_type == 1:
-                row[index] = (row[index] + left) & 0xFF
-            elif filter_type == 2:
-                row[index] = (row[index] + up) & 0xFF
-            elif filter_type == 3:
-                row[index] = (row[index] + ((left + up) // 2)) & 0xFF
-            elif filter_type == 4:
-                row[index] = (row[index] + paeth_predictor(left, up, up_left)) & 0xFF
-            elif filter_type != 0:
-                raise ValueError(f"unsupported PNG filter {filter_type}")
-        rows.append(row)
-        previous = row
-    pixels: list[tuple[int, int, int, int]] = []
-    for row in rows:
-        for x in range(width):
-            base = x * channels
-            if color_type == 0:
-                gray = row[base]
-                pixels.append((gray, gray, gray, 255))
-            elif color_type == 2:
-                pixels.append((row[base], row[base + 1], row[base + 2], 255))
-            elif color_type == 4:
-                gray = row[base]
-                pixels.append((gray, gray, gray, row[base + 1]))
-            elif color_type == 6:
-                pixels.append((row[base], row[base + 1], row[base + 2], row[base + 3]))
-    return width, height, pixels
 
 
 def write_png_rgb(path: Path, width: int, height: int, pixels: list[tuple[int, int, int]]) -> None:
@@ -162,30 +84,6 @@ def write_png_rgb(path: Path, width: int, height: int, pixels: list[tuple[int, i
     )
 
 
-def load_image(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
-    try:
-        return read_png(path)
-    except Exception as direct_error:
-        jpeg_bytes = path.read_bytes()
-        if is_jpeg(jpeg_bytes):
-            try:
-                return decode_jpeg(jpeg_bytes)[:3]
-            except UnsupportedJpeg:
-                pass
-        sips = shutil.which("sips")
-        if not sips:
-            raise ValueError(f"could not decode {path.name} as PNG and sips is unavailable: {direct_error}") from direct_error
-        with tempfile.TemporaryDirectory() as tmpdir:
-            converted = Path(tmpdir) / "converted.png"
-            result = subprocess.run(
-                [sips, "-s", "format", "png", str(path), "--out", str(converted)],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            if result.returncode != 0:
-                raise ValueError(result.stderr.strip() or result.stdout.strip() or "sips conversion failed")
-            return read_png(converted)
 
 
 def composite_over_white(pixel: tuple[int, int, int, int]) -> tuple[int, int, int]:
@@ -453,4 +351,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/extract_part_color_recipe.py
+++ b/forge/stage1_intake/extract_part_color_recipe.py
@@ -493,4 +493,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/extract_pbr_evidence.py
+++ b/forge/stage1_intake/extract_pbr_evidence.py
@@ -14,18 +14,15 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import shutil
 import struct
-import subprocess
 import sys
-import tempfile
 import zlib
 from collections import Counter
 from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
-from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+from image_codec import decode_cache_key, load_image  # noqa: E402
 
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
@@ -84,87 +81,6 @@ def median_color(samples: list[tuple[int, int, int]]) -> tuple[int, int, int]:
     )  # type: ignore[return-value]
 
 
-def read_png(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
-    data = path.read_bytes()
-    if not data.startswith(PNG_SIGNATURE):
-        raise ValueError("not a PNG file")
-    cursor = len(PNG_SIGNATURE)
-    width = height = bit_depth = color_type = None
-    idat = bytearray()
-    interlace = 0
-    while cursor + 8 <= len(data):
-        length = struct.unpack(">I", data[cursor : cursor + 4])[0]
-        chunk_type = data[cursor + 4 : cursor + 8]
-        chunk_data = data[cursor + 8 : cursor + 8 + length]
-        cursor += 12 + length
-        if chunk_type == b"IHDR":
-            width, height, bit_depth, color_type, _, _, interlace = struct.unpack(">IIBBBBB", chunk_data)
-        elif chunk_type == b"IDAT":
-            idat.extend(chunk_data)
-        elif chunk_type == b"IEND":
-            break
-    if width is None or height is None or bit_depth != 8 or interlace != 0:
-        raise ValueError("unsupported PNG; expected 8-bit non-interlaced image")
-    channels_by_type = {0: 1, 2: 3, 4: 2, 6: 4}
-    if color_type not in channels_by_type:
-        raise ValueError("unsupported PNG color type; convert to RGB/RGBA first")
-    channels = channels_by_type[color_type]
-    row_bytes = width * channels
-    raw = zlib.decompress(bytes(idat))
-    rows: list[bytearray] = []
-    offset = 0
-    previous = bytearray(row_bytes)
-    for _ in range(height):
-        filter_type = raw[offset]
-        offset += 1
-        row = bytearray(raw[offset : offset + row_bytes])
-        offset += row_bytes
-        for index in range(row_bytes):
-            left = row[index - channels] if index >= channels else 0
-            up = previous[index]
-            up_left = previous[index - channels] if index >= channels else 0
-            if filter_type == 1:
-                row[index] = (row[index] + left) & 0xFF
-            elif filter_type == 2:
-                row[index] = (row[index] + up) & 0xFF
-            elif filter_type == 3:
-                row[index] = (row[index] + ((left + up) // 2)) & 0xFF
-            elif filter_type == 4:
-                predictor = paeth_predictor(left, up, up_left)
-                row[index] = (row[index] + predictor) & 0xFF
-            elif filter_type != 0:
-                raise ValueError(f"unsupported PNG filter {filter_type}")
-        rows.append(row)
-        previous = row
-    pixels: list[tuple[int, int, int, int]] = []
-    for row in rows:
-        for x in range(width):
-            base = x * channels
-            if color_type == 0:
-                gray = row[base]
-                pixels.append((gray, gray, gray, 255))
-            elif color_type == 2:
-                pixels.append((row[base], row[base + 1], row[base + 2], 255))
-            elif color_type == 4:
-                gray = row[base]
-                pixels.append((gray, gray, gray, row[base + 1]))
-            elif color_type == 6:
-                pixels.append((row[base], row[base + 1], row[base + 2], row[base + 3]))
-    return width, height, pixels
-
-
-def paeth_predictor(a: int, b: int, c: int) -> int:
-    p = a + b - c
-    pa = abs(p - a)
-    pb = abs(p - b)
-    pc = abs(p - c)
-    if pa <= pb and pa <= pc:
-        return a
-    if pb <= pc:
-        return b
-    return c
-
-
 def write_png_rgb(path: Path, width: int, height: int, rgb: bytes) -> None:
     if len(rgb) != width * height * 3:
         raise ValueError("RGB payload has the wrong size")
@@ -189,31 +105,29 @@ def write_png_rgb(path: Path, width: int, height: int, rgb: bytes) -> None:
     )
 
 
-def load_image(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]], list[str]]:
-    warnings: list[str] = []
-    try:
-        return (*read_png(path), warnings)
-    except Exception as direct_error:
-        jpeg_bytes = path.read_bytes()
-        if is_jpeg(jpeg_bytes):
-            try:
-                return (*decode_jpeg(jpeg_bytes), warnings)
-            except UnsupportedJpeg as unsupported:
-                warnings.append(f"{path.name} needs an external converter: {unsupported}")
-        sips = shutil.which("sips")
-        if not sips:
-            raise ValueError(
-                f"could not decode {path.name} as PNG and macOS sips is unavailable: {direct_error}"
-            ) from direct_error
-        with tempfile.TemporaryDirectory() as tmpdir:
-            converted = Path(tmpdir) / "converted.png"
-            command = [sips, "-s", "format", "png", str(path), "--out", str(converted)]
-            result = subprocess.run(command, capture_output=True, text=True, check=False)
-            if result.returncode != 0:
-                raise ValueError(result.stderr.strip() or result.stdout.strip() or "sips conversion failed")
-            warnings.append("source image was converted to PNG with macOS sips before pixel extraction")
-            width, height, pixels = read_png(converted)
-            return width, height, pixels, warnings
+# Mask cache. The decode itself is cached in _shared/image_codec (one decode per
+# file per process, shared by every caller); this caches the full-resolution
+# foreground mask derived from it, so the Divine Eye's silhouette/luma/colour
+# paths stop rebuilding the same mask. Masks are shared — treat them as read-only.
+_MASK_CACHE: dict[
+    tuple[str, int, int],
+    tuple[int, int, list[bool], dict[str, Any], tuple[str, ...]],
+] = {}
+
+
+def foreground_mask_for_path(
+    path: Path,
+) -> tuple[int, int, list[bool], dict[str, Any], list[str]]:
+    """Cached build_foreground_mask for a whole image, keyed like the decode cache."""
+    key = decode_cache_key(path)
+    cached = _MASK_CACHE.get(key)
+    if cached is not None:
+        width, height, mask, meta, cached_warnings = cached
+        return width, height, mask, dict(meta), list(cached_warnings)
+    width, height, pixels, _warnings = load_image(path)
+    mask, meta, warnings = build_foreground_mask(width, height, pixels)
+    _MASK_CACHE[key] = (width, height, mask, dict(meta), tuple(warnings))
+    return width, height, mask, dict(meta), list(warnings)
 
 
 def sample_corner_background(
@@ -246,8 +160,8 @@ def build_foreground_mask(
     pixels: list[tuple[int, int, int, int]],
 ) -> tuple[list[bool], dict[str, Any], list[str]]:
     warnings: list[str] = []
-    alpha_values = [pixel[3] for pixel in pixels]
-    transparent_fraction = sum(1 for alpha in alpha_values if alpha < 245) / max(1, len(alpha_values))
+    transparent_count = sum(1 for pixel in pixels if pixel[3] < 245)
+    transparent_fraction = transparent_count / max(1, len(pixels))
     background, background_noise = sample_corner_background(width, height, pixels)
     threshold = max(24.0, background_noise * 2.4)
     mask: list[bool] = []
@@ -255,12 +169,29 @@ def build_foreground_mask(
         for red, green, blue, alpha in pixels:
             mask.append(alpha > 24)
     else:
+        # color_distance/saturation/srgb_luma inlined: three function calls per
+        # pixel dominated the Divine Eye profile at full resolution. Comparing
+        # squared distance against a squared threshold avoids the sqrt without
+        # changing any verdict (both sides non-negative, threshold >= 24).
+        bg_red, bg_green, bg_blue = background
+        threshold_squared = threshold * threshold
         for red, green, blue, alpha in pixels:
-            rgb = (red, green, blue)
-            distance = color_distance(rgb, background)
-            sat = saturation(rgb)
-            luma = srgb_luma(rgb)
-            mask.append(alpha > 16 and (distance > threshold or (sat > 0.16 and luma < 0.94)))
+            if alpha > 16:
+                dr = red - bg_red
+                dg = green - bg_green
+                db = blue - bg_blue
+                distance_squared = dr * dr + dg * dg + db * db
+                high = red if red > green else green
+                if blue > high:
+                    high = blue
+                low = red if red < green else green
+                if blue < low:
+                    low = blue
+                sat = 0.0 if high <= 0 else (high - low) / high
+                luma = (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255.0
+                mask.append(distance_squared > threshold_squared or (sat > 0.16 and luma < 0.94))
+            else:
+                mask.append(False)
     coverage = sum(1 for value in mask if value) / max(1, len(mask))
     if coverage < 0.035:
         warnings.append("foreground mask is tiny; material extraction is likely unreliable")
@@ -840,4 +771,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/fetch_cs2_metadata.py
+++ b/forge/stage1_intake/fetch_cs2_metadata.py
@@ -144,4 +144,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/label_glb_nodes.py
+++ b/forge/stage1_intake/label_glb_nodes.py
@@ -315,4 +315,19 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/locate_cs2_vpk.py
+++ b/forge/stage1_intake/locate_cs2_vpk.py
@@ -70,4 +70,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/material_region_analysis.py
+++ b/forge/stage1_intake/material_region_analysis.py
@@ -224,4 +224,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/probe_glb.py
+++ b/forge/stage1_intake/probe_glb.py
@@ -354,4 +354,20 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(__import__("sys").argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))
+

--- a/forge/stage1_intake/probe_image.py
+++ b/forge/stage1_intake/probe_image.py
@@ -165,4 +165,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/run_vision_adapter.py
+++ b/forge/stage1_intake/run_vision_adapter.py
@@ -42,4 +42,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/search_specs.py
+++ b/forge/stage1_intake/search_specs.py
@@ -255,4 +255,19 @@ def main(argv: Sequence[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage1_intake/solve_camera_pose.py
+++ b/forge/stage1_intake/solve_camera_pose.py
@@ -251,4 +251,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage2_spec/apply_material_analysis.py
+++ b/forge/stage2_spec/apply_material_analysis.py
@@ -189,4 +189,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage2_spec/derive_geometry.py
+++ b/forge/stage2_spec/derive_geometry.py
@@ -115,4 +115,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage2_spec/humanoid_proportions.py
+++ b/forge/stage2_spec/humanoid_proportions.py
@@ -211,4 +211,19 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage2_spec/new_pre_spec_assessment.py
+++ b/forge/stage2_spec/new_pre_spec_assessment.py
@@ -340,4 +340,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage2_spec/new_sculpt_spec.py
+++ b/forge/stage2_spec/new_sculpt_spec.py
@@ -2393,4 +2393,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage2_spec/validate_sculpt_spec.py
+++ b/forge/stage2_spec/validate_sculpt_spec.py
@@ -2868,4 +2868,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage3_build/bake_projected_texture.py
+++ b/forge/stage3_build/bake_projected_texture.py
@@ -178,4 +178,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage3_build/decimate.py
+++ b/forge/stage3_build/decimate.py
@@ -269,4 +269,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage3_build/generate_threejs_factory.py
+++ b/forge/stage3_build/generate_threejs_factory.py
@@ -4046,6 +4046,51 @@ def generate(spec: dict[str, Any], pass_id: str) -> str:
     return "\n".join(lines)
 
 
+# Presentation-only surface (RoomEnvironment/PMREM environment, DOF+bloom
+# composer, orbit controls). In split output these move OUT of the model file so
+# a scene can embed the reconstructed model without importing the whole
+# postprocessing stack; --single-file keeps the historical one-file layout.
+_HARNESS_FUNCTION_SUFFIXES = ("Environment", "PresentationComposer", "InspectControls")
+
+
+def split_factory_source(rendered: str, type_name: str) -> tuple[str, str]:
+    """Split one rendered factory into (model_source, harness_source).
+
+    The model file imports only 'three' and keeps the types, the model factory,
+    look-dev lights, camera framing and renderer configuration. The harness file
+    carries the three presentation-only functions plus the jsm imports that exist
+    only for them. Both halves are cut verbatim out of the single-file rendering
+    (comments travel with their function), so --single-file and the split emit
+    the same code — the split only changes where it lives.
+    """
+    lines = rendered.split("\n")
+    harness_blocks: list[list[str]] = []
+    for suffix in _HARNESS_FUNCTION_SUFFIXES:
+        marker = f"export function create{type_name}{suffix}("
+        index = next((i for i, line in enumerate(lines) if line.startswith(marker)), None)
+        if index is None:
+            raise ValueError(f"generated factory is missing the {suffix} harness function")
+        start = index
+        while start > 0 and lines[start - 1].startswith("//"):
+            start -= 1
+        end = next(i for i in range(index, len(lines)) if lines[i] == "}")
+        if end + 1 < len(lines) and lines[end + 1] == "":
+            end += 1  # take the separator blank line with the block
+        harness_blocks.append(lines[start : end + 1])
+        del lines[start : end + 1]
+    jsm_lines = [line for line in lines if line.startswith("import ") and "three/examples/jsm/" in line]
+    model_lines = [line for line in lines if line not in jsm_lines]
+    if not jsm_lines or not model_lines:
+        raise ValueError("generated factory has an unexpected import header")
+    harness_header = [model_lines[0], *jsm_lines, ""]
+    # Each cut block already carries its trailing blank separator line (the last
+    # one ends with the file's trailing newline), so blocks concatenate directly.
+    harness_parts: list[str] = [line for block in harness_blocks for line in block]
+    model_source = "\n".join(model_lines)
+    harness_source = "\n".join(harness_header + harness_parts)
+    return model_source, harness_source
+
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("spec", type=Path)
@@ -4055,6 +4100,19 @@ def main(argv: list[str]) -> int:
         help="Build pass to generate. Defaults to the current unlocked sculptPipeline pass.",
     )
     parser.add_argument("--force", action="store_true")
+    parser.add_argument(
+        "--single-file",
+        action="store_true",
+        help=(
+            "write one self-contained .ts (model + presentation harness), the historical "
+            "layout; by default the model is split from the presentation harness"
+        ),
+    )
+    parser.add_argument(
+        "--harness-out",
+        type=Path,
+        help="override the derived <model-stem>.harness.ts path (split mode only)",
+    )
     parser.add_argument(
         "--allow-nonstrict",
         action="store_true",
@@ -4091,8 +4149,21 @@ def main(argv: list[str]) -> int:
     if gaps:
         parser.error(f"build pass {pass_id!r} needs spec refinement: {'; '.join(gaps)}")
     output = args.out.expanduser().resolve()
-    if output.exists() and not args.force:
-        parser.error(f"{output} already exists; use --force to overwrite")
+    harness_output: Path | None = None
+    if args.single_file:
+        if args.harness_out:
+            parser.error("--harness-out only applies in split mode (drop --single-file)")
+        if output.exists() and not args.force:
+            parser.error(f"{output} already exists; use --force to overwrite")
+    else:
+        harness_output = (
+            args.harness_out.expanduser().resolve()
+            if args.harness_out
+            else output.with_name(f"{output.stem}.harness.ts")
+        )
+        for candidate in (output, harness_output):
+            if candidate.exists() and not args.force:
+                parser.error(f"{candidate} already exists; use --force to overwrite")
     output.parent.mkdir(parents=True, exist_ok=True)
     try:
         rendered = generate(spec, pass_id)
@@ -4102,10 +4173,35 @@ def main(argv: list[str]) -> int:
             f"implementation yet in geometry_for() — refine-spec to a supported primitive "
             f"or implement it before generating this component"
         )
-    output.write_text(rendered, encoding="utf-8")
+    if args.single_file:
+        output.write_text(rendered, encoding="utf-8")
+        print(output)
+        return 0
+    type_name = pascal_case(str(spec.get("targetName") or "Procedural Object"))
+    model_source, harness_source = split_factory_source(rendered, type_name)
+    output.write_text(model_source, encoding="utf-8")
     print(output)
+    if harness_output is not None:
+        harness_output.parent.mkdir(parents=True, exist_ok=True)
+        harness_output.write_text(harness_source, encoding="utf-8")
+        print(harness_output)
     return 0
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage3_build/module_cache.py
+++ b/forge/stage3_build/module_cache.py
@@ -152,4 +152,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage3_build/morph_targets.py
+++ b/forge/stage3_build/morph_targets.py
@@ -175,4 +175,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage3_build/orchestrate_passes.py
+++ b/forge/stage3_build/orchestrate_passes.py
@@ -650,4 +650,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage3_build/uv_unwrap.py
+++ b/forge/stage3_build/uv_unwrap.py
@@ -619,4 +619,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage3_build/visual_hull.py
+++ b/forge/stage3_build/visual_hull.py
@@ -354,4 +354,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/append_review.py
+++ b/forge/stage4_review/append_review.py
@@ -450,4 +450,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/attachment_anchor.py
+++ b/forge/stage4_review/attachment_anchor.py
@@ -346,4 +346,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/calibrate_eye.py
+++ b/forge/stage4_review/calibrate_eye.py
@@ -128,4 +128,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/check_part_coverage.py
+++ b/forge/stage4_review/check_part_coverage.py
@@ -295,4 +295,19 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(lambda _argv: main()))

--- a/forge/stage4_review/compare_region_passes.py
+++ b/forge/stage4_review/compare_region_passes.py
@@ -166,4 +166,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(__import__("sys").argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/correction_loop.py
+++ b/forge/stage4_review/correction_loop.py
@@ -255,4 +255,19 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/cs2_review.py
+++ b/forge/stage4_review/cs2_review.py
@@ -221,4 +221,19 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/diagnose_render.py
+++ b/forge/stage4_review/diagnose_render.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "stage1_intake"))
-from extract_pbr_evidence import build_foreground_mask, load_image  # noqa: E402
+from extract_pbr_evidence import foreground_mask_for_path, load_image  # noqa: E402
 from extract_part_color_recipe import lab_distance, lab_kmeans_palette, srgb_to_lab  # noqa: E402
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "stage3_build"))
@@ -111,8 +111,7 @@ def largest_component(mask: list[bool], size: int) -> tuple[list[bool], float]:
 
 def load_mask(png_path: Path, size: int = MASK_GRID_SIZE) -> tuple[list[bool], list[str]]:
     """Return the resized foreground mask and extraction warnings."""
-    width, height, pixels, _warnings = load_image(png_path)
-    mask, _diag, mask_warnings = build_foreground_mask(width, height, pixels)
+    width, height, mask, _meta, mask_warnings = foreground_mask_for_path(png_path)
     resized: list[bool] = []
     for y in range(size):
         sy = min(height - 1, int(y * height / size))
@@ -189,7 +188,7 @@ def per_part_color_delta(recipes: list[dict[str, Any]], render_path: Path) -> di
     if not recipes:
         return {"checked": 0, "maxDeltaE": 0.0, "perComponent": []}
     width, height, pixels, _warnings = load_image(render_path)
-    mask, _diag, _warn = build_foreground_mask(width, height, pixels)
+    _mw, _mh, mask, _diag, _warn = foreground_mask_for_path(render_path)
     foreground_lab = [srgb_to_lab((r, g, b)) for (r, g, b, _a), keep in zip(pixels, mask) if keep]
     clusters = lab_kmeans_palette(foreground_lab, k=min(5, max(1, len(recipes))))
     results = []
@@ -353,4 +352,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/diagnose_render_multi_angle.py
+++ b/forge/stage4_review/diagnose_render_multi_angle.py
@@ -140,4 +140,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/divine_eye.py
+++ b/forge/stage4_review/divine_eye.py
@@ -47,7 +47,7 @@ from diagnose_render import (  # noqa: E402
 )
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "stage1_intake"))
-from extract_pbr_evidence import build_foreground_mask, load_image  # noqa: E402
+from extract_pbr_evidence import foreground_mask_for_path, load_image  # noqa: E402
 
 from objectness import objectness_similarity  # noqa: E402  (stdlib OSIM-lite, same dir)
 
@@ -82,7 +82,7 @@ def _banded_median_lab(png_path: Path, axis: str, bands: int) -> list[tuple[floa
     """Median CIELAB per foreground-masked band along the axis (axis 'u'=x, 'v'=y).
     Colour-aware (not luma) — used only by hue_zone_parity, which is report-only until calibrated."""
     width, height, pixels, _ = load_image(png_path)
-    mask, _meta, _warn = build_foreground_mask(width, height, pixels)
+    _mw, _mh, mask, _meta, _warn = foreground_mask_for_path(png_path)
     span = width if axis == "u" else height
     band = max(1, span // bands)
     # Subsample on a coarse grid (≤ COLOR_SAMPLE px/axis) so full-res references stay O(fast) —
@@ -122,7 +122,7 @@ def _foreground_hsv_stats(png_path: Path) -> tuple[float, float]:
     import colorsys
     import math as _m
     width, height, pixels, _ = load_image(png_path)
-    mask, _meta, _warn = build_foreground_mask(width, height, pixels)
+    _mw, _mh, mask, _meta, _warn = foreground_mask_for_path(png_path)
     sx = max(1, width // COLOR_SAMPLE)
     sy = max(1, height // COLOR_SAMPLE)
     sc = ss = wsum = sat_sum = 0.0
@@ -189,14 +189,21 @@ def load_luma(png_path: Path, size: int) -> list[float]:
     width, height, pixels, _warn = load_image(png_path)
     acc = [0.0] * (size * size)
     cnt = [0] * (size * size)
-    for idx, (r, g, b, _a) in enumerate(pixels):
-        x = idx % width
-        y = idx // width
-        if y >= height:
-            break
-        cell = min(size - 1, y * size // height) * size + min(size - 1, x * size // width)
-        acc[cell] += (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0
-        cnt[cell] += 1
+    # Row traversal + precomputed cell maps: per-pixel divmod dominated the profile
+    # on full-resolution references. Same cells in the same order, bit-exact sums.
+    col_cell = [min(size - 1, x * size // width) for x in range(width)]
+    row_cell = [min(size - 1, y * size // height) for y in range(height)]
+    idx = 0
+    for y in range(height):
+        row_offset = row_cell[y] * size
+        for x in range(width):
+            if idx >= len(pixels):
+                return [acc[i] / cnt[i] if cnt[i] else 0.0 for i in range(size * size)]
+            r, g, b, _a = pixels[idx]
+            idx += 1
+            cell = row_offset + col_cell[x]
+            acc[cell] += (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0
+            cnt[cell] += 1
     return [acc[i] / cnt[i] if cnt[i] else 0.0 for i in range(size * size)]
 
 
@@ -458,4 +465,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/fit_params.py
+++ b/forge/stage4_review/fit_params.py
@@ -378,4 +378,19 @@ def main(argv: Sequence[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/hair_gate.py
+++ b/forge/stage4_review/hair_gate.py
@@ -213,4 +213,19 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/interior_difference.py
+++ b/forge/stage4_review/interior_difference.py
@@ -185,4 +185,19 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/joint_loops.py
+++ b/forge/stage4_review/joint_loops.py
@@ -206,4 +206,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/make_comparison_sheet.py
+++ b/forge/stage4_review/make_comparison_sheet.py
@@ -10,98 +10,20 @@ from __future__ import annotations
 
 import argparse
 import json
-import shutil
 import struct
-import subprocess
 import sys
-import tempfile
 import zlib
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
-from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+from image_codec import decode_image as load_image  # noqa: E402
 
 
 PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
 
 
-def paeth_predictor(a: int, b: int, c: int) -> int:
-    p = a + b - c
-    pa = abs(p - a)
-    pb = abs(p - b)
-    pc = abs(p - c)
-    if pa <= pb and pa <= pc:
-        return a
-    if pb <= pc:
-        return b
-    return c
 
 
-def read_png(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
-    data = path.read_bytes()
-    if not data.startswith(PNG_SIGNATURE):
-        raise ValueError("not a PNG file")
-    cursor = len(PNG_SIGNATURE)
-    width = height = bit_depth = color_type = interlace = None
-    idat = bytearray()
-    while cursor + 8 <= len(data):
-        length = struct.unpack(">I", data[cursor : cursor + 4])[0]
-        chunk_type = data[cursor + 4 : cursor + 8]
-        chunk_data = data[cursor + 8 : cursor + 8 + length]
-        cursor += 12 + length
-        if chunk_type == b"IHDR":
-            width, height, bit_depth, color_type, _, _, interlace = struct.unpack(">IIBBBBB", chunk_data)
-        elif chunk_type == b"IDAT":
-            idat.extend(chunk_data)
-        elif chunk_type == b"IEND":
-            break
-    if width is None or height is None or bit_depth != 8 or interlace != 0:
-        raise ValueError("unsupported PNG; expected 8-bit non-interlaced image")
-    channels_by_type = {0: 1, 2: 3, 4: 2, 6: 4}
-    if color_type not in channels_by_type:
-        raise ValueError("unsupported PNG color type; convert to RGB/RGBA first")
-    channels = channels_by_type[color_type]
-    row_bytes = width * channels
-    raw = zlib.decompress(bytes(idat))
-    rows: list[bytearray] = []
-    offset = 0
-    previous = bytearray(row_bytes)
-    for _ in range(height):
-        filter_type = raw[offset]
-        offset += 1
-        row = bytearray(raw[offset : offset + row_bytes])
-        offset += row_bytes
-        for index in range(row_bytes):
-            left = row[index - channels] if index >= channels else 0
-            up = previous[index]
-            up_left = previous[index - channels] if index >= channels else 0
-            if filter_type == 1:
-                row[index] = (row[index] + left) & 0xFF
-            elif filter_type == 2:
-                row[index] = (row[index] + up) & 0xFF
-            elif filter_type == 3:
-                row[index] = (row[index] + ((left + up) // 2)) & 0xFF
-            elif filter_type == 4:
-                row[index] = (row[index] + paeth_predictor(left, up, up_left)) & 0xFF
-            elif filter_type != 0:
-                raise ValueError(f"unsupported PNG filter {filter_type}")
-        rows.append(row)
-        previous = row
-    pixels: list[tuple[int, int, int, int]] = []
-    for row in rows:
-        for x in range(width):
-            base = x * channels
-            if color_type == 0:
-                gray = row[base]
-                pixels.append((gray, gray, gray, 255))
-            elif color_type == 2:
-                pixels.append((row[base], row[base + 1], row[base + 2], 255))
-            elif color_type == 4:
-                gray = row[base]
-                pixels.append((gray, gray, gray, row[base + 1]))
-            elif color_type == 6:
-                pixels.append((row[base], row[base + 1], row[base + 2], row[base + 3]))
-    return width, height, pixels
 
 
 def write_png_rgb(path: Path, width: int, height: int, pixels: list[tuple[int, int, int]]) -> None:
@@ -127,30 +49,6 @@ def write_png_rgb(path: Path, width: int, height: int, pixels: list[tuple[int, i
     )
 
 
-def load_image(path: Path) -> tuple[int, int, list[tuple[int, int, int, int]]]:
-    try:
-        return read_png(path)
-    except Exception as direct_error:
-        jpeg_bytes = path.read_bytes()
-        if is_jpeg(jpeg_bytes):
-            try:
-                return decode_jpeg(jpeg_bytes)[:3]
-            except UnsupportedJpeg:
-                pass
-        sips = shutil.which("sips")
-        if not sips:
-            raise ValueError(f"could not decode {path.name} as PNG and sips is unavailable: {direct_error}") from direct_error
-        with tempfile.TemporaryDirectory() as tmpdir:
-            converted = Path(tmpdir) / "converted.png"
-            result = subprocess.run(
-                [sips, "-s", "format", "png", str(path), "--out", str(converted)],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
-            if result.returncode != 0:
-                raise ValueError(result.stderr.strip() or result.stdout.strip() or "sips conversion failed")
-            return read_png(converted)
 
 
 def composite_over_checker(pixel: tuple[int, int, int, int], x: int, y: int) -> tuple[int, int, int]:
@@ -289,4 +187,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/material_comparator.py
+++ b/forge/stage4_review/material_comparator.py
@@ -178,4 +178,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/material_feedback.py
+++ b/forge/stage4_review/material_feedback.py
@@ -140,4 +140,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/material_gate.py
+++ b/forge/stage4_review/material_gate.py
@@ -123,4 +123,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/material_views.py
+++ b/forge/stage4_review/material_views.py
@@ -181,4 +181,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/mesh_reference_compare.py
+++ b/forge/stage4_review/mesh_reference_compare.py
@@ -359,4 +359,19 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(lambda _argv: main()))

--- a/forge/stage4_review/objectness.py
+++ b/forge/stage4_review/objectness.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "stage1_intake"))
-from extract_pbr_evidence import build_foreground_mask, load_image  # noqa: E402
+from extract_pbr_evidence import foreground_mask_for_path, load_image  # noqa: E402
 
 GRID = 96   # canonical square the object bbox is resampled to
 CELLS = 8   # CELLS x CELLS spatial cells
@@ -76,7 +76,7 @@ def descriptor(path: str | Path) -> list[float]:
     """HOG-like descriptor of the object's foreground, canonicalised for pose/scale/bg."""
     w, h, pixels, _ = load_image(Path(path))
     gray = _to_gray(pixels)
-    mask, _diag, _warn = build_foreground_mask(w, h, pixels)
+    _mw, _mh, mask, _diag, _warn = foreground_mask_for_path(Path(path))
     x0, y0, x1, y1 = _bbox(mask, w, h)
     # pad the bbox so the object's silhouette contour (its strongest shape cue) lands
     # INSIDE the resampled grid — a solid object cropped flush would otherwise put its
@@ -140,4 +140,19 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/pairwise_penetration.py
+++ b/forge/stage4_review/pairwise_penetration.py
@@ -373,4 +373,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/per_feature.py
+++ b/forge/stage4_review/per_feature.py
@@ -212,4 +212,19 @@ def main(argv):
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/render_bridge.py
+++ b/forge/stage4_review/render_bridge.py
@@ -553,4 +553,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/scalp_exposure.py
+++ b/forge/stage4_review/scalp_exposure.py
@@ -254,4 +254,19 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/self_intersection.py
+++ b/forge/stage4_review/self_intersection.py
@@ -589,4 +589,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/swept_arc_gate.py
+++ b/forge/stage4_review/swept_arc_gate.py
@@ -328,7 +328,20 @@ def main(argv: list[str]) -> int:
 
 if __name__ == "__main__":
     try:
-        raise SystemExit(main(sys.argv[1:]))
+        _shared_dir = next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )
+        if str(_shared_dir) not in sys.path:
+            sys.path.insert(0, str(_shared_dir))
+        from cli_run import run_entry  # noqa: E402
+    except (ImportError, StopIteration, NameError):
+        def run_entry(main_fn):
+            return main_fn(sys.argv[1:])
+
+    try:
+        raise SystemExit(run_entry(main))
     except SystemExit as exit_error:
         if isinstance(exit_error.code, str):
             print(exit_error.code, file=sys.stderr)

--- a/forge/stage4_review/turntable_gate.py
+++ b/forge/stage4_review/turntable_gate.py
@@ -412,4 +412,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage4_review/validate_render_profile.py
+++ b/forge/stage4_review/validate_render_profile.py
@@ -179,4 +179,20 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(__import__("sys").argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))
+

--- a/forge/stage4_review/vertex_region_gate.py
+++ b/forge/stage4_review/vertex_region_gate.py
@@ -448,7 +448,20 @@ def main(argv: list[str]) -> int:
 
 if __name__ == "__main__":
     try:
-        raise SystemExit(main(sys.argv[1:]))
+        _shared_dir = next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )
+        if str(_shared_dir) not in sys.path:
+            sys.path.insert(0, str(_shared_dir))
+        from cli_run import run_entry  # noqa: E402
+    except (ImportError, StopIteration, NameError):
+        def run_entry(main_fn):
+            return main_fn(sys.argv[1:])
+
+    try:
+        raise SystemExit(run_entry(main))
     except SystemExit as exit_error:
         if isinstance(exit_error.code, str):
             print(exit_error.code, file=sys.stderr)

--- a/forge/stage4_review/vlm_gate.py
+++ b/forge/stage4_review/vlm_gate.py
@@ -193,4 +193,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage5_rig/action_design.py
+++ b/forge/stage5_rig/action_design.py
@@ -2155,4 +2155,19 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage5_rig/clip_features.py
+++ b/forge/stage5_rig/clip_features.py
@@ -756,4 +756,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage5_rig/geodesic_skinning.py
+++ b/forge/stage5_rig/geodesic_skinning.py
@@ -505,4 +505,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage5_rig/glb_rig_reference.py
+++ b/forge/stage5_rig/glb_rig_reference.py
@@ -1434,4 +1434,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage5_rig/mesh_parity.py
+++ b/forge/stage5_rig/mesh_parity.py
@@ -900,4 +900,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage5_rig/rig_gates.py
+++ b/forge/stage5_rig/rig_gates.py
@@ -1938,4 +1938,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage5_rig/skin_conditioning.py
+++ b/forge/stage5_rig/skin_conditioning.py
@@ -610,4 +610,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/stage5_rig/validate_rig_payload.py
+++ b/forge/stage5_rig/validate_rig_payload.py
@@ -192,4 +192,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/state.py
+++ b/forge/state.py
@@ -99,4 +99,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/forge/tests/showcase_test_support.py
+++ b/forge/tests/showcase_test_support.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import os
+import shutil
 import unittest
 from pathlib import Path
+
+# On Windows npx is npx.cmd and CreateProcess does not apply PATHEXT, so a bare
+# "npx" in a subprocess argv list fails with FileNotFoundError. Resolve the real
+# executable once; tests that shell out to tsc must use this instead of "npx".
+NPX = shutil.which("npx") or "npx"
 
 
 def showcase_root() -> Path:

--- a/forge/tests/test_cli_run.py
+++ b/forge/tests/test_cli_run.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""cli_run contract: a piped consumer closing early must exit 141 SILENTLY
+(this used to be a BrokenPipeError traceback plus an "Exception ignored" line,
+which agents read as command failure), Ctrl-C maps to 130, a missing input file
+prints one line and exits 66, and a vendored copy without the forge runtime
+still runs (bare, no pipe handling).
+
+Run: python forge/tests/test_cli_run.py
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SHARED = Path(__file__).resolve().parent.parent / "_shared"
+
+CHILD_TEMPLATE = textwrap.dedent(
+    """
+    import sys
+    sys.path.insert(0, {shared!r})
+    from cli_run import run_entry
+
+    {body}
+    """
+)
+
+
+def run_shared_child(body: str) -> subprocess.CompletedProcess[str]:
+    source = CHILD_TEMPLATE.format(shared=str(SHARED), body=body)
+    return subprocess.run([sys.executable, "-c", source], capture_output=True, text=True, timeout=60)
+
+
+class CliRunTest(unittest.TestCase):
+    def test_broken_pipe_exits_141_silently(self) -> None:
+        body = textwrap.dedent(
+            """
+            def main(argv):
+                for _ in range(20000):
+                    print("x" * 100)
+                return 0
+
+            raise SystemExit(run_entry(main))
+            """
+        )
+        # Close the read end after a small read so the child's later writes hit
+        # a closed pipe (POSIX raises BrokenPipeError, Windows EINVAL — both are
+        # supposed to funnel to exit 141 with no stderr noise).
+        process = subprocess.Popen(
+            [sys.executable, "-c", CHILD_TEMPLATE.format(shared=str(SHARED), body=body)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        process.stdout.read(1024)  # type: ignore[union-attr]
+        process.stdout.close()  # type: ignore[union-attr]
+        process.wait(timeout=60)
+        stderr = process.stderr.read().decode("utf-8", "replace") if process.stderr else ""
+        process.stderr.close()  # type: ignore[union-attr]
+        self.assertEqual(process.returncode, 141, f"stderr was: {stderr!r}")
+        self.assertEqual(stderr, "")
+
+    def test_keyboard_interrupt_exits_130(self) -> None:
+        body = textwrap.dedent(
+            """
+            def main(argv):
+                raise KeyboardInterrupt
+
+            raise SystemExit(run_entry(main))
+            """
+        )
+        completed = run_shared_child(body)
+        self.assertEqual(completed.returncode, 130, completed.stderr)
+        self.assertEqual(completed.stderr, "")
+
+    def test_missing_file_prints_one_line_and_exits_66(self) -> None:
+        missing = os.path.join(tempfile.gettempdir(), "definitely-not-here.png")
+        body = textwrap.dedent(
+            f"""
+            def main(argv):
+                open(argv[0], "rb").read()
+                return 0
+
+            raise SystemExit(run_entry(main, [{missing!r}]))
+            """
+        )
+        completed = run_shared_child(body)
+        self.assertEqual(completed.returncode, 66, completed.stderr)
+        self.assertIn("error:", completed.stderr)
+        self.assertEqual(len(completed.stderr.strip().splitlines()), 1, "exactly one line")
+
+    def test_real_bugs_keep_their_traceback(self) -> None:
+        body = textwrap.dedent(
+            """
+            def main(argv):
+                raise ValueError("a genuine bug")
+
+            raise SystemExit(run_entry(main))
+            """
+        )
+        completed = run_shared_child(body)
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("ValueError: a genuine bug", completed.stderr)
+
+    def test_vendored_copy_without_shared_runtime_runs_bare(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            vendored = Path(directory) / "entry.py"
+            # A copy that cannot find forge/_shared/cli_run.py must still run main.
+            vendored.write_text(
+                textwrap.dedent(
+                    """
+                    import sys
+
+                    try:
+                        sys.path.insert(0, str(next(
+                            parent / "forge" / "_shared"
+                            for parent in __import__("pathlib").Path(__file__).resolve().parents
+                            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+                        )))
+                        from cli_run import run_entry
+                    except (ImportError, StopIteration):
+                        def run_entry(main_fn, argv=None):
+                            return main_fn(sys.argv[1:] if argv is None else argv)
+
+                    def main(argv):
+                        print("bare run ok")
+                        return 0
+
+                    raise SystemExit(run_entry(main))
+                    """
+                ),
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [sys.executable, str(vendored)],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                cwd=directory,  # nowhere up-tree carries forge/_shared
+            )
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn("bare run ok", completed.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/forge/tests/test_emit_animation_runtime_tsc_smoke.py
+++ b/forge/tests/test_emit_animation_runtime_tsc_smoke.py
@@ -21,9 +21,9 @@ import unittest
 from pathlib import Path
 
 if __package__:
-    from .showcase_test_support import showcase_root
+    from .showcase_test_support import NPX, showcase_root
 else:
-    from showcase_test_support import showcase_root
+    from showcase_test_support import NPX, showcase_root
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "stage5_rig"))
@@ -50,7 +50,7 @@ class EmitAnimationRuntimeTscSmokeTest(unittest.TestCase):
 
     def _run_tsc(self) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
-            ["npx", "tsc", "--noEmit"],
+            [NPX, "tsc", "--noEmit"],
             cwd=self.showcase_root,
             capture_output=True,
             text=True,

--- a/forge/tests/test_factory_split.py
+++ b/forge/tests/test_factory_split.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""The generated factory used to hard-bind the whole presentation stack
+(EffectComposer / BokehPass / UnrealBloomPass / OrbitControls / RoomEnvironment)
+into every file — even a single-component blockout that only wanted a model.
+These tests pin the split layout: model file imports only 'three', the
+presentation harness lives in its own file, every moved block is byte-identical
+to the single-file rendering, and --single-file still reproduces the
+historical one-file layout exactly.
+
+Run: python forge/tests/test_factory_split.py
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from collections import Counter
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[2]
+GENERATOR = SKILL_ROOT / "forge" / "stage3_build" / "generate_threejs_factory.py"
+IMPLICIT_FIXTURE = SKILL_ROOT / "forge" / "tests" / "fixtures" / "implicit_character_torso_limb.json"
+
+sys.path.insert(0, str(SKILL_ROOT / "forge" / "stage3_build"))
+from generate_threejs_factory import generate, split_factory_source  # noqa: E402
+
+JSM_NAMES = ("RoomEnvironment", "EffectComposer", "RenderPass", "BokehPass", "UnrealBloomPass", "OrbitControls")
+TYPE_NAME = "ImplicitCharacterTorsoLimb"
+SUFFIXES = ("Environment", "PresentationComposer", "InspectControls")
+
+
+def run_cli(*args: object) -> subprocess.CompletedProcess[str]:
+    command = [sys.executable, str(GENERATOR), *map(str, args)]
+    # Same fixture escape hatch the other CLI-level tests use: these specs are
+    # deliberately shallow, strict-quality would block them before generation.
+    command.append("--allow-nonstrict")
+    return subprocess.run(command, capture_output=True, text=True)
+
+
+class FactorySplitTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.rendered = generate(__import__("json").loads(IMPLICIT_FIXTURE.read_text(encoding="utf-8")), "blockout")
+        cls.model, cls.harness = split_factory_source(cls.rendered, TYPE_NAME)
+
+    def test_model_imports_only_three(self) -> None:
+        imports = [line for line in self.model.splitlines() if line.startswith("import ")]
+        self.assertEqual(imports, ["import * as THREE from 'three';"])
+
+    def test_model_has_no_jsm_references(self) -> None:
+        for name in JSM_NAMES:
+            self.assertNotIn(name, self.model, f"{name} leaked into the model file")
+
+    def test_harness_carries_the_presentation_functions(self) -> None:
+        for suffix in SUFFIXES:
+            self.assertIn(f"export function create{TYPE_NAME}{suffix}(", self.harness, suffix)
+        self.assertNotIn("createModel", self.harness, "harness must not carry the model factory")
+
+    def test_moved_blocks_are_verbatim_from_the_single_file(self) -> None:
+        for suffix in SUFFIXES:
+            pattern = rf"(?://[^\n]*\n)*export function create{TYPE_NAME}{suffix}\(.*?^\}}\n"
+            match = re.search(pattern, self.rendered, re.S | re.M)
+            self.assertIsNotNone(match, suffix)
+            block = match.group(0)
+            self.assertIn(block, self.harness, f"{suffix} block changed in transit")
+            self.assertNotIn(block, self.model, f"{suffix} block duplicated in the model file")
+
+    def test_no_source_line_lost_or_duplicated(self) -> None:
+        original = Counter(self.rendered.splitlines())
+        combined = Counter(self.model.splitlines()) + Counter(self.harness.splitlines())
+        # The split relocates every line verbatim with exactly one deliberate
+        # addition: the harness re-imports 'three' alongside the jsm modules.
+        expected = original + Counter({"import * as THREE from 'three';": 1})
+        self.assertEqual(combined, expected, "split must relocate lines verbatim, not rewrite them")
+
+    def test_single_file_flag_reproduces_historical_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            out = Path(directory) / "createImplicitCharacterTorsoLimbModel.ts"
+            result = run_cli(IMPLICIT_FIXTURE, "--out", out, "--single-file")
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(out.read_text(encoding="utf-8"), self.rendered)
+            self.assertEqual(len(list(Path(directory).glob("*"))), 1, "single-file mode must write exactly one file")
+
+    def test_default_split_writes_two_files(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            out = Path(directory) / "createImplicitCharacterTorsoLimbModel.ts"
+            result = run_cli(IMPLICIT_FIXTURE, "--out", out)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            harness_path = Path(directory) / "createImplicitCharacterTorsoLimbModel.harness.ts"
+            self.assertTrue(out.is_file(), result.stdout)
+            self.assertTrue(harness_path.is_file(), result.stdout)
+            self.assertEqual(out.read_text(encoding="utf-8"), self.model)
+            self.assertEqual(harness_path.read_text(encoding="utf-8"), self.harness)
+            self.assertIn(str(out), result.stdout)
+            self.assertIn(str(harness_path), result.stdout)
+
+    def test_harness_identifier_closure(self) -> None:
+        """Every non-THREE symbol the harness uses is imported there."""
+        imported = set(re.findall(r"import \{ (\w+) \} from", self.harness))
+        for name in JSM_NAMES:
+            self.assertIn(name, imported, f"{name} used but not imported by the harness")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/forge/tests/test_hair_material.py
+++ b/forge/tests/test_hair_material.py
@@ -148,7 +148,7 @@ class EmittedSourceTypechecks(unittest.TestCase):
         import subprocess  # noqa: PLC0415
 
         sys.path.insert(0, str(Path(__file__).resolve().parent))
-        from showcase_test_support import showcase_root  # noqa: PLC0415
+        from showcase_test_support import NPX, showcase_root  # noqa: PLC0415
 
         root = showcase_root()
         destination = root / "src" / "__hair_material_smoke__.ts"
@@ -159,7 +159,7 @@ class EmittedSourceTypechecks(unittest.TestCase):
         try:
             destination.write_text(source, encoding="utf-8")
             result = subprocess.run(
-                ["npx", "tsc", "--noEmit"], cwd=root, capture_output=True, text=True, check=False
+                [NPX, "tsc", "--noEmit"], cwd=root, capture_output=True, text=True, check=False
             )
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         finally:

--- a/forge/tests/test_hierarchy_scale.py
+++ b/forge/tests/test_hierarchy_scale.py
@@ -33,9 +33,9 @@ import unittest
 from pathlib import Path
 
 if __package__:
-    from .showcase_test_support import showcase_root
+    from .showcase_test_support import NPX, showcase_root
 else:
-    from showcase_test_support import showcase_root
+    from showcase_test_support import NPX, showcase_root
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -105,7 +105,7 @@ def compile_generated_module(generated: str, work_dir: Path) -> tuple[subprocess
     source.write_text(generated, encoding="utf-8")
     result = subprocess.run(
         [
-            "npx", "tsc", "--target", "ES2020", "--module", "NodeNext", "--moduleResolution", "NodeNext",
+            NPX, "tsc", "--target", "ES2020", "--module", "NodeNext", "--moduleResolution", "NodeNext",
             "--strict", "--skipLibCheck", "--noUnusedLocals", "--noUnusedParameters",
             "--outDir", str(build_dir), str(source),
         ],

--- a/forge/tests/test_image_codec_extended.py
+++ b/forge/tests/test_image_codec_extended.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Extended image_codec coverage: the layers the PNG/Pillow cross-check does not
+reach.
+
+  * JPEG cross-check — decode_jpeg is the portability backbone for reference
+    photos (the whole reason load_image stopped needing macOS sips), so its
+    output is compared against Pillow across quality levels, chroma subsampling
+    and grayscale variants.
+  * external fallback chain — a format neither pure-Python decoder reads (WebP)
+    must arrive through the machine's converter chain (here: Pillow), with the
+    conversion recorded as a warning; and when NOTHING can convert, the error
+    must name the whole chain and the fix instead of blaming the file.
+  * decode cache — keyed by (path, mtime, size): an edited file must re-decode,
+    a restored (path, mtime, size) must hit the cache. This is the invariant the
+    Divine Eye speedup rests on.
+
+Pillow-dependent cases self-skip on stdlib-only machines.
+Run: python forge/tests/test_image_codec_extended.py
+"""
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from io import BytesIO
+from pathlib import Path
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+import image_codec  # noqa: E402
+from image_codec import decode_cache_key, decode_image, load_image  # noqa: E402
+from jpeg import UnsupportedJpeg, decode_jpeg, is_jpeg  # noqa: E402
+
+try:
+    from PIL import Image  # noqa: E402
+
+    PIL_AVAILABLE = True
+except ImportError:
+    PIL_AVAILABLE = False
+
+RNG_SEED = 20260905
+
+
+def random_rgb_image(size: int = 48):
+    import random
+
+    rng = random.Random(RNG_SEED)
+    img = Image.new("RGB", (size, size))
+    img.putdata([(rng.randrange(256), rng.randrange(256), rng.randrange(256)) for _ in range(size * size)])
+    return img
+
+
+@unittest.skipUnless(PIL_AVAILABLE, "Pillow (the reference decoder) is not installed")
+class JpegCrossCheckTest(unittest.TestCase):
+    """decode_jpeg vs Pillow on baseline JPEGs.
+
+    JPEG is deterministic for identical BYTES in one decoder, but two conforming
+    decoders may differ in IDCT/level-shift rounding: libjpeg (Pillow) uses a
+    fixed-point IDCT, the pure-Python decoder a float one, so ±1 (rarely 2) per
+    channel is expected and harmless for every downstream signal (masks, luma,
+    pHash). The bar is therefore max|Δ| <= 2 with mean |Δ| < 1 — not bit equality
+    (which PNG, being lossless, does demand).
+    """
+
+    VARIANTS = (
+        {"quality": 95},
+        {"quality": 60},
+        {"quality": 95, "subsampling": 0},  # 4:4:4
+        {"quality": 85, "subsampling": 2},  # 4:2:0
+        {"quality": 75, "optimize": True},
+    )
+
+    def _assert_close_to_pillow(self, data: bytes, note: str) -> None:
+        width, height, pixels = decode_jpeg(data)
+        reference = list(Image.open(BytesIO(data)).convert("RGBA").getdata())
+        self.assertEqual((width, height), Image.open(BytesIO(data)).size)
+        self.assertEqual(len(pixels), len(reference))
+        deltas = [
+            abs(ours[channel] - ref[channel])
+            for ours, ref in zip(pixels, reference)
+            for channel in range(3)
+        ]
+        # Rounding-only bar: essentially all channels within ±2 (zero at q>=75),
+        # a vanishing tail up to 8 at aggressive quantization, mean well under 1.
+        self.assertLess(sum(deltas) / len(deltas), 1.0, f"{note}: mean delta drifted beyond rounding")
+        self.assertLessEqual(max(deltas), 8, f"{note}: max channel delta {max(deltas)} is not rounding noise")
+        beyond_two = sum(1 for delta in deltas if delta > 2) / len(deltas)
+        self.assertLess(beyond_two, 0.005, f"{note}: {beyond_two:.2%} of channels differ by more than 2")
+        self.assertEqual([p[3] for p in pixels], [p[3] for p in reference], "alpha must be opaque 255 everywhere")
+
+    def test_color_variants_match_pillow(self) -> None:
+        for kwargs in self.VARIANTS:
+            with self.subTest(**kwargs):
+                buffer = BytesIO()
+                random_rgb_image().save(buffer, format="JPEG", **kwargs)
+                self.assertTrue(is_jpeg(buffer.getvalue()))
+                self._assert_close_to_pillow(buffer.getvalue(), str(kwargs))
+
+    def test_grayscale_jpeg_matches_pillow(self) -> None:
+        import random
+
+        rng = random.Random(RNG_SEED + 1)
+        gray = Image.new("L", (40, 30))
+        gray.putdata([rng.randrange(256) for _ in range(40 * 30)])
+        buffer = BytesIO()
+        gray.save(buffer, format="JPEG", quality=90)
+        self._assert_close_to_pillow(buffer.getvalue(), "grayscale")
+
+    def test_decode_is_deterministic(self) -> None:
+        buffer = BytesIO()
+        random_rgb_image(24).save(buffer, format="JPEG", quality=88)
+        data = buffer.getvalue()
+        self.assertEqual(decode_jpeg(data), decode_jpeg(data), "same bytes must decode identically")
+
+    def test_progressive_still_raises_clearly(self) -> None:
+        buffer = BytesIO()
+        random_rgb_image(32).save(buffer, format="JPEG", quality=80, progressive=True)
+        with self.assertRaises(UnsupportedJpeg):
+            decode_jpeg(buffer.getvalue())
+
+    def test_load_image_routes_jpeg_without_any_converter(self) -> None:
+        # the portability contract from test_jpeg, restated at codec level:
+        # no sips/magick/ffmpeg on the machine must not block a baseline JPEG
+        buffer = BytesIO()
+        random_rgb_image(32).save(buffer, format="JPEG", quality=90)
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "photo.jpg"
+            path.write_bytes(buffer.getvalue())
+            with mock.patch.object(shutil, "which", return_value=None):
+                width, height, pixels, warnings = load_image(path)
+            self.assertEqual((width, height), (32, 32))
+            self.assertEqual(warnings, [])
+
+
+@unittest.skipUnless(PIL_AVAILABLE, "WebP fixtures need Pillow to write")
+class ExternalChainTest(unittest.TestCase):
+    def _webp_fixture(self, directory: str) -> Path:
+        path = Path(directory) / "shot.webp"
+        random_rgb_image(24).save(path, format="WEBP", quality=90)
+        return path
+
+    def test_webp_decodes_through_the_chain_with_warning(self) -> None:
+        # mirror the codec's own probing: on Windows, bare `convert` is the
+        # FAT->NTFS tool and does not count as ImageMagick
+        has_external = bool(
+            shutil.which("magick")
+            or (shutil.which("convert") and sys.platform != "win32")
+            or shutil.which("ffmpeg")
+            or shutil.which("sips")
+        )
+        if has_external:
+            self.skipTest("machine has an external converter; chain tail differs")
+        with tempfile.TemporaryDirectory() as directory:
+            path = self._webp_fixture(directory)
+            width, height, pixels, warnings = load_image(path)
+            self.assertEqual((width, height), (24, 24))
+            self.assertEqual(len(pixels), 24 * 24)
+            self.assertTrue(
+                any("Pillow" in warning for warning in warnings),
+                f"conversion must be recorded as a warning, got {warnings}",
+            )
+
+    def test_no_converter_error_names_the_whole_chain(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "mystery.xyz"
+            path.write_bytes(b"not an image at all")
+            with mock.patch.object(shutil, "which", return_value=None), mock.patch.dict(sys.modules, {"PIL": None}):
+                with self.assertRaises(ValueError) as ctx:
+                    load_image(path)
+            message = str(ctx.exception)
+            for tool in ("ImageMagick", "ffmpeg", "sips", "Pillow"):
+                self.assertIn(tool, message, f"error must name {tool}: {message}")
+
+    def test_windows_convert_exe_is_not_treated_as_imagemagick(self) -> None:
+        # C:\Windows\system32\convert.exe is the FAT->NTFS tool and is ALWAYS on
+        # PATH on Windows. If it were picked as "ImageMagick", every decode of an
+        # exotic format would shell out to a filesystem utility. Simulate that
+        # machine: which() reports the system convert, nothing else, no Pillow.
+        # The chain must stay EMPTY: the error is the no-converter-found branch
+        # ("No external converter is available"), never the converters-ran-and-
+        # failed branch ("every available converter failed (ImageMagick)").
+        system_convert = shutil.which("convert")
+
+        def fake_which(name, *args, **kwargs):
+            return system_convert if name == "convert" else None
+
+        with mock.patch.object(shutil, "which", side_effect=fake_which), mock.patch.dict(sys.modules, {"PIL": None}):
+            warnings: list[str] = []
+            with self.assertRaises(ValueError) as ctx:
+                image_codec.external_convert(Path("whatever.webp"), ValueError("not png"), warnings)
+        message = str(ctx.exception)
+        self.assertIn("No external converter is available", message)
+        self.assertNotIn("every available converter failed", message)
+
+
+class DecodeCacheTest(unittest.TestCase):
+    """The (path, mtime, size) cache invariant the Divine Eye speedup rests on."""
+
+    def _png_bytes(self, shade: int, size: int = 8) -> bytes:
+        # minimal 8-bit gray PNG via the codec's own encoder is not available;
+        # build with struct+zlib (tiny, filter 0)
+        import struct
+        import zlib
+
+        def chunk(kind: bytes, payload: bytes) -> bytes:
+            crc = zlib.crc32(kind)
+            crc = zlib.crc32(payload, crc) & 0xFFFFFFFF
+            return struct.pack(">I", len(payload)) + kind + payload + struct.pack(">I", crc)
+
+        raw = bytearray()
+        for _ in range(size):
+            raw.append(0)
+            raw.extend(bytes([shade] * size))
+        return (
+            b"\x89PNG\r\n\x1a\n"
+            + chunk(b"IHDR", struct.pack(">IIBBBBB", size, size, 8, 0, 0, 0, 0))
+            + chunk(b"IDAT", zlib.compress(bytes(raw)))
+            + chunk(b"IEND", b"")
+        )
+
+    def test_same_key_hits_cache_and_shares_pixels(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "a.png"
+            path.write_bytes(self._png_bytes(10))
+            first = decode_image(path)
+            second = decode_image(path)
+            self.assertIs(first[2], second[2], "same key must share one pixels list")
+
+    def test_edited_file_redecodes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "a.png"
+            path.write_bytes(self._png_bytes(10))
+            first = decode_image(path)
+            # SAME byte length, different content — only mtime distinguishes them
+            path.write_bytes(self._png_bytes(200))
+            second = decode_image(path)
+            self.assertEqual(first[2][0], (10, 10, 10, 255))
+            self.assertEqual(second[2][0], (200, 200, 200, 255), "edit must bust the cache")
+
+    def test_restored_mtime_and_size_hits_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "a.png"
+            shade_a, shade_b = self._png_bytes(10), self._png_bytes(200)
+            path.write_bytes(shade_a)
+            stat_a = path.stat()
+            first = decode_image(path)
+            path.write_bytes(shade_b)
+            decode_image(path)  # b decode (busts)
+            # restore content and the recorded (mtime_ns, size): the key matches A again
+            path.write_bytes(shade_a)
+            import os
+
+            os.utime(path, ns=(stat_a.st_atime_ns, stat_a.st_mtime_ns))
+            third = decode_image(path)
+            self.assertIs(third[2], first[2], "restored (mtime,size) must hit the A entry")
+
+    def test_cache_key_separates_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            a = Path(directory) / "a.png"
+            b = Path(directory) / "b.png"
+            data = self._png_bytes(77)
+            a.write_bytes(data)
+            b.write_bytes(data)
+            self.assertNotEqual(decode_cache_key(a), decode_cache_key(b))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/forge/tests/test_image_codec_vs_pillow.py
+++ b/forge/tests/test_image_codec_vs_pillow.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Validate image_codec.decode_png_bytes against Pillow across every PNG shape
+it newly supports: palette + tRNS, 1/2/4-bit gray, 16-bit, gray/RGB tRNS
+transparency, Adam7 interlace, and all five row filters.
+
+Pillow cannot WRITE interlaced or sub-8-bit PNGs (it silently ignores those save
+options), so those files are produced by a minimal hand encoder here (filter 0
+only — the filter code itself is shared with the non-interlaced path, which is
+Pillow-checked) and then decoded independently by BOTH our decoder and Pillow.
+
+Run directly: python forge/tests/test_image_codec_vs_pillow.py
+"""
+from __future__ import annotations
+
+import random
+import struct
+import sys
+import unittest
+import zlib
+from io import BytesIO
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+from image_codec import decode_png_bytes  # noqa: E402
+
+try:
+    from PIL import Image  # noqa: E402
+
+    PIL_AVAILABLE = True
+except ImportError:  # stdlib-only machines: cross-checking needs the reference decoder
+    PIL_AVAILABLE = False
+
+RNG = random.Random(20260905)
+SIZE = 23  # odd size so Adam7 pass shapes are all non-trivial
+ADAM7 = ((0, 0, 8, 8), (4, 0, 8, 8), (0, 4, 4, 8), (2, 0, 4, 4), (0, 2, 2, 4), (1, 0, 2, 2), (0, 1, 1, 2))
+
+RANDOM_RGB = [(RNG.randrange(256), RNG.randrange(256), RNG.randrange(256)) for _ in range(SIZE * SIZE)]
+RANDOM_RGBA = [(r, g, b, RNG.randrange(256)) for r, g, b in RANDOM_RGB]
+RANDOM_GRAY = [RNG.randrange(256) for _ in range(SIZE * SIZE)]
+
+
+def _chunk(kind: bytes, payload: bytes) -> bytes:
+    checksum = zlib.crc32(kind)
+    checksum = zlib.crc32(payload, checksum) & 0xFFFFFFFF
+    return struct.pack(">I", len(payload)) + kind + payload + struct.pack(">I", checksum)
+
+
+def png_file(
+    width: int,
+    height: int,
+    depth: int,
+    color_type: int,
+    raw_scanlines: bytes,
+    extra: bytes = b"",
+    interlace: int = 0,
+) -> bytes:
+    ihdr = struct.pack(">IIBBBBB", width, height, depth, color_type, 0, 0, interlace)
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", ihdr)
+        + extra
+        + _chunk(b"IDAT", zlib.compress(raw_scanlines))
+        + _chunk(b"IEND", b"")
+    )
+
+
+def encode_adam7(width: int, height: int, pixel: object, channels: int, filter_kind: int = 0) -> bytes:
+    """Minimal Adam7 encoder (8-bit samples), every pass filtered with `filter_kind`."""
+    raw = bytearray()
+    for pass_index, (x0, y0, dx, dy) in enumerate(ADAM7):
+        pass_width = (width - x0 + dx - 1) // dx if width > x0 else 0
+        pass_height = (height - y0 + dy - 1) // dy if height > y0 else 0
+        if pass_width <= 0 or pass_height <= 0:
+            continue
+        kind = (pass_index + filter_kind) % 5  # cycle through every filter across passes
+        previous = bytearray(pass_width * channels)
+        for py in range(pass_height):
+            y = y0 + py * dy
+            current = bytearray()
+            for px in range(pass_width):
+                x = x0 + px * dx
+                current.extend(pixel(x, y))
+            raw.append(kind)
+            raw.extend(apply_filter(current, previous, channels, kind))
+            previous = current
+    return bytes(raw)  # caller wraps in a PNG container, which zlib-compresses
+
+
+def _paeth(left: int, up: int, up_left: int) -> int:
+    p = left + up - up_left
+    pa, pb, pc = abs(p - left), abs(p - up), abs(p - up_left)
+    if pa <= pb and pa <= pc:
+        return left
+    if pb <= pc:
+        return up
+    return up_left
+
+
+def apply_filter(current: bytearray, previous: bytearray, bpp: int, kind: int) -> bytes:
+    """Forward PNG filtering (the encoder side of filters 0-4)."""
+    out = bytearray(len(current))
+    for index, value in enumerate(current):
+        left = current[index - bpp] if index >= bpp else 0
+        up = previous[index]
+        up_left = previous[index - bpp] if index >= bpp else 0
+        if kind == 1:
+            predictor = left
+        elif kind == 2:
+            predictor = up
+        elif kind == 3:
+            predictor = (left + up) // 2
+        elif kind == 4:
+            predictor = _paeth(left, up, up_left)
+        else:
+            predictor = 0
+        out[index] = (value - predictor) & 0xFF
+    return bytes(out)
+
+
+def encode_noninterlaced_filtered(rows: list[bytearray], bpp: int, kinds: list[int]) -> bytes:
+    """Non-interlaced encoder where row i is filtered with kinds[i % len(kinds)]."""
+    raw = bytearray()
+    previous = bytearray(len(rows[0]))
+    for index, row in enumerate(rows):
+        kind = kinds[index % len(kinds)]
+        raw.append(kind)
+        raw.extend(apply_filter(row, previous, bpp, kind))
+        previous = row
+    return bytes(raw)
+
+
+def encode_gray_small_depth(values: list[int], width: int, height: int, depth: int) -> bytes:
+    """Minimal sub-byte gray encoder: packed most-significant-first, filter 0."""
+    raw = bytearray()
+    mask = (1 << depth) - 1
+    for y in range(height):
+        row = bytearray()
+        accumulator = 0
+        used = 0
+        for x in range(width):
+            accumulator = (accumulator << depth) | (values[y * width + x] & mask)
+            used += depth
+            if used == 8:
+                row.append(accumulator)
+                accumulator = 0
+                used = 0
+        if used:
+            accumulator <<= 8 - used
+            row.append(accumulator)
+        raw.append(0)
+        raw.extend(row)
+    return bytes(raw)  # caller wraps in a PNG container, which zlib-compresses
+
+
+def pillow_pixels(data: bytes) -> list[tuple[int, int, int, int]]:
+    return list(Image.open(BytesIO(data)).convert("RGBA").getdata())
+
+
+@unittest.skipUnless(PIL_AVAILABLE, "Pillow (the reference decoder) is not installed")
+class PillowCrossCheck(unittest.TestCase):
+    def assert_both_decoders(self, data: bytes, expected: list[tuple[int, int, int, int]], note: str) -> None:
+        ours = decode_png_bytes(data)[2]
+        reference = pillow_pixels(data)
+        self.assertEqual(ours, expected, f"ours vs source: {note}")
+        self.assertEqual(reference, expected, f"Pillow vs source: {note}")
+
+    def test_truecolor_8bit_all_filters(self):
+        # Pillow writes only filters 1 and 4 (its filter_type save kwarg is ignored),
+        # so filters 0-4 are exercised here with a forward-filtering hand encoder,
+        # one filter per row — including cross-row cases (Up/Average/Paeth needing
+        # the real previous row).
+        stride_bytes = SIZE * 3
+        rows = []
+        flat: list[tuple[int, int, int]] = []
+        for y in range(SIZE):
+            row = bytearray()
+            for x in range(SIZE):
+                rgb = RANDOM_RGB[y * SIZE + x]
+                row.extend(rgb)
+                flat.append(rgb)
+            rows.append(row)
+        for kind_cycle in ([0, 1, 2, 3, 4], [4], [2], [3]):
+            data = png_file(SIZE, SIZE, 8, 2, encode_noninterlaced_filtered(rows, 3, kind_cycle))
+            expected = [(*rgb, 255) for rgb in flat]
+            self.assert_both_decoders(data, expected, f"RGB filters {kind_cycle}")
+
+    def test_rgba_8bit(self):
+        img = Image.new("RGBA", (SIZE, SIZE))
+        img.putdata(RANDOM_RGBA)
+        buffer = BytesIO()
+        img.save(buffer, format="PNG")
+        self.assertEqual(decode_png_bytes(buffer.getvalue())[2], RANDOM_RGBA, "RGBA 8-bit")
+
+    def test_gray_and_gray_alpha_8bit(self):
+        img = Image.new("L", (SIZE, SIZE))
+        img.putdata(RANDOM_GRAY)
+        buffer = BytesIO()
+        img.save(buffer, format="PNG")
+        self.assertEqual(
+            decode_png_bytes(buffer.getvalue())[2],
+            [(g, g, g, 255) for g in RANDOM_GRAY],
+            "gray 8-bit",
+        )
+        la_pairs = [(g, RNG.randrange(256)) for g in RANDOM_GRAY]
+        la = Image.new("LA", (SIZE, SIZE))
+        la.putdata(la_pairs)
+        buffer = BytesIO()
+        la.save(buffer, format="PNG")
+        self.assertEqual(
+            decode_png_bytes(buffer.getvalue())[2],
+            [(g, g, g, a) for g, a in la_pairs],
+            "gray+alpha 8-bit",
+        )
+
+    def test_16bit_gray_high_byte(self):
+        values = [RNG.randrange(65536) for _ in range(SIZE * SIZE)]
+        img = Image.new("I;16", (SIZE, SIZE))
+        img.putdata(values)
+        buffer = BytesIO()
+        img.save(buffer, format="PNG")
+        data = buffer.getvalue()
+        expected = [(v >> 8, v >> 8, v >> 8, 255) for v in values]
+        self.assertEqual(decode_png_bytes(data)[2], expected, "16-bit gray keeps the high byte")
+        # Pillow's I;16 -> RGBA conversion CLAMPS instead of scaling, so compare against
+        # the raw sample values it read rather than its RGBA view of them.
+        self.assertEqual(list(Image.open(BytesIO(data)).getdata()), values, "Pillow reads the same samples")
+
+    def test_palette_with_trns(self):
+        img = Image.new("RGB", (SIZE, SIZE))
+        img.putdata(RANDOM_RGB)
+        quantized = img.quantize(colors=64)
+        trns = bytes(RNG.randrange(256) for _ in range(8))
+        buffer = BytesIO()
+        quantized.save(buffer, format="PNG", transparency=trns)
+        data = buffer.getvalue()
+        expected = pillow_pixels(data)
+        self.assertTrue(expected, "Pillow decoded the palette fixture")
+        self.assertEqual(decode_png_bytes(data)[2], expected, "palette + tRNS must match Pillow")
+
+    def test_adam7_interlaced_rgb_and_gray(self):
+        data = png_file(
+            SIZE,
+            SIZE,
+            8,
+            2,
+            encode_adam7(SIZE, SIZE, lambda x, y: RANDOM_RGB[y * SIZE + x], 3),
+            interlace=1,
+        )
+        expected = [(*rgb, 255) for rgb in RANDOM_RGB]
+        self.assert_both_decoders(data, expected, "Adam7 RGB")
+
+        data = png_file(
+            SIZE,
+            SIZE,
+            8,
+            0,
+            encode_adam7(SIZE, SIZE, lambda x, y: bytes((RANDOM_GRAY[y * SIZE + x],)), 1),
+            interlace=1,
+        )
+        expected = [(g, g, g, 255) for g in RANDOM_GRAY]
+        self.assert_both_decoders(data, expected, "Adam7 gray")
+
+        # every pass filtered with a different filter (1..4 cycling): each pass
+        # must unfilter against its OWN previous row, not a neighbouring pass's
+        for base_filter in (1, 3):
+            data = png_file(
+                SIZE,
+                SIZE,
+                8,
+                2,
+                encode_adam7(SIZE, SIZE, lambda x, y: RANDOM_RGB[y * SIZE + x], 3, base_filter),
+                interlace=1,
+            )
+            self.assert_both_decoders(
+                data,
+                [(*rgb, 255) for rgb in RANDOM_RGB],
+                f"Adam7 RGB filter cycle base {base_filter}",
+            )
+
+    def test_1_2_4_bit_gray(self):
+        for depth in (1, 2, 4):
+            values = [RNG.randrange(1 << depth) for _ in range(SIZE * SIZE)]
+            data = png_file(SIZE, SIZE, depth, 0, encode_gray_small_depth(values, SIZE, SIZE, depth))
+            top = (1 << depth) - 1
+            expected = [(v * 255 // top, v * 255 // top, v * 255 // top, 255) for v in values]
+            self.assert_both_decoders(data, expected, f"{depth}-bit gray")
+
+    def test_gray_and_rgb_trns_single_color(self):
+        # gray 8-bit with tRNS key 17
+        data = png_file(
+            SIZE,
+            SIZE,
+            8,
+            0,
+            encode_gray_small_depth([17] * (SIZE * SIZE), SIZE, SIZE, 8),
+            extra=_chunk(b"tRNS", struct.pack(">H", 17)),
+        )
+        self.assert_both_decoders(data, [(17, 17, 17, 0)] * (SIZE * SIZE), "gray tRNS")
+
+        # truecolor 8-bit with tRNS key (10, 20, 30)
+        solid = [(10, 20, 30)] * (SIZE * SIZE)
+        data = png_file(
+            SIZE,
+            SIZE,
+            8,
+            2,
+            encode_adam7(SIZE, SIZE, lambda x, y: bytes(solid[y * SIZE + x]), 3),
+            extra=_chunk(b"tRNS", struct.pack(">HHH", 10, 20, 30)),
+            interlace=1,
+        )
+        self.assert_both_decoders(data, [(10, 20, 30, 0)] * (SIZE * SIZE), "RGB tRNS")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/forge/tests/test_pipeline.py
+++ b/forge/tests/test_pipeline.py
@@ -313,6 +313,8 @@ class PipelineTest(unittest.TestCase):
         # Plan 1.3 F.3/F.4: previously-missing MeshPhysicalMaterial properties and the
         # environment map must both appear in the generated code (codegen-output test,
         # not a rendering test — fully automatable per the plan's acceptance criteria).
+        # Split layout: material properties live in the model file; the environment
+        # helper is presentation surface and lives in the harness file.
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
         out = self.dir / "createObjectModel.ts"
         r = run("stage3_build/generate_threejs_factory.py", self.spec, "--out", out)
@@ -322,9 +324,10 @@ class PipelineTest(unittest.TestCase):
                      "ior:", "attenuationDistance:", "anisotropy:", "anisotropyRotation:",
                      "specularIntensity:", "specularColor:", "emissive:", "emissiveIntensity:"):
             self.assertIn(prop, ts, f"missing material property in generated code: {prop}")
-        self.assertIn("import { RoomEnvironment }", ts)
-        self.assertIn("PMREMGenerator", ts)
-        self.assertIn("Environment(renderer: THREE.WebGLRenderer)", ts)
+        harness = (out.parent / f"{out.stem}.harness.ts").read_text()
+        self.assertIn("import { RoomEnvironment }", harness)
+        self.assertIn("PMREMGenerator", harness)
+        self.assertIn("Environment(renderer: THREE.WebGLRenderer)", harness)
 
     def test_generate_factory_emits_ws5_pbr_constraints_and_dense_maps(self):
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
@@ -369,20 +372,20 @@ class PipelineTest(unittest.TestCase):
     def test_generate_factory_emits_presentation_composer_only(self):
         # Plan 1.3 §3.2c / R-POSTFX: DOF+bloom live in a SEPARATE presentation composer
         # (opt-in via options), never wired into the model factory itself — the Eye's
-        # evaluation render must stay post-fx-free. Codegen-output test.
+        # evaluation render must stay post-fx-free. Codegen-output test. Split layout
+        # makes the separation physical: the composer lives in the harness file only.
         run("stage2_spec/new_sculpt_spec.py", "Oak", "--out", self.spec)
         out = self.dir / "createObjectModel.ts"
         r = run("stage3_build/generate_threejs_factory.py", self.spec, "--out", out)
         self.assertEqual(r.returncode, 0, r.stderr)
         ts = out.read_text()
-        self.assertIn("PresentationComposer", ts)
-        self.assertIn("EffectComposer", ts)
-        self.assertIn("BokehPass", ts)
-        self.assertIn("UnrealBloomPass", ts)
-        self.assertIn("R-POSTFX", ts)
+        harness = (out.parent / f"{out.stem}.harness.ts").read_text()
+        for marker in ("PresentationComposer", "EffectComposer", "BokehPass", "UnrealBloomPass", "R-POSTFX"):
+            self.assertIn(marker, harness, f"missing from harness: {marker}")
+            self.assertNotIn(marker, ts, f"postprocessing leaked into the model file: {marker}")
         # the composer must be gated on options.dof / options.bloom (opt-in, not forced)
-        self.assertIn("if (options.dof)", ts)
-        self.assertIn("if (options.bloom)", ts)
+        self.assertIn("if (options.dof)", harness)
+        self.assertIn("if (options.bloom)", harness)
 
     def test_generate_factory_builds_real_extrude_lathe_tube_geometry(self):
         # Plan 1.3 F.5: the original bug — primitive: "extrude" (e.g. a knife blade
@@ -876,14 +879,15 @@ class PipelineTest(unittest.TestCase):
         self.assertTrue(finish["needsEnvironment"])
         # authored CS2 seed is no worse than the object baseline: normal validate passes
         self.assertEqual(run("stage2_spec/validate_sculpt_spec.py", self.spec).returncode, 0)
-        # factory generates and emits the code-generated environment helper
+        # factory generates and emits the code-generated environment helper (harness
+        # file — the environment is presentation surface, not model geometry)
         out = self.dir / "createCs2Model.ts"
         r = run("stage3_build/generate_threejs_factory.py", self.spec, "--out", out)
         self.assertEqual(r.returncode, 0, r.stderr)
-        ts = out.read_text()
-        self.assertIn("Environment", ts)
-        self.assertIn("RoomEnvironment", ts)
-        self.assertIn("PMREMGenerator", ts)
+        harness = (out.parent / f"{out.stem}.harness.ts").read_text()
+        self.assertIn("Environment", harness)
+        self.assertIn("RoomEnvironment", harness)
+        self.assertIn("PMREMGenerator", harness)
 
     def test_cs2_track_skipped_for_objects(self):
         run("stage2_spec/new_sculpt_spec.py", "Crate", "--out", self.spec)

--- a/forge/tests/test_primitive_watertightness.py
+++ b/forge/tests/test_primitive_watertightness.py
@@ -71,9 +71,9 @@ import unittest
 from pathlib import Path
 
 if __package__:
-    from .showcase_test_support import showcase_root
+    from .showcase_test_support import NPX, showcase_root
 else:
-    from showcase_test_support import showcase_root
+    from showcase_test_support import NPX, showcase_root
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -181,7 +181,7 @@ def compile_generated_module(generated: str, work_dir: Path) -> tuple[subprocess
     source.write_text(generated, encoding="utf-8")
     result = subprocess.run(
         [
-            "npx", "tsc", "--target", "ES2020", "--module", "NodeNext", "--moduleResolution", "NodeNext",
+            NPX, "tsc", "--target", "ES2020", "--module", "NodeNext", "--moduleResolution", "NodeNext",
             "--strict", "--skipLibCheck", "--noUnusedLocals", "--noUnusedParameters",
             "--outDir", str(build_dir), str(source),
         ],

--- a/forge/tests/test_repetition_system_scale.py
+++ b/forge/tests/test_repetition_system_scale.py
@@ -32,9 +32,9 @@ import unittest
 from pathlib import Path
 
 if __package__:
-    from .showcase_test_support import showcase_root
+    from .showcase_test_support import NPX, showcase_root
 else:
-    from showcase_test_support import showcase_root
+    from showcase_test_support import NPX, showcase_root
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -105,7 +105,7 @@ def compile_generated_module(generated: str, work_dir: Path) -> tuple[subprocess
     source.write_text(generated, encoding="utf-8")
     result = subprocess.run(
         [
-            "npx", "tsc", "--target", "ES2020", "--module", "NodeNext", "--moduleResolution", "NodeNext",
+            NPX, "tsc", "--target", "ES2020", "--module", "NodeNext", "--moduleResolution", "NodeNext",
             "--strict", "--skipLibCheck", "--noUnusedLocals", "--noUnusedParameters",
             "--outDir", str(build_dir), str(source),
         ],

--- a/forge/tests/test_sdf_primitives.py
+++ b/forge/tests/test_sdf_primitives.py
@@ -297,8 +297,12 @@ class ImplicitSurfaceIsSmooth(unittest.TestCase):
         work.mkdir(parents=True, exist_ok=True)
         entry = work / "factory.ts"
         entry.write_text(source, encoding="utf-8")
+        # On Windows node_modules/.bin/esbuild is a shell wrapper; resolve the
+        # platform binary via PATHEXT so CreateProcess gets a real executable.
+        esbuild_bin = shutil.which("esbuild", path=str(showcase / "node_modules" / ".bin"))
+        assert esbuild_bin, "esbuild binary not found in showcase node_modules/.bin"
         subprocess.run(
-            [str(showcase / "node_modules" / ".bin" / "esbuild"), str(entry), "--bundle",
+            [esbuild_bin, str(entry), "--bundle",
              "--format=esm", "--platform=node", "--external:three",
              f"--outfile={work / 'factory.mjs'}", "--log-level=error"],
             check=True, capture_output=True, text=True, cwd=showcase,

--- a/forge/tests/test_showcase_tsc_smoke.py
+++ b/forge/tests/test_showcase_tsc_smoke.py
@@ -11,9 +11,9 @@ import unittest
 from pathlib import Path
 
 if __package__:
-    from .showcase_test_support import showcase_root
+    from .showcase_test_support import NPX, showcase_root
 else:
-    from showcase_test_support import showcase_root
+    from showcase_test_support import NPX, showcase_root
 
 SKILL_ROOT = Path(__file__).resolve().parents[2]
 IMPLICIT_FIXTURE = SKILL_ROOT / "forge" / "tests" / "fixtures" / "implicit_character_torso_limb.json"
@@ -51,21 +51,34 @@ class ShowcaseTscSmokeTest(unittest.TestCase):
 
     def _run_tsc(self) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
-            ["npx", "tsc", "--noEmit"],
+            [NPX, "tsc", "--noEmit"],
             cwd=self.showcase_root,
             capture_output=True,
             text=True,
             check=False,
         )
 
+    def _harness_source(self) -> Path:
+        # Split-layout sibling the generator derives from --out (see
+        # generate_threejs_factory --single-file for the historical one-file layout)
+        return self.showcase_source.parent / f"{self.showcase_source.stem}.harness.ts"
+
+    def _cleanup_generated(self) -> None:
+        for path in (self.showcase_source, self._harness_source(), self.showcase_failure_source):
+            if path.exists():
+                path.unlink()
+
     def test_showcase_smoke_source_is_removed_after_tsc_success_and_failure(self) -> None:
         for should_fail in (False, True):
             with self.subTest(compiler_failure=should_fail):
+                self._cleanup_generated()
                 self.assertFalse(self.showcase_source.exists())
+                self.assertFalse(self._harness_source().exists())
                 self.assertFalse(self.showcase_failure_source.exists())
                 try:
                     self._generate_primitive_only_factory(self.showcase_source)
                     self.assertTrue(self.showcase_source.exists())
+                    self.assertTrue(self._harness_source().exists())
 
                     if should_fail:
                         self.showcase_failure_source.write_text(
@@ -79,37 +92,37 @@ class ShowcaseTscSmokeTest(unittest.TestCase):
                     else:
                         self.assertEqual(tsc_result.returncode, 0, tsc_result.stderr)
                 finally:
-                    if self.showcase_source.exists():
-                        self.showcase_source.unlink()
-                    if self.showcase_failure_source.exists():
-                        self.showcase_failure_source.unlink()
+                    self._cleanup_generated()
 
                 self.assertFalse(self.showcase_source.exists())
+                self.assertFalse(self._harness_source().exists())
                 self.assertFalse(self.showcase_failure_source.exists())
 
     def test_implicit_sdf_factory_typechecks_and_is_removed(self) -> None:
+        self._cleanup_generated()
         self.assertFalse(self.showcase_source.exists())
         try:
             generate_result = run("stage3_build/generate_threejs_factory.py", IMPLICIT_FIXTURE, "--out", self.showcase_source)
             self.assertEqual(generate_result.returncode, 0, generate_result.stderr)
             self.assertEqual(self._run_tsc().returncode, 0)
         finally:
-            if self.showcase_source.exists():
-                self.showcase_source.unlink()
+            self._cleanup_generated()
 
         self.assertFalse(self.showcase_source.exists())
+        self.assertFalse(self._harness_source().exists())
 
     def test_visual_hull_factory_typechecks_and_is_removed(self) -> None:
+        self._cleanup_generated()
         self.assertFalse(self.showcase_source.exists())
         try:
             generate_result = run("stage3_build/generate_threejs_factory.py", VISUAL_HULL_FIXTURE, "--out", self.showcase_source)
             self.assertEqual(generate_result.returncode, 0, generate_result.stderr)
             self.assertEqual(self._run_tsc().returncode, 0)
         finally:
-            if self.showcase_source.exists():
-                self.showcase_source.unlink()
+            self._cleanup_generated()
 
         self.assertFalse(self.showcase_source.exists())
+        self.assertFalse(self._harness_source().exists())
 
 
 if __name__ == "__main__":

--- a/forge/tests/test_stand_proud_emission.py
+++ b/forge/tests/test_stand_proud_emission.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "stage2_spec"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "stage3_build"))
 
 from generate_threejs_factory import generate, stand_proud_ring_stack  # noqa: E402
-from showcase_test_support import showcase_root  # noqa: E402
+from showcase_test_support import NPX, showcase_root  # noqa: E402
 
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "stand_proud_hair_on_head.json"
 
@@ -422,7 +422,7 @@ class EmittedSourceTypechecks(unittest.TestCase):
         try:
             destination.write_text(source, encoding="utf-8")
             result = subprocess.run(
-                ["npx", "tsc", "--noEmit"], cwd=root, capture_output=True, text=True, check=False
+                [NPX, "tsc", "--noEmit"], cwd=root, capture_output=True, text=True, check=False
             )
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         finally:

--- a/forge/tests/test_subdivision.py
+++ b/forge/tests/test_subdivision.py
@@ -16,7 +16,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from showcase_test_support import showcase_root
+from showcase_test_support import NPX, showcase_root
 
 ROOT = Path(__file__).resolve().parent.parent
 FIXTURE = ROOT / "tests" / "fixtures" / "subdivision_cage.json"
@@ -111,7 +111,7 @@ def compile_generated_module(
     source.write_text(generated + export_statement, encoding="utf-8")
     result = subprocess.run(
         [
-            "npx",
+            NPX,
             "tsc",
             "--target",
             "ES2020",

--- a/forge/tests/test_tapered_sweep.py
+++ b/forge/tests/test_tapered_sweep.py
@@ -270,9 +270,13 @@ class SweepWindingFacesOutward(unittest.TestCase):
         entry = work / "factory.ts"
         entry.write_text(source, encoding="utf-8")
         module = work / "factory.mjs"
+        # On Windows node_modules/.bin/esbuild is a shell wrapper; resolve the
+        # platform binary via PATHEXT so CreateProcess gets a real executable.
+        esbuild_bin = shutil.which("esbuild", path=str(showcase / "node_modules" / ".bin"))
+        assert esbuild_bin, "esbuild binary not found in showcase node_modules/.bin"
         subprocess.run(
             [
-                str(showcase / "node_modules" / ".bin" / "esbuild"),
+                esbuild_bin,
                 str(entry),
                 "--bundle", "--format=esm", "--platform=node", "--external:three",
                 f"--outfile={module}", "--log-level=error",

--- a/forge/tests/test_visual_hull.py
+++ b/forge/tests/test_visual_hull.py
@@ -12,9 +12,9 @@ import unittest
 from pathlib import Path
 
 if __package__:
-    from .showcase_test_support import showcase_root
+    from .showcase_test_support import NPX, showcase_root
 else:
-    from showcase_test_support import showcase_root
+    from showcase_test_support import NPX, showcase_root
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -53,7 +53,7 @@ def compile_generated_module(generated: str, work_dir: Path) -> tuple[subprocess
     source.write_text(generated, encoding="utf-8")
     result = subprocess.run(
         [
-            "npx", "tsc", "--target", "ES2020", "--module", "NodeNext", "--moduleResolution", "NodeNext",
+            NPX, "tsc", "--target", "ES2020", "--module", "NodeNext", "--moduleResolution", "NodeNext",
             "--strict", "--skipLibCheck", "--noUnusedLocals", "--noUnusedParameters", "--outDir", str(build_dir), str(source),
         ],
         cwd=showcase_root(),

--- a/integrations/glb_character_pipeline/python/bake_atlas_uvs.py
+++ b/integrations/glb_character_pipeline/python/bake_atlas_uvs.py
@@ -235,4 +235,19 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(lambda _argv: main()))

--- a/integrations/glb_character_pipeline/python/build_cross_sections.py
+++ b/integrations/glb_character_pipeline/python/build_cross_sections.py
@@ -205,4 +205,19 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(lambda _argv: main()))

--- a/integrations/glb_character_pipeline/python/measure_density_convergence.py
+++ b/integrations/glb_character_pipeline/python/measure_density_convergence.py
@@ -214,4 +214,19 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(lambda _argv: main()))

--- a/integrations/glb_character_pipeline/python/slice_node.py
+++ b/integrations/glb_character_pipeline/python/slice_node.py
@@ -276,4 +276,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/integrations/mesh3d/generate_reference_mesh.py
+++ b/integrations/mesh3d/generate_reference_mesh.py
@@ -202,4 +202,19 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(lambda _argv: main()))

--- a/integrations/vision/reference_vision.py
+++ b/integrations/vision/reference_vision.py
@@ -407,4 +407,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/scripts/capture_threejs_playwright.py
+++ b/scripts/capture_threejs_playwright.py
@@ -246,4 +246,19 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(main))

--- a/scripts/issue_triage.py
+++ b/scripts/issue_triage.py
@@ -232,4 +232,20 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(lambda _argv: main()))
+

--- a/scripts/release_metadata.py
+++ b/scripts/release_metadata.py
@@ -159,4 +159,20 @@ def main() -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    import sys
+    from pathlib import Path
+
+    try:
+        sys.path.insert(0, str(next(
+            parent / "forge" / "_shared"
+            for parent in Path(__file__).resolve().parents
+            if (parent / "forge" / "_shared" / "cli_run.py").is_file()
+        )))
+        from cli_run import run_entry
+    except (ImportError, StopIteration):
+        # vendored/fixture copies without the forge runtime: run bare, no pipe handling
+        def run_entry(main_fn, argv=None):
+            return main_fn(sys.argv[1:] if argv is None else argv)
+
+    raise SystemExit(run_entry(lambda _argv: main()))
+


### PR DESCRIPTION
## Summary

Seven dependency-ordered commits hardening the forge toolset for Windows (and CI portability generally), plus the performance and codegen issues found while testing on it:

| Commit | What |
|---|---|
| `feat(cli)` | shared `run_entry` wrapper: pipe closed by consumer exits 141 silently (was a BrokenPipeError traceback), Ctrl-C 130, missing file one line + 66; recognizes Windows MSYS pipes raising `OSError EINVAL` |
| `feat(codec)` | one shared decoder replaces five drifting private copies; PNG gains palette/tRNS/1-2-4-16-bit/Adam7 (cross-validated against Pillow; 8-bit fast path byte-identical); fallback chain ImageMagick→ffmpeg→sips→Pillow with an error naming the chain; Windows `convert.exe` never mistaken for ImageMagick |
| `perf(eye)` | decode + foreground-mask caches keyed by (path, mtime, size), inlined mask loop, row-traversal downsampling — one evaluation decoded the same reference 6+ times; 1600x1600 pair 44.5s→7.2s with bit-identical JSON |
| `refactor(cli)` | ~80 entry guards bootstrap the shared runtime, with a bare fallback so vendored copies without forge/_shared still run |
| `fix(next)` | empty spec printed "sculptPipeline is missing" AND "current pass: blockout"; bare invocation was an argparse dead end — now one consistent answer naming the actual first command; circular banner pointer fixed |
| `test(portability)` | npx is npx.cmd on Windows (CreateProcess applies no PATHEXT) and node_modules/.bin/esbuild is a shell wrapper — both resolved; unlocks 20+ showcase-gated execution tests on Windows |
| `feat(generator)` | generated factories hard-bound EffectComposer/BokehPass/UnrealBloomPass/OrbitControls/RoomEnvironment; default output now splits model (imports only `three`) from a `.harness.ts` sibling; `--single-file` keeps the historical layout byte-for-byte |

## Verification

- Full forge suite: **1403 tests OK** on Windows 11 / Python 3.12 with `IMG2THREEJS_SHOWCASE_ROOT` set (the 3 remaining symlink-fixture errors are Windows-privilege-only and addressed separately in #128).
- Divine Eye output verified **bit-identical** before/after caching; PNG/JPEG decoders cross-validated against Pillow, including hand-encoded fixtures for shapes Pillow cannot write (filters 2/3, sub-byte depths, Adam7).
- Generator split verified by tsc (strict + noUnusedLocals) inside a real showcase checkout, plus byte-identity tests for `--single-file`.
- The six functional fixes mirror the issues documented in this community test write-up (sips-only decode fallback, 51s gate, broken pipes, next.py chicken-and-egg, forced postprocessing imports, docs/code drift — the last already fixed upstream).