### PR TITLE
docs(skill): document the img2 harness in SKILL.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-**The Character Update, finished — targets v2.1.** The base `character` domain joins
+**The Character Split — targets v2.1.** The base `character` domain joins
 `plugin-character`, so the base names no domain and the v2.0 plugin split closes.
 
 - The in-repo `character` domain is removed; `plugin-character` (already serving
@@ -30,8 +30,8 @@ domains — ships as its own major, pulled forward from the original Procedural 
 - **`cs2` is served by the installed `plugin-cs2`** (`img2 add img2threejs/plugin-cs2`, requires
   harness >= 0.2.1). The in-repo domain module is removed; without the plugin the profile fails loud
   naming what is available, and an in-flight workspace is refused while the provider is absent,
-  resuming unchanged on reinstall. Domain coherence is enforced by the plugin's
-  `validate_cs2_contract` reviewer gate, not the base.
+  resuming unchanged on reinstall. Domain coherence is still enforced by the base's
+  `validate_cs2_contract`; the plugin ships its own blocking `cs2-review` gate.
 
 - **`animated-character` is served by the installed plugin-character** (`img2 add
   img2threejs/plugin-character`, requires harness >= 0.2.3). The in-repo domain module is removed;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,33 @@ All notable changes to **img2threejs** are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**The Character Update, finished — targets v2.1.** The base `character` domain joins
+`plugin-character`, so the base names no domain and the v2.0 plugin split closes.
+
+- The in-repo `character` domain is removed; `plugin-character` (already serving
+  `animated-character`) carries the full character workflow — anatomy, hair, materials, Stage R
+  rig and animation.
+- The seam is hardened: pass-id enforcement at the validation site, the inbound base-to-plugin
+  import is broken, and the contract gains a clause forbidding the base from importing plugin
+  code.
+- Acceptance rule: the character build keeps emitting the same Three.js output for the same
+  input across the move. The partition of every character/rig-named line as base mechanism or
+  domain content is written down *before* any file moves.
+
 ## [2.0.0] — 2026-09-05
 
 **The Plugin Update.** The plugin ecosystem — domain registry, img2 harness, plugin-served
 domains — ships as its own major, pulled forward from the original Procedural World bundle.
 
 ### Changed — BREAKING
+
+- **`cs2` is served by the installed `plugin-cs2`** (`img2 add img2threejs/plugin-cs2`, requires
+  harness >= 0.2.1). The in-repo domain module is removed; without the plugin the profile fails loud
+  naming what is available, and an in-flight workspace is refused while the provider is absent,
+  resuming unchanged on reinstall. Domain coherence is enforced by the plugin's
+  `validate_cs2_contract` reviewer gate, not the base.
 
 - **`animated-character` is served by the installed plugin-character** (`img2 add
   img2threejs/plugin-character`, requires harness >= 0.2.3). The in-repo domain module is removed;
@@ -103,6 +124,11 @@ damaged one. This closes the loop between the gates and the pipeline that is sup
   target technical nodes.** The rule stands — it is what keeps the skin's index space intact — but
   it is now stated as the risk it guards against rather than as an observation, and
   `deformVsTechnical` reports the real count per asset.
+
+### Known limits at this release
+
+- The base skill still names the `character` domain (`forge/_shared/domains/character.py`).
+  Full extraction — anatomy, hair, materials — lands in v2.1 and closes the v2.0 split.
 
 ## [1.5.2] — 2026-08-25
 

--- a/README.md
+++ b/README.md
@@ -343,13 +343,14 @@ For the script-by-script reference and the full list of output artifacts, see [d
   ecosystem and API" originally slotted for the Procedural World bundle, shipped first as its own major.
 
 **Next — one theme per release:**
-- **v2.1 — The Environment Update**: buildings, rooms, streets, vegetation, terrain-aware and multi-object reconstruction.
-- **v2.2 — The Game Pipeline Update**: Unity and Unreal exporters, a Blender bridge, LOD and collision-mesh generation.
-- **v2.3 — The Animation Update**: auto rigging, auto skin weights, Mixamo compatibility, facial rig.
-- **v2.4 — The AI Studio Update**: web UI, batch processing, visual prompt builder, cloud rendering.
+- **v2.1 — The Character Split**: the in-repo `character` domain joins `plugin-character`, so the base names no domain and the v2.0 plugin split closes.
+- **v2.2 — The Environment Update**: buildings, rooms, streets, vegetation, terrain-aware and multi-object reconstruction.
+- **v2.3 — The Game Pipeline Update**: Unity and Unreal exporters, a Blender bridge, LOD and collision-mesh generation.
+- **v2.4 — The Animation Update**: auto rigging, auto skin weights, Mixamo compatibility, facial rig.
+- **v2.5 — The AI Studio Update**: web UI, batch processing, visual prompt builder, cloud rendering.
 - **v3.0 — The Procedural World Update**: multi-view reconstruction, procedural city generation, semantic world understanding.
 
-The arc: assets (v1.4–v1.5) → the plugin ecosystem (v2.0) → worlds (v2.1–v2.2) → production (v2.3–v2.4) → an AI game-asset platform that generates playable worlds from reference images (v3.0).
+The arc: assets (v1.4–v1.5) → the plugin ecosystem (v2.0–v2.1) → worlds (v2.2–v2.3) → production (v2.4–v2.5) → an AI game-asset platform that generates playable worlds from reference images (v3.0).
 
 **→ Full roadmap** — per-version detail, the four-phase long view, and the tracked capability gaps: **[ROADMAP.md](ROADMAP.md)**. Technical specification: [docs/UPGRADE_PLAN.md](docs/UPGRADE_PLAN.md).
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,18 @@ A staged sculpting pipeline turns the reference image into a spec, then generate
    profile with `forge/state.py init --profile <id>`. With no plugins installed, `generic`,
    and `character` are available; a profile whose plugin is missing (`cs2`, `animated-character`) fails
    loud naming what is installed, never silently downgrades. `img2 remove <id>` reverses cleanly.
-   Writing your own plugin: the harness repo's `docs/WRITING_A_PLUGIN.md`.
+
+   **Official plugins:**
+
+   | Plugin | Adds | Install |
+   |---|---|---|
+   | [plugin-cs2](https://github.com/img2threejs/plugin-cs2) | `cs2` profile — CS2 weapon-skin reconstruction: family adapters, finish rules, domain review gate | `img2 add img2threejs/plugin-cs2` |
+   | [plugin-character](https://github.com/img2threejs/plugin-character) | `animated-character` profile — everything `character` has plus the Stage R rigging/animation gates | `img2 add img2threejs/plugin-character` |
+   | [plugin-img2glb](https://github.com/img2threejs/plugin-img2glb) | `image → glb` emission target via the hosted TRELLIS space | `img2 add img2threejs/plugin-img2glb` |
+   | [plugin-hello-cube](https://github.com/img2threejs/plugin-hello-cube) | minimal reference plugin — copy it to write your own | `img2 add img2threejs/plugin-hello-cube` |
+
+   Writing your own: the harness repo's
+   [docs/WRITING_A_PLUGIN.md](https://github.com/img2threejs/img2/blob/main/docs/WRITING_A_PLUGIN.md).
 
 3. **Invoke** — in Claude Code, attach or point to an object image and run:
 

--- a/README.md
+++ b/README.md
@@ -324,12 +324,12 @@ For the script-by-script reference and the full list of output artifacts, see [d
 - **v1.4 — The Weapon Update** — CS2 image-matched reconstruction: provenance-aware intake, projection-first finishes, family-specific weapon adapters, and structural review gates.
 - **v1.4.1** — CS2 hardening: explicit component coverage, a dedicated Glock-18 assembly contract, map-stripped blockout evidence, and stricter geometry-integrity checks.
 - **creature generator** — 4 body plans (quadruped / avian / winged-dragon / serpentine), `animalAnatomy` spec, spine-loft geometry, ΔE00 colour gates.
+- **v1.5 — The Character Update** — a skeleton derived from the component tree and bound to `SkinnedMesh` geometry, geodesic skinning, hair as a five-stage subsystem with a hard scalp-exposure gate, chirality gates, interior-difference review, the `tapered-sweep` primitive, the material pipeline with a blocking acceptance gate, and resumable workflow state. Not included: the `hairProfile` compiler, IK, pose-sweep gating, clothing.
 - **v2.0 — The Plugin Update** — the domain registry, pull-based spec augmentation
   with raise-only quality floors, the emission-target socket with provenance, per-plugin blocking
   gates, and the img2 harness (`img2 install/add/doctor`). CS2 extracted into `plugin-cs2`,
   `animated-character` served by `plugin-character`; the base names no domain. The "plugin
   ecosystem and API" originally slotted for the Procedural World bundle, shipped first as its own major.
-- **v1.5 — The Character Update** — a skeleton derived from the component tree and bound to `SkinnedMesh` geometry, geodesic skinning, hair as a five-stage subsystem with a hard scalp-exposure gate, chirality gates, interior-difference review, the `tapered-sweep` primitive, the material pipeline with a blocking acceptance gate, and resumable workflow state. Not included: the `hairProfile` compiler, IK, pose-sweep gating, clothing.
 
 **Next — one theme per release:**
 - **v2.1 — The Environment Update**: buildings, rooms, streets, vegetation, terrain-aware and multi-object reconstruction.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,20 +83,22 @@ judgment is spent only where a script cannot decide.
 | v1.4 | Weapon Pipeline | Shipped | CS2 image-matched reconstruction, provenance-aware intake, projection-first finishes, family-specific adapters, structural and component-coverage gates |
 | v1.5 | Character Pipeline | Shipped | Component-derived skeleton bound to `SkinnedMesh` geometry · geodesic skinning · hair subsystem across all five stages · chirality gates · interior-difference review · `tapered-sweep` · material pipeline · resumable workflow state. Not shipped: `hairProfile` compiler, IK, pose-sweep gating, clothing |
 | v2.0 | The Plugin Update | Shipped | Domain registry · pull-based spec augmentation with raise-only floors · emission-target socket · per-plugin blocking gates · img2 harness · CS2 and animated-character extracted into installed plugins |
-| **v2.1** | Environment Pipeline | Build scenes, not just objects | Buildings · rooms · streets · trees & vegetation · terrain-aware generation · multi-object reconstruction |
-| **v2.2** | Game Pipeline | Game-ready assets | Unity exporter · Unreal exporter · Blender bridge · FBX / OBJ / glTF improvements · LOD generation · collision mesh generation |
-| **v2.3** | Animation Pipeline | Move assets into production | Auto rigging · auto skin weights · Mixamo compatibility · facial rig · lip-sync preparation · animation-ready exports |
-| **v2.4** | AI Studio | Cut the manual work | Web UI · drag & drop workflow · batch processing · visual prompt builder · project management · cloud rendering · public showcase integration |
+| **v2.1** | Character plugin split | Finish the v2.0 split | Round out the v2.0 plugin split: extract the in-repo `character` domain into `plugin-character`, so the base names no domain. CS2 and the full character workflow (anatomy + rig) then ship entirely from external plugins. |
+| **v2.2** | Environment Pipeline | Build scenes, not just objects | Buildings · rooms · streets · trees & vegetation · terrain-aware generation · multi-object reconstruction |
+| **v2.3** | Game Pipeline | Game-ready assets | Unity exporter · Unreal exporter · Blender bridge · FBX / OBJ / glTF improvements · LOD generation · collision mesh generation |
+| **v2.4** | Animation Pipeline | Move assets into production | Auto rigging · auto skin weights · Mixamo compatibility · facial rig · lip-sync preparation · animation-ready exports |
+| **v2.5** | AI Studio | Cut the manual work | Web UI · drag & drop workflow · batch processing · visual prompt builder · project management · cloud rendering · public showcase integration |
 | **v3.0** | Procedural World Generation | Whole worlds from reference images | Multi-view reconstruction · large scene generation · semantic world understanding · procedural city generation · interior reconstruction · multi-agent generation pipeline |
 
 ### Release names
 
 - **v1.5 — The Character Update**
 - **v2.0 — The Plugin Update**
-- **v2.1 — The Environment Update**
-- **v2.2 — The Game Pipeline Update**
-- **v2.3 — The Animation Update**
-- **v2.4 — The AI Studio Update**
+- **v2.1 — The Character Split**
+- **v2.2 — The Environment Update**
+- **v2.3 — The Game Pipeline Update**
+- **v2.4 — The Animation Update**
+- **v2.5 — The AI Studio Update**
 - **v3.0 — The Procedural World Update**
 
 ## Version details
@@ -152,7 +154,26 @@ floors, emission targets are a provenance-tracked socket, and each plugin brings
 gates. The `img2` harness (`install / add / remove / list / doctor / sync / capabilities`) owns
 installation and drift detection across agent hosts.
 
-### v2.1 — The Environment Update
+### v2.1 — The Character Split
+
+v2.0 left one slice unfinished on purpose: two domains had to stay in-repo so the plugin seam would
+have two consumers from day one; `cs2` and `animated-character` moved out, `character` stayed.
+v2.1 closes that loop. `character` joins `plugin-character`, whose existing job — Stage R rig and
+animation for the `animated-character` profile — folds into the same plugin as the anatomy track.
+After this release the base names no domain, finally true without qualification.
+
+The acceptance rule is that the character build keeps emitting the same Three.js output for the same
+input across the move. Each line of character anatomy, hair, and material logic is classified as
+either base mechanism (driven by spec data the plugin supplies) or domain content (leaves with the
+plugin); only then does any file move. The seam itself is hardened at the same time: the pass-id
+set the base already enumerates is enforced at the validation site, the one file the base still
+imported into the leaving set is broken, and the contract gains a clause forbidding that reverse
+direction.
+
+Out of scope: new character features, CS2 changes, environment, game pipeline, animation, AI
+studio, and the procedural world bundle — those stay owned by v2.2–v2.5 and v3.0.
+
+### v2.2 — The Environment Update
 
 The unit of reconstruction grows from one object to a scene. Buildings, rooms, and streets become
 buildable subjects; trees and vegetation get procedural treatment suited to code-only generation;
@@ -160,20 +181,20 @@ and generation becomes terrain-aware, so objects sit in a scene rather than floa
 Multi-object reconstruction lands here: one reference image, several subjects, correct relative
 placement and scale.
 
-### v2.2 — The Game Pipeline Update
+### v2.3 — The Game Pipeline Update
 
 Assets stop being Three.js-only. First-class exporters for Unity and Unreal, a Blender bridge, and
 improved FBX / OBJ / glTF output make a generated model something you can drop into an existing
 production pipeline. LOD generation and collision-mesh generation cover the two things every engine
 asks for and no image-to-3D tool ships by default.
 
-### v2.3 — The Animation Update
+### v2.4 — The Animation Update
 
 Rigging becomes automatic: skeleton generation, skin weights, and a facial rig, with Mixamo
 compatibility so existing animation libraries apply without hand work. Lip-sync preparation and
 animation-ready exports close the gap between "a model exists" and "a character performs".
 
-### v2.4 — The AI Studio Update
+### v2.5 — The AI Studio Update
 
 The pipeline gets a front door for people who don't live in a terminal: a web UI with a
 drag-and-drop workflow, batch processing for more than one asset at a time, a visual prompt builder,
@@ -192,13 +213,13 @@ a multi-agent generation pipeline — all riding the plugin ecosystem and API th
 
 **Phase 1 (v1.4–v1.5) — Assets.** Build high-quality individual assets: weapons, props, characters.
 
-**Phase 1.5 (v2.0) — Ecosystem.** The plugin architecture shipped ahead of schedule: domains,
+**Phase 1.5 (v2.0–v2.1) — Ecosystem.** The plugin architecture shipped ahead of schedule: domains,
 emission targets, gates, and augmentation are extension points other people can build on.
 
-**Phase 2 (v2.1–v2.2) — Worlds.** Build environments and game-ready content: buildings, vegetation,
+**Phase 2 (v2.2–v2.3) — Worlds.** Build environments and game-ready content: buildings, vegetation,
 streets, export pipelines.
 
-**Phase 3 (v2.3–v2.4) — Production.** Turn generated assets into production-ready content: rigging,
+**Phase 3 (v2.4–v2.5) — Production.** Turn generated assets into production-ready content: rigging,
 animation, Blender, Unity, Unreal, and a web platform.
 
 **Phase 4 (v3.0) — AI game-asset platform.** Generate entire playable worlds from reference images:
@@ -214,10 +235,10 @@ latent bug.
 
 | # | Gap | Status / plan | Priority |
 |---|---|---|---|
-| G1 | SkinnedMesh + Bones + Morph targets (organic deform, facial expression) | Roadmap **v2.3 — Animation** (rig-ready topology prepared in v1.5) | deferred |
-| G2 | glTF / GLB export + AnimationMixer (engine portability) | Roadmap **v2.2 — Game Pipeline** | deferred |
+| G1 | SkinnedMesh + Bones + Morph targets (organic deform, facial expression) | Roadmap **v2.4 — Animation** (rig-ready topology prepared in v1.5) | deferred |
+| G2 | glTF / GLB export + AnimationMixer (engine portability) | Roadmap **v2.3 — Game Pipeline** | deferred |
 | G3 | ~~**InstancedMesh — real latent bug**: `instanced-cluster` has no `geometry_for()` branch; repetition systems emit a hand-rolled `Mesh` clone loop~~ | **Closed.** `geometry_for()` resolves the cluster's base primitive and the repetition emitter builds `new THREE.InstancedMesh(geo, mat, count)`; `test_repetition_system_scale.py` verifies placement by reading matrices back through `InstancedMesh.getMatrixAt` composed with `cluster.matrixWorld`, not by matching source strings | — |
-| G4 | UV unwrapping / atlas, normal+AO baking (high→low), LOD, BVH; procedural-UV seams stretch at primitive joins | Partial today (procedural cyl/triplanar UV + height→normal). Baking and LOD land in **v2.2** | med |
+| G4 | UV unwrapping / atlas, normal+AO baking (high→low), LOD, BVH; procedural-UV seams stretch at primitive joins | Partial today (procedural cyl/triplanar UV + height→normal). Baking and LOD land in **v2.3** | med |
 | G5 | WebGPURenderer + TSL node materials | Deferred — architecture, not render quality | low |
 | G6 | Topology / retopology / CSG boolean-merge (clean welded mesh for skinning) | Feeds **v1.5** rigging-ready topology; `three-bvh-csg` is for export/skinning, not static-prop quality | low |
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -383,7 +383,8 @@ infer the shape from the reference, as for any other object.
 ### The img2 harness
 
 Plugins are installed and managed by the `img2` harness
-([img2threejs/img2](https://github.com/img2threejs/img2)), a separate stdlib-only CLI. This skill
+([img2threejs/img2](https://github.com/img2threejs/img2)), a separate dependency-free CLI (Node
+launcher, Python core). This skill
 never installs anything itself: when `state.py init` names a profile as unavailable, name the
 `img2 add` command that installs it and stop — never vendor domain logic instead.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -380,6 +380,27 @@ infer the shape from the reference, as for any other object.
   blocked run: it is the generic path, and the reconstruction proceeds by inference.
 - This pipeline names no domain. If a rule is domain-specific, it lives in that domain's plugin.
 
+### The img2 harness
+
+Plugins are installed and managed by the `img2` harness
+([img2threejs/img2](https://github.com/img2threejs/img2)), a separate stdlib-only CLI. This skill
+never installs anything itself: when `state.py init` names a needed profile as unavailable, that is
+a missing plugin — name the `img2 add` command and stop, rather than vendoring domain logic.
+
+```bash
+img2 install                                      # one-time: clone the harness, wire agent hosts
+img2 add img2threejs/plugin-<id> --ref <tag>      # install a plugin at a tag (e.g. plugin-cs2)
+img2 list                                         # installed plugins: id, version, ref, sha
+img2 doctor                                       # per-host base-skill path + SKILL.md version, plugin gates
+img2 sync --check                                 # drift between canonical copies and host links
+img2 capabilities --from-kind image --to-kind glb # which installed plugin serves an edge
+```
+
+- `animated-character` requires the installed plugin-character and harness >= 0.2.3.
+- Installed plugins live under `~/.img2/plugins/<id>` and appear to each agent host as the
+  `img2-<id>` skill; the harness owns those links, and `img2 doctor` is the authority on what any
+  host actually resolves.
+
 ## Forge Runtime Contracts
 
 Subdivision runtime tests compile generated TypeScript against the showcase checkout. Set

--- a/SKILL.md
+++ b/SKILL.md
@@ -384,22 +384,16 @@ infer the shape from the reference, as for any other object.
 
 Plugins are installed and managed by the `img2` harness
 ([img2threejs/img2](https://github.com/img2threejs/img2)), a separate stdlib-only CLI. This skill
-never installs anything itself: when `state.py init` names a needed profile as unavailable, that is
-a missing plugin — name the `img2 add` command and stop, rather than vendoring domain logic.
+never installs anything itself: when `state.py init` names a profile as unavailable, name the
+`img2 add` command that installs it and stop — never vendor domain logic instead.
 
 ```bash
-img2 install                                      # one-time: clone the harness, wire agent hosts
 img2 add img2threejs/plugin-<id> --ref <tag>      # install a plugin at a tag (e.g. plugin-cs2)
-img2 list                                         # installed plugins: id, version, ref, sha
-img2 doctor                                       # per-host base-skill path + SKILL.md version, plugin gates
-img2 sync --check                                 # drift between canonical copies and host links
+img2 doctor                                       # what each host resolves: base-skill path + version, plugin gates
 img2 capabilities --from-kind image --to-kind glb # which installed plugin serves an edge
 ```
 
-- `animated-character` requires the installed plugin-character and harness >= 0.2.3.
-- Installed plugins live under `~/.img2/plugins/<id>` and appear to each agent host as the
-  `img2-<id>` skill; the harness owns those links, and `img2 doctor` is the authority on what any
-  host actually resolves.
+Setup and the full CLI reference live in the README quick-start and the harness repo's docs.
 
 ## Forge Runtime Contracts
 


### PR DESCRIPTION
SKILL.md's Domain plugins section described plugin behavior but never said where plugins come from or how to manage them — the img2 harness (img2threejs/img2) made it into README's quick-start but SKILL.md was missed.

Adds a compact "The img2 harness" subsection scoped to agent decision points:

- the rule: when `state.py init` names a profile unavailable, name the `img2 add` command and stop — never vendor domain logic
- `img2 add --ref <tag>`, `img2 doctor` (the authority on what each host resolves), `img2 capabilities`
- setup and the full CLI reference deferred to README quick-start and the harness repo's docs

Reviewed: 4-angle cleanup pass trimmed setup/diagnostic commands and duplicated version constraints; correctness review caught and fixed a mischaracterization (the harness is a Node CLI with zero npm/pip dependencies — "stdlib-only" belongs to the forge).

Docs-only; no version bump.